### PR TITLE
Implement OpinionatedEventing.EntityFramework EF Core integration (#4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Always run `/review` on the staged changes before committing, and address any fi
 
 ## Issue tracking
 
-Each GitHub issue corresponds to a specific library. When implementing an issue, work on a branch named `issue/<number>-<short-description>` and open a PR targeting `main`.
+The GitHub repository is **`SierraNL/OpinionatedEventing`**. Use this owner/repo pair for all MCP GitHub tool calls.
+
+Each GitHub issue corresponds to a specific library. When implementing an issue, always fetch and reset to `origin/main` before creating a branch named `issue/<number>-<short-description>`, then open a PR targeting `main`.
 
 Always use the MCP GitHub tools (`mcp__github__*`) for all GitHub interactions — never the `gh` CLI.

--- a/src/OpinionatedEventing.EntityFramework/Configuration/OutboxMessageEntityTypeConfiguration.cs
+++ b/src/OpinionatedEventing.EntityFramework/Configuration/OutboxMessageEntityTypeConfiguration.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.EntityFramework.Configuration;
+
+/// <summary>
+/// EF Core entity type configuration for <see cref="OutboxMessage"/>.
+/// Maps the outbox table to <c>outbox_messages</c> with an index optimised for pending-message queries.
+/// </summary>
+/// <remarks>
+/// Apply via <c>modelBuilder.ApplyOutboxConfiguration()</c> inside <c>OnModelCreating</c>,
+/// or let EF Core discover it automatically via <c>modelBuilder.ApplyConfigurationsFromAssembly</c>.
+/// </remarks>
+public sealed class OutboxMessageEntityTypeConfiguration : IEntityTypeConfiguration<OutboxMessage>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<OutboxMessage> builder)
+    {
+        builder.ToTable("outbox_messages");
+        builder.HasKey(m => m.Id);
+
+        builder.Property(m => m.MessageType).IsRequired().HasMaxLength(512);
+        builder.Property(m => m.Payload).IsRequired();
+        builder.Property(m => m.MessageKind).IsRequired().HasMaxLength(16);
+        builder.Property(m => m.CorrelationId).IsRequired();
+        builder.Property(m => m.CausationId);
+        builder.Property(m => m.CreatedAt).IsRequired();
+        builder.Property(m => m.ProcessedAt);
+        builder.Property(m => m.FailedAt);
+        builder.Property(m => m.AttemptCount).IsRequired().HasDefaultValue(0);
+        builder.Property(m => m.Error);
+
+        // Supports efficient pending-message polling: WHERE ProcessedAt IS NULL AND FailedAt IS NULL ORDER BY CreatedAt
+        builder.HasIndex(m => new { m.ProcessedAt, m.FailedAt, m.CreatedAt })
+            .HasDatabaseName("IX_outbox_messages_pending");
+    }
+}

--- a/src/OpinionatedEventing.EntityFramework/Configuration/SagaStateEntityTypeConfiguration.cs
+++ b/src/OpinionatedEventing.EntityFramework/Configuration/SagaStateEntityTypeConfiguration.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OpinionatedEventing.Sagas;
+
+namespace OpinionatedEventing.EntityFramework.Configuration;
+
+/// <summary>
+/// EF Core entity type configuration for <see cref="SagaState"/>.
+/// Maps the saga state table to <c>saga_states</c> with an index optimised for timeout polling.
+/// </summary>
+/// <remarks>
+/// Apply via <c>modelBuilder.ApplySagaStateConfiguration()</c> inside <c>OnModelCreating</c>,
+/// or let EF Core discover it automatically via <c>modelBuilder.ApplyConfigurationsFromAssembly</c>.
+/// </remarks>
+public sealed class SagaStateEntityTypeConfiguration : IEntityTypeConfiguration<SagaState>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<SagaState> builder)
+    {
+        builder.ToTable("saga_states");
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.SagaType).IsRequired().HasMaxLength(512);
+        builder.Property(s => s.CorrelationId).IsRequired().HasMaxLength(256);
+        builder.Property(s => s.State).IsRequired();
+        builder.Property(s => s.Status).IsRequired();
+        builder.Property(s => s.CreatedAt).IsRequired();
+        builder.Property(s => s.UpdatedAt).IsRequired();
+        builder.Property(s => s.ExpiresAt);
+
+        // Unique constraint: one instance per saga type + correlation ID
+        builder.HasIndex(s => new { s.SagaType, s.CorrelationId })
+            .IsUnique()
+            .HasDatabaseName("UX_saga_states_type_correlation");
+
+        // Supports efficient timeout polling: WHERE Status = Active AND ExpiresAt <= now
+        builder.HasIndex(s => new { s.Status, s.ExpiresAt })
+            .HasDatabaseName("IX_saga_states_timeout");
+    }
+}

--- a/src/OpinionatedEventing.EntityFramework/DependencyInjection/EntityFrameworkBuilderExtensions.cs
+++ b/src/OpinionatedEventing.EntityFramework/DependencyInjection/EntityFrameworkBuilderExtensions.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OpinionatedEventing.EntityFramework;
+using OpinionatedEventing.EntityFramework.Sagas;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Sagas;
+
+// Placing in this namespace so the extension is available without an extra using directive.
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods on <see cref="IServiceCollection"/> for registering
+/// OpinionatedEventing EF Core services.
+/// </summary>
+public static class EntityFrameworkBuilderExtensions
+{
+    /// <summary>
+    /// Registers the EF Core implementations of <see cref="IOutboxStore"/> and
+    /// <see cref="ISagaStateStore"/>, and registers the <see cref="DomainEventInterceptor"/>
+    /// for use with the application's <typeparamref name="TDbContext"/>.
+    /// </summary>
+    /// <typeparam name="TDbContext">
+    /// The application's <see cref="DbContext"/> type. Must be registered in the DI container
+    /// before or after this call.
+    /// </typeparam>
+    /// <param name="services">The service collection to register into.</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Wire the interceptor into your <c>DbContext</c> configuration by adding
+    /// <c>options.AddInterceptors(sp.GetRequiredService&lt;DomainEventInterceptor&gt;())</c>
+    /// inside your <c>AddDbContext</c> delegate:
+    /// </para>
+    /// <code>
+    /// services.AddDbContext&lt;AppDbContext&gt;((sp, options) =>
+    /// {
+    ///     options.UseSqlServer(connectionString);
+    ///     options.AddInterceptors(sp.GetRequiredService&lt;DomainEventInterceptor&gt;());
+    /// });
+    /// services.AddOpinionatedEventingEntityFramework&lt;AppDbContext&gt;();
+    /// </code>
+    /// <para>
+    /// The <c>outbox_messages</c> and <c>saga_states</c> tables must be included in the
+    /// <c>DbContext</c> model. Call <c>modelBuilder.ApplyOutboxConfiguration()</c> and
+    /// <c>modelBuilder.ApplySagaStateConfiguration()</c> inside <c>OnModelCreating</c>.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddOpinionatedEventingEntityFramework<TDbContext>(
+        this IServiceCollection services)
+        where TDbContext : DbContext
+    {
+        services.TryAddScoped<IOutboxStore, EFCoreOutboxStore<TDbContext>>();
+        services.TryAddScoped<ISagaStateStore, EFCoreSagaStateStore<TDbContext>>();
+        services.TryAddScoped<DomainEventInterceptor>();
+
+        return services;
+    }
+}

--- a/src/OpinionatedEventing.EntityFramework/DomainEventInterceptor.cs
+++ b/src/OpinionatedEventing.EntityFramework/DomainEventInterceptor.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Options;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.EntityFramework;
+
+/// <summary>
+/// EF Core <see cref="SaveChangesInterceptor"/> that harvests domain events from tracked
+/// <see cref="IAggregateRoot"/> instances and writes them to the outbox atomically within
+/// the same <c>SaveChanges</c> transaction.
+/// </summary>
+/// <remarks>
+/// Register this interceptor with the application's <see cref="DbContext"/> by calling
+/// <c>options.AddInterceptors(sp.GetRequiredService&lt;DomainEventInterceptor&gt;())</c>
+/// inside the <c>AddDbContext</c> configuration delegate.
+/// </remarks>
+public sealed class DomainEventInterceptor : SaveChangesInterceptor
+{
+    private readonly IMessagingContext _messagingContext;
+    private readonly IOptions<OpinionatedEventingOptions> _options;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initialises a new <see cref="DomainEventInterceptor"/>.</summary>
+    public DomainEventInterceptor(
+        IMessagingContext messagingContext,
+        IOptions<OpinionatedEventingOptions> options,
+        TimeProvider timeProvider)
+    {
+        _messagingContext = messagingContext;
+        _options = options;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc/>
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        HarvestDomainEvents(eventData.Context);
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        HarvestDomainEvents(eventData.Context);
+        return ValueTask.FromResult(result);
+    }
+
+    private void HarvestDomainEvents(DbContext? context)
+    {
+        if (context is null) return;
+
+        var aggregates = context.ChangeTracker
+            .Entries<IAggregateRoot>()
+            .Where(e => e.Entity.DomainEvents.Count > 0)
+            .Select(e => e.Entity)
+            .ToList();
+
+        if (aggregates.Count == 0) return;
+
+        var serializerOptions = _options.Value.SerializerOptions;
+        var now = _timeProvider.GetUtcNow();
+        var outboxSet = context.Set<OutboxMessage>();
+
+        foreach (var aggregate in aggregates)
+        {
+            foreach (var domainEvent in aggregate.DomainEvents)
+            {
+                var eventType = domainEvent.GetType();
+                outboxSet.Add(new OutboxMessage
+                {
+                    Id = Guid.NewGuid(),
+                    // AssemblyQualifiedName is null only for array/pointer/open-generic types,
+                    // none of which can implement IEvent.
+                    MessageType = eventType.AssemblyQualifiedName!,
+                    Payload = JsonSerializer.Serialize(domainEvent, eventType, serializerOptions),
+                    MessageKind = "Event",
+                    CorrelationId = _messagingContext.CorrelationId,
+                    CausationId = _messagingContext.CausationId,
+                    CreatedAt = now,
+                });
+            }
+
+            aggregate.ClearDomainEvents();
+        }
+    }
+}

--- a/src/OpinionatedEventing.EntityFramework/EFCoreOutboxStore.cs
+++ b/src/OpinionatedEventing.EntityFramework/EFCoreOutboxStore.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.EntityFramework;
+
+/// <summary>
+/// EF Core implementation of <see cref="IOutboxStore"/>.
+/// Persists outbox messages in the same <typeparamref name="TDbContext"/> as the calling unit of work,
+/// ensuring atomic writes when <c>SaveChanges</c> is called by the application.
+/// </summary>
+/// <typeparam name="TDbContext">The application's <see cref="DbContext"/> type.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="SaveAsync"/> only stages the message in the change tracker — it does not call
+/// <c>SaveChanges</c>. The surrounding business transaction is responsible for committing.
+/// </para>
+/// <para>
+/// <see cref="GetPendingAsync"/>, <see cref="MarkProcessedAsync"/>, <see cref="MarkFailedAsync"/>,
+/// and <see cref="IncrementAttemptAsync"/> each call <c>SaveChangesAsync</c> internally because
+/// they are invoked by <c>OutboxDispatcherWorker</c> in an isolated scope.
+/// </para>
+/// <para>
+/// When <see cref="OpinionatedEventing.Options.OutboxOptions.ConcurrentWorkers"/> is greater
+/// than <c>1</c>, consider using a database that supports <c>SELECT … FOR UPDATE SKIP LOCKED</c>
+/// (SQL Server, PostgreSQL) and configure the <c>GetPendingAsync</c> query accordingly to
+/// avoid duplicate dispatch under concurrent workers.
+/// </para>
+/// </remarks>
+internal sealed class EFCoreOutboxStore<TDbContext> : IOutboxStore
+    where TDbContext : DbContext
+{
+    private readonly TDbContext _dbContext;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initialises a new <see cref="EFCoreOutboxStore{TDbContext}"/>.</summary>
+    public EFCoreOutboxStore(TDbContext dbContext, TimeProvider timeProvider)
+    {
+        _dbContext = dbContext;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Stages the message in the EF change tracker without calling <c>SaveChanges</c>.
+    /// The caller must include a <c>SaveChangesAsync</c> call within the same transaction.
+    /// </remarks>
+    public Task SaveAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    {
+        _dbContext.Set<OutboxMessage>().Add(message);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<OutboxMessage>> GetPendingAsync(
+        int batchSize,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Set<OutboxMessage>()
+            .Where(m => m.ProcessedAt == null && m.FailedAt == null)
+            .OrderBy(m => m.CreatedAt)
+            .Take(batchSize)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task MarkProcessedAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var message = await _dbContext.Set<OutboxMessage>().FindAsync([id], cancellationToken);
+        if (message is null) return;
+
+        message.ProcessedAt = _timeProvider.GetUtcNow();
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task MarkFailedAsync(Guid id, string error, CancellationToken cancellationToken = default)
+    {
+        var message = await _dbContext.Set<OutboxMessage>().FindAsync([id], cancellationToken);
+        if (message is null) return;
+
+        message.FailedAt = _timeProvider.GetUtcNow();
+        message.Error = error;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task IncrementAttemptAsync(Guid id, string error, CancellationToken cancellationToken = default)
+    {
+        var message = await _dbContext.Set<OutboxMessage>().FindAsync([id], cancellationToken);
+        if (message is null) return;
+
+        message.AttemptCount++;
+        message.Error = error;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/OpinionatedEventing.EntityFramework/Extensions/MigrationBuilderExtensions.cs
+++ b/src/OpinionatedEventing.EntityFramework/Extensions/MigrationBuilderExtensions.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+// Placing in this namespace so the extension is available without an extra using directive.
+namespace Microsoft.EntityFrameworkCore.Migrations;
+
+/// <summary>
+/// Extension methods on <see cref="MigrationBuilder"/> for OpinionatedEventing schema operations.
+/// Use these helpers inside EF Core <c>Migration</c> classes to create or drop the outbox
+/// and saga state tables.
+/// </summary>
+public static class OpinionatedEventingMigrationBuilderExtensions
+{
+    /// <summary>Creates the <c>outbox_messages</c> table.</summary>
+    /// <param name="migrationBuilder">The migration builder.</param>
+    /// <returns>The same <paramref name="migrationBuilder"/> for chaining.</returns>
+    public static MigrationBuilder CreateOutboxTable(this MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "outbox_messages",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(nullable: false),
+                MessageType = table.Column<string>(maxLength: 512, nullable: false),
+                Payload = table.Column<string>(nullable: false),
+                MessageKind = table.Column<string>(maxLength: 16, nullable: false),
+                CorrelationId = table.Column<Guid>(nullable: false),
+                CausationId = table.Column<Guid>(nullable: true),
+                CreatedAt = table.Column<DateTimeOffset>(nullable: false),
+                ProcessedAt = table.Column<DateTimeOffset>(nullable: true),
+                FailedAt = table.Column<DateTimeOffset>(nullable: true),
+                AttemptCount = table.Column<int>(nullable: false, defaultValue: 0),
+                Error = table.Column<string>(nullable: true),
+            },
+            constraints: table =>
+                table.PrimaryKey("PK_outbox_messages", x => x.Id));
+
+        migrationBuilder.CreateIndex(
+            name: "IX_outbox_messages_pending",
+            table: "outbox_messages",
+            columns: ["ProcessedAt", "FailedAt", "CreatedAt"]);
+
+        return migrationBuilder;
+    }
+
+    /// <summary>Drops the <c>outbox_messages</c> table.</summary>
+    /// <param name="migrationBuilder">The migration builder.</param>
+    /// <returns>The same <paramref name="migrationBuilder"/> for chaining.</returns>
+    public static MigrationBuilder DropOutboxTable(this MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "outbox_messages");
+        return migrationBuilder;
+    }
+
+    /// <summary>Creates the <c>saga_states</c> table.</summary>
+    /// <param name="migrationBuilder">The migration builder.</param>
+    /// <returns>The same <paramref name="migrationBuilder"/> for chaining.</returns>
+    public static MigrationBuilder CreateSagaStateTable(this MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "saga_states",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(nullable: false),
+                SagaType = table.Column<string>(maxLength: 512, nullable: false),
+                CorrelationId = table.Column<string>(maxLength: 256, nullable: false),
+                State = table.Column<string>(nullable: false),
+                Status = table.Column<int>(nullable: false),
+                CreatedAt = table.Column<DateTimeOffset>(nullable: false),
+                UpdatedAt = table.Column<DateTimeOffset>(nullable: false),
+                ExpiresAt = table.Column<DateTimeOffset>(nullable: true),
+            },
+            constraints: table =>
+                table.PrimaryKey("PK_saga_states", x => x.Id));
+
+        migrationBuilder.CreateIndex(
+            name: "UX_saga_states_type_correlation",
+            table: "saga_states",
+            columns: ["SagaType", "CorrelationId"],
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_saga_states_timeout",
+            table: "saga_states",
+            columns: ["Status", "ExpiresAt"]);
+
+        return migrationBuilder;
+    }
+
+    /// <summary>Drops the <c>saga_states</c> table.</summary>
+    /// <param name="migrationBuilder">The migration builder.</param>
+    /// <returns>The same <paramref name="migrationBuilder"/> for chaining.</returns>
+    public static MigrationBuilder DropSagaStateTable(this MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "saga_states");
+        return migrationBuilder;
+    }
+}

--- a/src/OpinionatedEventing.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/src/OpinionatedEventing.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using OpinionatedEventing.EntityFramework.Configuration;
+
+// Placing in this namespace so the extension is available without an extra using directive.
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Extension methods on <see cref="ModelBuilder"/> for OpinionatedEventing EF Core configuration.
+/// </summary>
+public static class OpinionatedEventingModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies the <c>outbox_messages</c> table configuration to the model.
+    /// Call this inside <c>OnModelCreating</c> to include the outbox table in your schema.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder to configure.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ApplyOutboxConfiguration(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new OutboxMessageEntityTypeConfiguration());
+        return modelBuilder;
+    }
+
+    /// <summary>
+    /// Applies the <c>saga_states</c> table configuration to the model.
+    /// Call this inside <c>OnModelCreating</c> to include the saga state table in your schema.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder to configure.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ApplySagaStateConfiguration(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new SagaStateEntityTypeConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/OpinionatedEventing.EntityFramework/Properties/AssemblyInfo.cs
+++ b/src/OpinionatedEventing.EntityFramework/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpinionatedEventing.EntityFramework.Tests")]
+[assembly: InternalsVisibleTo("OpinionatedEventing.EntityFramework.Specs")]

--- a/src/OpinionatedEventing.EntityFramework/Sagas/EFCoreSagaStateStore.cs
+++ b/src/OpinionatedEventing.EntityFramework/Sagas/EFCoreSagaStateStore.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using OpinionatedEventing.Sagas;
+
+namespace OpinionatedEventing.EntityFramework.Sagas;
+
+/// <summary>
+/// EF Core implementation of <see cref="ISagaStateStore"/>.
+/// Persists saga state in the same <typeparamref name="TDbContext"/> as the application.
+/// </summary>
+/// <typeparam name="TDbContext">The application's <see cref="DbContext"/> type.</typeparam>
+internal sealed class EFCoreSagaStateStore<TDbContext> : ISagaStateStore
+    where TDbContext : DbContext
+{
+    private readonly TDbContext _dbContext;
+
+    /// <summary>Initialises a new <see cref="EFCoreSagaStateStore{TDbContext}"/>.</summary>
+    public EFCoreSagaStateStore(TDbContext dbContext)
+        => _dbContext = dbContext;
+
+    /// <inheritdoc/>
+    public async Task<SagaState?> FindAsync(
+        string sagaType,
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Set<SagaState>()
+            .FirstOrDefaultAsync(
+                s => s.SagaType == sagaType && s.CorrelationId == correlationId,
+                cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(SagaState state, CancellationToken cancellationToken = default)
+    {
+        _dbContext.Set<SagaState>().Add(state);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateAsync(SagaState state, CancellationToken cancellationToken = default)
+    {
+        _dbContext.Set<SagaState>().Update(state);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<SagaState>> GetExpiredAsync(
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Set<SagaState>()
+            .Where(s => s.ExpiresAt <= now && s.Status == SagaStatus.Active)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/OpinionatedEventing.Sagas/ISagaStateStore.cs
+++ b/src/OpinionatedEventing.Sagas/ISagaStateStore.cs
@@ -1,0 +1,40 @@
+namespace OpinionatedEventing.Sagas;
+
+/// <summary>
+/// Persistence contract for saga state.
+/// The default implementation is provided by <c>OpinionatedEventing.EntityFramework</c>.
+/// </summary>
+public interface ISagaStateStore
+{
+    /// <summary>
+    /// Returns the saga instance for the given orchestrator type and correlation identifier,
+    /// or <see langword="null"/> if no matching instance exists.
+    /// </summary>
+    /// <param name="sagaType">The assembly-qualified CLR type name of the orchestrator.</param>
+    /// <param name="correlationId">The correlation identifier of the saga instance.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    Task<SagaState?> FindAsync(
+        string sagaType,
+        string correlationId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Persists a new saga state entry.</summary>
+    /// <param name="state">The saga state to save.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    Task SaveAsync(SagaState state, CancellationToken cancellationToken = default);
+
+    /// <summary>Updates an existing saga state entry.</summary>
+    /// <param name="state">The saga state to update.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    Task UpdateAsync(SagaState state, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all <see cref="SagaStatus.Active"/> saga instances whose
+    /// <see cref="SagaState.ExpiresAt"/> is less than or equal to <paramref name="now"/>.
+    /// </summary>
+    /// <param name="now">The current point in time to compare against <see cref="SagaState.ExpiresAt"/>.</param>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    Task<IReadOnlyList<SagaState>> GetExpiredAsync(
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
+}

--- a/src/OpinionatedEventing.Sagas/Properties/AssemblyInfo.cs
+++ b/src/OpinionatedEventing.Sagas/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpinionatedEventing.EntityFramework")]
+[assembly: InternalsVisibleTo("OpinionatedEventing.Sagas.Tests")]
+[assembly: InternalsVisibleTo("OpinionatedEventing.Sagas.Specs")]

--- a/src/OpinionatedEventing.Sagas/SagaState.cs
+++ b/src/OpinionatedEventing.Sagas/SagaState.cs
@@ -1,0 +1,39 @@
+namespace OpinionatedEventing.Sagas;
+
+/// <summary>
+/// Represents the persisted state of a saga instance.
+/// Stored and retrieved by <see cref="ISagaStateStore"/>.
+/// </summary>
+public sealed class SagaState
+{
+    /// <summary>Gets the unique identifier of this saga instance.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Gets the assembly-qualified CLR type name of the orchestrator that owns this state.
+    /// </summary>
+    public required string SagaType { get; init; }
+
+    /// <summary>
+    /// Gets the correlation identifier that links all messages belonging to this saga instance.
+    /// </summary>
+    public required string CorrelationId { get; init; }
+
+    /// <summary>Gets or sets the JSON-serialised saga-specific state payload.</summary>
+    public required string State { get; set; }
+
+    /// <summary>Gets or sets the current lifecycle status of this saga instance.</summary>
+    public SagaStatus Status { get; set; }
+
+    /// <summary>Gets the UTC time at which this saga instance was created.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Gets or sets the UTC time at which this saga instance was last modified.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC time at which this saga instance expires,
+    /// or <see langword="null"/> if no timeout is configured.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; set; }
+}

--- a/src/OpinionatedEventing.Sagas/SagaStatus.cs
+++ b/src/OpinionatedEventing.Sagas/SagaStatus.cs
@@ -1,0 +1,20 @@
+namespace OpinionatedEventing.Sagas;
+
+/// <summary>Represents the lifecycle status of a saga instance.</summary>
+public enum SagaStatus
+{
+    /// <summary>The saga is running and awaiting further events.</summary>
+    Active,
+
+    /// <summary>The saga completed successfully.</summary>
+    Completed,
+
+    /// <summary>The saga is executing compensation handlers after a failure.</summary>
+    Compensating,
+
+    /// <summary>The saga expired before completing.</summary>
+    TimedOut,
+
+    /// <summary>The saga failed and could not be compensated.</summary>
+    Failed,
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/DomainEventInterceptorTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/DomainEventInterceptorTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.EntityFramework.Tests.TestSupport;
+using OpinionatedEventing.Options;
+using OpinionatedEventing.Outbox;
+using Xunit;
+
+namespace OpinionatedEventing.EntityFramework.Tests;
+
+public sealed class DomainEventInterceptorTests : IDisposable
+{
+    private readonly InMemoryDbContextFactory _factory = new();
+
+    public void Dispose() => _factory.Dispose();
+
+    private static DomainEventInterceptor CreateInterceptor(
+        Guid? correlationId = null,
+        Guid? causationId = null)
+    {
+        var context = new FakeMessagingContext(correlationId ?? Guid.NewGuid(), causationId);
+        var options = Microsoft.Extensions.Options.Options.Create(new OpinionatedEventingOptions());
+        return new DomainEventInterceptor(context, options, TimeProvider.System);
+    }
+
+    private TestDbContext CreateContextWithInterceptor(DomainEventInterceptor interceptor)
+        => new(_factory.CreateOptionsBuilder().AddInterceptors(interceptor).Options);
+
+    [Fact]
+    public async Task SaveChanges_writes_domain_events_to_outbox()
+    {
+        var interceptor = CreateInterceptor();
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var order = TestOrder.Place(Guid.NewGuid());
+        context.Set<TestOrder>().Add(order);
+        await context.SaveChangesAsync(ct);
+
+        var outboxMessages = context.Set<OutboxMessage>().ToList();
+        Assert.Single(outboxMessages);
+        Assert.Equal("Event", outboxMessages[0].MessageKind);
+    }
+
+    [Fact]
+    public async Task SaveChanges_clears_domain_events_after_harvest()
+    {
+        var interceptor = CreateInterceptor();
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var order = TestOrder.Place(Guid.NewGuid());
+        context.Set<TestOrder>().Add(order);
+        await context.SaveChangesAsync(ct);
+
+        Assert.Empty(order.DomainEvents);
+    }
+
+    [Fact]
+    public async Task SaveChanges_stamps_correlation_id_from_messaging_context()
+    {
+        var correlationId = Guid.NewGuid();
+        var interceptor = CreateInterceptor(correlationId: correlationId);
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var order = TestOrder.Place(Guid.NewGuid());
+        context.Set<TestOrder>().Add(order);
+        await context.SaveChangesAsync(ct);
+
+        var message = context.Set<OutboxMessage>().Single();
+        Assert.Equal(correlationId, message.CorrelationId);
+    }
+
+    [Fact]
+    public async Task SaveChanges_stamps_causation_id_from_messaging_context()
+    {
+        var causationId = Guid.NewGuid();
+        var interceptor = CreateInterceptor(causationId: causationId);
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var order = TestOrder.Place(Guid.NewGuid());
+        context.Set<TestOrder>().Add(order);
+        await context.SaveChangesAsync(ct);
+
+        var message = context.Set<OutboxMessage>().Single();
+        Assert.Equal(causationId, message.CausationId);
+    }
+
+    [Fact]
+    public async Task SaveChanges_causation_id_is_null_for_originating_messages()
+    {
+        var interceptor = CreateInterceptor(causationId: null);
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var order = TestOrder.Place(Guid.NewGuid());
+        context.Set<TestOrder>().Add(order);
+        await context.SaveChangesAsync(ct);
+
+        var message = context.Set<OutboxMessage>().Single();
+        Assert.Null(message.CausationId);
+    }
+
+    [Fact]
+    public async Task SaveChanges_writes_all_events_from_all_aggregates()
+    {
+        var interceptor = CreateInterceptor();
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var order1 = TestOrder.Place(Guid.NewGuid());
+        var order2 = TestOrder.Place(Guid.NewGuid());
+        context.Set<TestOrder>().AddRange(order1, order2);
+        await context.SaveChangesAsync(ct);
+
+        var outboxMessages = context.Set<OutboxMessage>().ToList();
+        Assert.Equal(2, outboxMessages.Count);
+    }
+
+    [Fact]
+    public async Task SaveChanges_writes_multiple_events_from_same_aggregate()
+    {
+        var interceptor = CreateInterceptor();
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var order = TestOrder.Place(Guid.NewGuid());
+        order.Cancel();
+        context.Set<TestOrder>().Add(order);
+        await context.SaveChangesAsync(ct);
+
+        var outboxMessages = context.Set<OutboxMessage>().ToList();
+        Assert.Equal(2, outboxMessages.Count);
+    }
+
+    [Fact]
+    public async Task SaveChanges_commits_aggregate_and_outbox_atomically()
+    {
+        var interceptor = CreateInterceptor();
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var id = Guid.NewGuid();
+        var order = TestOrder.Place(id);
+        context.Set<TestOrder>().Add(order);
+        await context.SaveChangesAsync(ct);
+
+        Assert.NotNull(await context.Set<TestOrder>().FindAsync([id], ct));
+        Assert.Single(context.Set<OutboxMessage>().ToList());
+    }
+
+    [Fact]
+    public async Task SaveChanges_does_nothing_for_aggregates_with_no_events()
+    {
+        var interceptor = CreateInterceptor();
+        await using var context = CreateContextWithInterceptor(interceptor);
+        var ct = TestContext.Current.CancellationToken;
+
+        var order = new TestOrder { Id = Guid.NewGuid() };
+        context.Set<TestOrder>().Add(order);
+        await context.SaveChangesAsync(ct);
+
+        Assert.Empty(context.Set<OutboxMessage>().ToList());
+    }
+
+    private sealed class FakeMessagingContext : IMessagingContext
+    {
+        public FakeMessagingContext(Guid correlationId, Guid? causationId)
+        {
+            CorrelationId = correlationId;
+            CausationId = causationId;
+        }
+
+        public Guid CorrelationId { get; }
+        public Guid? CausationId { get; }
+    }
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxStoreTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxStoreTests.cs
@@ -1,0 +1,189 @@
+using OpinionatedEventing.EntityFramework.Tests.TestSupport;
+using OpinionatedEventing.Outbox;
+using Xunit;
+
+namespace OpinionatedEventing.EntityFramework.Tests;
+
+public sealed class EFCoreOutboxStoreTests : IDisposable
+{
+    private readonly InMemoryDbContextFactory _factory = new();
+
+    public void Dispose() => _factory.Dispose();
+
+    private EFCoreOutboxStore<TestDbContext> CreateStore(TestDbContext context)
+        => new(context, TimeProvider.System);
+
+    private static OutboxMessage MakeMessage(string kind = "Event") => new()
+    {
+        Id = Guid.NewGuid(),
+        MessageType = "SomeType, SomeAssembly",
+        Payload = "{}",
+        MessageKind = kind,
+        CorrelationId = Guid.NewGuid(),
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+
+    [Fact]
+    public async Task SaveAsync_stages_message_without_saving()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, TestContext.Current.CancellationToken);
+
+        Assert.Single(context.ChangeTracker.Entries<OutboxMessage>());
+        Assert.Empty(context.Set<OutboxMessage>());
+    }
+
+    [Fact]
+    public async Task SaveAsync_persists_after_SaveChanges()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, TestContext.Current.CancellationToken);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, context.Set<OutboxMessage>().Count());
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_returns_unprocessed_messages_ordered_by_created_at()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var ct = TestContext.Current.CancellationToken;
+        var older = new OutboxMessage
+        {
+            Id = Guid.NewGuid(), MessageType = "T, A", Payload = "{}",
+            MessageKind = "Event", CorrelationId = Guid.NewGuid(),
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+        };
+        var newer = MakeMessage();
+
+        await store.SaveAsync(older, ct);
+        await store.SaveAsync(newer, ct);
+        await context.SaveChangesAsync(ct);
+
+        var pending = await store.GetPendingAsync(10, ct);
+
+        Assert.Equal(2, pending.Count);
+        Assert.Equal(older.Id, pending[0].Id);
+        Assert.Equal(newer.Id, pending[1].Id);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_excludes_processed_messages()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var ct = TestContext.Current.CancellationToken;
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, ct);
+        await context.SaveChangesAsync(ct);
+        await store.MarkProcessedAsync(message.Id, ct);
+
+        var pending = await store.GetPendingAsync(10, ct);
+        Assert.Empty(pending);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_excludes_failed_messages()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var ct = TestContext.Current.CancellationToken;
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, ct);
+        await context.SaveChangesAsync(ct);
+        await store.MarkFailedAsync(message.Id, "permanent error", ct);
+
+        var pending = await store.GetPendingAsync(10, ct);
+        Assert.Empty(pending);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_respects_batch_size()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var ct = TestContext.Current.CancellationToken;
+
+        for (var i = 0; i < 5; i++)
+            await store.SaveAsync(MakeMessage(), ct);
+        await context.SaveChangesAsync(ct);
+
+        var pending = await store.GetPendingAsync(3, ct);
+        Assert.Equal(3, pending.Count);
+    }
+
+    [Fact]
+    public async Task MarkProcessedAsync_sets_processed_at()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var ct = TestContext.Current.CancellationToken;
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, ct);
+        await context.SaveChangesAsync(ct);
+        await store.MarkProcessedAsync(message.Id, ct);
+
+        var saved = await context.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        Assert.NotNull(saved!.ProcessedAt);
+    }
+
+    [Fact]
+    public async Task MarkFailedAsync_sets_failed_at_and_error()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var ct = TestContext.Current.CancellationToken;
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, ct);
+        await context.SaveChangesAsync(ct);
+        await store.MarkFailedAsync(message.Id, "broker unavailable", ct);
+
+        var saved = await context.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        Assert.NotNull(saved!.FailedAt);
+        Assert.Equal("broker unavailable", saved.Error);
+    }
+
+    [Fact]
+    public async Task IncrementAttemptAsync_increments_count_and_sets_error()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var ct = TestContext.Current.CancellationToken;
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, ct);
+        await context.SaveChangesAsync(ct);
+        await store.IncrementAttemptAsync(message.Id, "transient", ct);
+
+        var saved = await context.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        Assert.Equal(1, saved!.AttemptCount);
+        Assert.Equal("transient", saved.Error);
+    }
+
+    [Fact]
+    public async Task IncrementAttemptAsync_message_remains_pending()
+    {
+        await using var context = _factory.CreateContext();
+        var store = CreateStore(context);
+        var ct = TestContext.Current.CancellationToken;
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, ct);
+        await context.SaveChangesAsync(ct);
+        await store.IncrementAttemptAsync(message.Id, "transient", ct);
+
+        var pending = await store.GetPendingAsync(10, ct);
+        Assert.Single(pending);
+    }
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/OpinionatedEventing.EntityFramework.Tests.csproj
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/OpinionatedEventing.EntityFramework.Tests.csproj
@@ -15,15 +15,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="8.0.25" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="9.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="9.0.14" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OpinionatedEventing.EntityFramework.Tests/TestSupport/InMemoryDbContextFactory.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/TestSupport/InMemoryDbContextFactory.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace OpinionatedEventing.EntityFramework.Tests.TestSupport;
+
+/// <summary>
+/// Creates <see cref="TestDbContext"/> instances backed by the EF Core in-memory provider.
+/// All contexts from the same factory share the same named database, so writes in one
+/// context are visible to a subsequent context — matching the isolation level of a real DB
+/// within a single test.
+/// </summary>
+internal sealed class InMemoryDbContextFactory : IDisposable
+{
+    private readonly string _databaseName = Guid.NewGuid().ToString();
+
+    /// <summary>Returns a pre-configured options builder for the shared in-memory database.</summary>
+    public DbContextOptionsBuilder<TestDbContext> CreateOptionsBuilder()
+        => new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(_databaseName);
+
+    /// <summary>Creates a new <see cref="TestDbContext"/> connected to the shared in-memory database.</summary>
+    public TestDbContext CreateContext()
+        => new(CreateOptionsBuilder().Options);
+
+    public void Dispose() { }
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/TestSupport/TestDbContext.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/TestSupport/TestDbContext.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using OpinionatedEventing;
+
+namespace OpinionatedEventing.EntityFramework.Tests.TestSupport;
+
+internal sealed class TestDbContext : DbContext
+{
+    public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyOutboxConfiguration();
+        modelBuilder.ApplySagaStateConfiguration();
+        modelBuilder.ApplyConfiguration(new TestOrderEntityTypeConfiguration());
+    }
+}
+
+internal sealed class OrderPlaced : IEvent
+{
+    public Guid OrderId { get; init; }
+}
+
+internal sealed class TestOrder : AggregateRoot
+{
+    public Guid Id { get; init; }
+
+    public static TestOrder Place(Guid id)
+    {
+        var order = new TestOrder { Id = id };
+        order.RaiseDomainEvent(new OrderPlaced { OrderId = id });
+        return order;
+    }
+
+    public void Cancel()
+        => RaiseDomainEvent(new OrderPlaced { OrderId = Id });
+}
+
+internal sealed class TestOrderEntityTypeConfiguration : IEntityTypeConfiguration<TestOrder>
+{
+    public void Configure(EntityTypeBuilder<TestOrder> builder)
+    {
+        builder.ToTable("test_orders");
+        builder.HasKey(o => o.Id);
+        builder.Ignore(o => o.DomainEvents);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `EFCoreOutboxStore<TDbContext>` and `EFCoreSagaStateStore<TDbContext>` — scoped EF Core implementations of `IOutboxStore` and `ISagaStateStore`
- Adds `DomainEventInterceptor : SaveChangesInterceptor` — harvests domain events from `IAggregateRoot` change tracker entries and writes them to the outbox atomically within the same `SaveChanges` transaction
- Adds `IEntityTypeConfiguration` for both `OutboxMessage` and `SagaState`, plus `ModelBuilder` and `MigrationBuilder` extension methods for easy schema setup
- Adds `SagaState`, `SagaStatus`, and `ISagaStateStore` to `OpinionatedEventing.Sagas`
- Adds `AddOpinionatedEventingEntityFramework<TDbContext>()` DI extension
- Timestamps stored as native `DateTimeOffset`; tests use EF Core InMemory provider (no SQLite schema workarounds)
- 57 unit tests covering all outbox store operations and domain event interception scenarios

## Test plan

- [x] All 57 tests pass on net8.0, net9.0, and net10.0
- [x] `/review` run — one Major finding (migration column type mismatch) found and fixed; remaining findings were Minor/Nit
- [x] No SQLite-specific hacks in production entity configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)