### PR TITLE
Implement OpinionatedEventing.AzureServiceBus transport (#8)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />

--- a/src/OpinionatedEventing.AzureServiceBus/Attributes/SessionEnabledAttribute.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/Attributes/SessionEnabledAttribute.cs
@@ -1,0 +1,15 @@
+#nullable enable
+
+namespace OpinionatedEventing.AzureServiceBus.Attributes;
+
+/// <summary>
+/// Marks a command type as requiring a session-enabled queue so that messages sharing the
+/// same session ID are processed in order.
+/// The session ID defaults to <see cref="OpinionatedEventing.IMessagingContext.CorrelationId"/>.
+/// </summary>
+/// <remarks>
+/// Requires <see cref="OpinionatedEventing.AzureServiceBus.AzureServiceBusOptions.EnableSessions"/>
+/// to be set to <see langword="true"/>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class SessionEnabledAttribute : Attribute { }

--- a/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusConsumerWorker.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusConsumerWorker.cs
@@ -1,0 +1,296 @@
+#nullable enable
+
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.AzureServiceBus.Attributes;
+using OpinionatedEventing.AzureServiceBus.DependencyInjection;
+using OpinionatedEventing.AzureServiceBus.Routing;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.AzureServiceBus;
+
+/// <summary>
+/// Background service that receives messages from Azure Service Bus topics (events) and queues
+/// (commands), then dispatches them to registered handlers via <see cref="IMessageHandlerRunner"/>.
+/// </summary>
+internal sealed class AzureServiceBusConsumerWorker : BackgroundService
+{
+    private readonly ServiceBusClient _client;
+    private readonly IMessageHandlerRunner _handlerRunner;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ServiceCollectionAccessor _accessor;
+    private readonly IOptions<AzureServiceBusOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<AzureServiceBusConsumerWorker> _logger;
+
+    private readonly List<ServiceBusProcessor> _processors = new();
+    private readonly List<ServiceBusSessionProcessor> _sessionProcessors = new();
+
+    /// <summary>Initialises a new <see cref="AzureServiceBusConsumerWorker"/>.</summary>
+    public AzureServiceBusConsumerWorker(
+        ServiceBusClient client,
+        IMessageHandlerRunner handlerRunner,
+        IServiceScopeFactory scopeFactory,
+        ServiceCollectionAccessor accessor,
+        IOptions<AzureServiceBusOptions> options,
+        TimeProvider timeProvider,
+        ILogger<AzureServiceBusConsumerWorker> logger)
+    {
+        _client = client;
+        _handlerRunner = handlerRunner;
+        _scopeFactory = scopeFactory;
+        _accessor = accessor;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var opts = _options.Value;
+        var processorOptions = new ServiceBusProcessorOptions
+        {
+            AutoCompleteMessages = false,
+            MaxConcurrentCalls = opts.MaxConcurrentCalls,
+        };
+
+        var eventTypes = ScanHandlerTypes(typeof(IEventHandler<>));
+        var commandTypes = ScanHandlerTypes(typeof(ICommandHandler<>));
+
+        foreach (var eventType in eventTypes)
+        {
+            if (string.IsNullOrEmpty(opts.ServiceName))
+            {
+                _logger.LogWarning(
+                    "ServiceName is not configured — skipping subscription for event '{EventType}'.",
+                    eventType.Name);
+                continue;
+            }
+
+            var topicName = MessageNamingConvention.GetTopicName(eventType);
+            var processor = _client.CreateProcessor(topicName, opts.ServiceName, processorOptions);
+            processor.ProcessMessageAsync += OnMessageAsync;
+            processor.ProcessErrorAsync += OnErrorAsync;
+            _processors.Add(processor);
+            await processor.StartProcessingAsync(stoppingToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Consuming event '{EventType}' from topic '{Topic}' subscription '{Subscription}'.",
+                eventType.Name, topicName, opts.ServiceName);
+        }
+
+        foreach (var commandType in commandTypes)
+        {
+            var queueName = MessageNamingConvention.GetQueueName(commandType);
+            var useSession = opts.EnableSessions
+                && Attribute.IsDefined(commandType, typeof(SessionEnabledAttribute));
+
+            if (useSession)
+            {
+                var sessionOpts = new ServiceBusSessionProcessorOptions
+                {
+                    AutoCompleteMessages = false,
+                    MaxConcurrentSessions = opts.MaxConcurrentSessions,
+                };
+                var sessionProcessor = _client.CreateSessionProcessor(queueName, sessionOpts);
+                sessionProcessor.ProcessMessageAsync += OnSessionMessageAsync;
+                sessionProcessor.ProcessErrorAsync += OnErrorAsync;
+                _sessionProcessors.Add(sessionProcessor);
+                await sessionProcessor.StartProcessingAsync(stoppingToken).ConfigureAwait(false);
+                _logger.LogInformation(
+                    "Consuming command '{CommandType}' from session-enabled queue '{Queue}'.",
+                    commandType.Name, queueName);
+            }
+            else
+            {
+                var processor = _client.CreateProcessor(queueName, processorOptions);
+                processor.ProcessMessageAsync += OnMessageAsync;
+                processor.ProcessErrorAsync += OnErrorAsync;
+                _processors.Add(processor);
+                await processor.StartProcessingAsync(stoppingToken).ConfigureAwait(false);
+                _logger.LogInformation(
+                    "Consuming command '{CommandType}' from queue '{Queue}'.",
+                    commandType.Name, queueName);
+            }
+        }
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // normal shutdown
+        }
+
+        await StopAllProcessorsAsync().ConfigureAwait(false);
+    }
+
+    private async Task StopAllProcessorsAsync()
+    {
+        foreach (var processor in _processors)
+        {
+            try { await processor.StopProcessingAsync().ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Error stopping processor."); }
+            await processor.DisposeAsync().ConfigureAwait(false);
+        }
+        foreach (var processor in _sessionProcessors)
+        {
+            try { await processor.StopProcessingAsync().ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Error stopping session processor."); }
+            await processor.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private Task OnMessageAsync(ProcessMessageEventArgs args)
+        => ProcessReceivedMessageAsync(
+            args.Message,
+            ct => args.CompleteMessageAsync(args.Message, ct),
+            ct => args.AbandonMessageAsync(args.Message, cancellationToken: ct),
+            (reason, desc, ct) => args.DeadLetterMessageAsync(args.Message, reason, desc, ct),
+            args.CancellationToken);
+
+    private Task OnSessionMessageAsync(ProcessSessionMessageEventArgs args)
+        => ProcessReceivedMessageAsync(
+            args.Message,
+            ct => args.CompleteMessageAsync(args.Message, ct),
+            ct => args.AbandonMessageAsync(args.Message, cancellationToken: ct),
+            (reason, desc, ct) => args.DeadLetterMessageAsync(args.Message, reason, desc, ct),
+            args.CancellationToken);
+
+    private Task OnErrorAsync(ProcessErrorEventArgs args)
+    {
+        _logger.LogError(
+            args.Exception,
+            "Azure Service Bus processor error. Source={Source}, EntityPath={EntityPath}.",
+            args.ErrorSource, args.EntityPath);
+        return Task.CompletedTask;
+    }
+
+
+    private async Task ProcessReceivedMessageAsync(
+        ServiceBusReceivedMessage message,
+        Func<CancellationToken, Task> complete,
+        Func<CancellationToken, Task> abandon,
+        Func<string, string, CancellationToken, Task> deadLetter,
+        CancellationToken ct)
+    {
+        try
+        {
+            var messageType = message.ApplicationProperties.TryGetValue("MessageType", out var mt)
+                ? mt as string : null;
+            var messageKind = message.ApplicationProperties.TryGetValue("MessageKind", out var mk)
+                ? mk as string : null;
+            var correlationIdStr = message.ApplicationProperties.TryGetValue("CorrelationId", out var cid)
+                ? cid as string : null;
+            var causationIdStr = message.ApplicationProperties.TryGetValue("CausationId", out var caus)
+                ? caus as string : null;
+
+            if (messageType is null || messageKind is null || correlationIdStr is null)
+            {
+                _logger.LogWarning(
+                    "Received message {MessageId} is missing required application properties; dead-lettering.",
+                    message.MessageId);
+                await deadLetter("InvalidMessageFormat", "Missing required application properties.", ct)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            if (!Guid.TryParse(correlationIdStr, out var correlationId))
+            {
+                await deadLetter("InvalidMessageFormat", "CorrelationId is not a valid Guid.", ct)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            Guid? causationId = Guid.TryParse(causationIdStr, out var c) ? c : null;
+            var payload = message.Body.ToString();
+
+            await _handlerRunner.RunAsync(messageType, messageKind, payload, correlationId, causationId, ct)
+                .ConfigureAwait(false);
+
+            await complete(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Host is shutting down; let the processor handle the message lock expiry.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to handle message {MessageId} (delivery {DeliveryCount}/{MaxDeliveryCount}).",
+                message.MessageId, message.DeliveryCount, _options.Value.MaxDeliveryCount);
+
+            if (message.DeliveryCount >= _options.Value.MaxDeliveryCount)
+            {
+                await WriteDeadLetterRecordAsync(message, ex.Message, ct).ConfigureAwait(false);
+                await deadLetter("HandlerException", ex.Message, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                await abandon(ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task WriteDeadLetterRecordAsync(
+        ServiceBusReceivedMessage message,
+        string error,
+        CancellationToken ct)
+    {
+        try
+        {
+            var messageType = message.ApplicationProperties.TryGetValue("MessageType", out var mt)
+                ? mt as string ?? string.Empty : string.Empty;
+            var messageKind = message.ApplicationProperties.TryGetValue("MessageKind", out var mk)
+                ? mk as string ?? string.Empty : string.Empty;
+            var correlationIdStr = message.ApplicationProperties.TryGetValue("CorrelationId", out var cid)
+                ? cid as string : null;
+            var causationIdStr = message.ApplicationProperties.TryGetValue("CausationId", out var caus)
+                ? caus as string : null;
+
+            _ = Guid.TryParse(correlationIdStr, out var correlationId);
+            Guid? causationId = Guid.TryParse(causationIdStr, out var c) ? c : null;
+
+            var record = new OutboxMessage
+            {
+                Id = Guid.NewGuid(),
+                MessageType = messageType,
+                MessageKind = messageKind,
+                Payload = message.Body.ToString(),
+                CorrelationId = correlationId,
+                CausationId = causationId,
+                CreatedAt = _timeProvider.GetUtcNow(),
+                AttemptCount = message.DeliveryCount,
+            };
+
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+            await store.SaveAsync(record, ct).ConfigureAwait(false);
+            // MarkFailedAsync calls SaveChanges for EF-backed stores, persisting the record.
+            await store.MarkFailedAsync(record.Id, error, ct).ConfigureAwait(false);
+
+            _logger.LogWarning(
+                "Dead-lettered message {OriginalMessageId} recorded in outbox as {RecordId}.",
+                message.MessageId, record.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to write dead-letter record for message {MessageId} to outbox.",
+                message.MessageId);
+        }
+    }
+
+    private List<Type> ScanHandlerTypes(Type openGenericInterface)
+        => _accessor.Services
+            .Where(d => d.ServiceType.IsGenericType
+                && d.ServiceType.GetGenericTypeDefinition() == openGenericInterface)
+            .Select(d => d.ServiceType.GetGenericArguments()[0])
+            .Distinct()
+            .ToList();
+}

--- a/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusOptions.cs
@@ -1,0 +1,65 @@
+#nullable enable
+
+namespace OpinionatedEventing.AzureServiceBus;
+
+/// <summary>
+/// Configuration options for the Azure Service Bus transport.
+/// </summary>
+public sealed class AzureServiceBusOptions
+{
+    /// <summary>
+    /// Gets or sets the Azure Service Bus connection string.
+    /// When set, takes precedence over <see cref="FullyQualifiedNamespace"/>.
+    /// Set to <see langword="null"/> to use <see cref="FullyQualifiedNamespace"/> with
+    /// <see cref="Azure.Identity.DefaultAzureCredential"/>.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fully qualified namespace (e.g. <c>mybus.servicebus.windows.net</c>).
+    /// Used together with <see cref="Azure.Identity.DefaultAzureCredential"/> when
+    /// <see cref="ConnectionString"/> is <see langword="null"/>.
+    /// </summary>
+    public string? FullyQualifiedNamespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the logical name of this consuming service.
+    /// Used as the subscription name on event topics.
+    /// </summary>
+    public string ServiceName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether topics, subscriptions, and queues should be
+    /// created or updated at application startup. Defaults to <see langword="false"/>.
+    /// Safe to enable in development; leave disabled in production where infrastructure is
+    /// managed externally.
+    /// </summary>
+    public bool AutoCreateResources { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether commands decorated with
+    /// <see cref="OpinionatedEventing.AzureServiceBus.Attributes.SessionEnabledAttribute"/>
+    /// use session-enabled queues. Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool EnableSessions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum delivery count before a received message is dead-lettered and
+    /// written to the outbox as a failed record. Should match the broker's configured max
+    /// delivery count when <see cref="AutoCreateResources"/> is <see langword="false"/>.
+    /// Defaults to <c>5</c>.
+    /// </summary>
+    public int MaxDeliveryCount { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent calls to the message handler for regular
+    /// (non-session) processors. Defaults to <c>1</c>.
+    /// </summary>
+    public int MaxConcurrentCalls { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent sessions processed by session-enabled
+    /// processors. Defaults to <c>1</c>.
+    /// </summary>
+    public int MaxConcurrentSessions { get; set; } = 1;
+}

--- a/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusTransport.cs
@@ -1,0 +1,86 @@
+#nullable enable
+
+using System.Collections.Concurrent;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.AzureServiceBus.Attributes;
+using OpinionatedEventing.AzureServiceBus.Routing;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.AzureServiceBus;
+
+/// <summary>
+/// Azure Service Bus implementation of <see cref="ITransport"/>.
+/// Forwards outbox messages to the correct ASB topic (events) or queue (commands).
+/// </summary>
+internal sealed class AzureServiceBusTransport : ITransport, IAsyncDisposable
+{
+    private readonly ServiceBusClient _client;
+    private readonly IOptions<AzureServiceBusOptions> _options;
+    private readonly ILogger<AzureServiceBusTransport> _logger;
+    private readonly ConcurrentDictionary<string, Lazy<ServiceBusSender>> _senders = new();
+
+    /// <summary>Initialises a new <see cref="AzureServiceBusTransport"/>.</summary>
+    public AzureServiceBusTransport(
+        ServiceBusClient client,
+        IOptions<AzureServiceBusOptions> options,
+        ILogger<AzureServiceBusTransport> logger)
+    {
+        _client = client;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    {
+        var type = Type.GetType(message.MessageType)
+            ?? throw new InvalidOperationException(
+                $"Cannot resolve CLR type '{message.MessageType}' for outbox message {message.Id}.");
+
+        var destination = message.MessageKind == "Event"
+            ? MessageNamingConvention.GetTopicName(type)
+            : MessageNamingConvention.GetQueueName(type);
+
+        var sender = _senders.GetOrAdd(destination,
+            static (name, client) => new Lazy<ServiceBusSender>(() => client.CreateSender(name)),
+            _client).Value;
+
+        var sbMessage = new ServiceBusMessage(BinaryData.FromString(message.Payload))
+        {
+            MessageId = message.Id.ToString(),
+            ContentType = "application/json",
+            CorrelationId = message.CorrelationId.ToString(),
+        };
+        sbMessage.ApplicationProperties["MessageType"] = message.MessageType;
+        sbMessage.ApplicationProperties["MessageKind"] = message.MessageKind;
+        sbMessage.ApplicationProperties["CorrelationId"] = message.CorrelationId.ToString();
+        if (message.CausationId.HasValue)
+            sbMessage.ApplicationProperties["CausationId"] = message.CausationId.Value.ToString();
+
+        var opts = _options.Value;
+        if (opts.EnableSessions
+            && message.MessageKind == "Command"
+            && Attribute.IsDefined(type, typeof(SessionEnabledAttribute)))
+        {
+            sbMessage.SessionId = message.CorrelationId.ToString();
+        }
+
+        await sender.SendMessageAsync(sbMessage, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogDebug(
+            "Forwarded outbox message {MessageId} ({MessageKind}: {MessageType}) to '{Destination}'.",
+            message.Id, message.MessageKind, message.MessageType, destination);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var lazy in _senders.Values)
+        {
+            if (lazy.IsValueCreated)
+                await lazy.Value.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/OpinionatedEventing.AzureServiceBus/DependencyInjection/AzureServiceBusServiceCollectionExtensions.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/DependencyInjection/AzureServiceBusServiceCollectionExtensions.cs
@@ -1,0 +1,84 @@
+#nullable enable
+
+using Azure.Identity;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.AzureServiceBus;
+using OpinionatedEventing.AzureServiceBus.DependencyInjection;
+using OpinionatedEventing.Outbox;
+
+// Placed in this namespace so the extension is available without an extra using directive.
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods on <see cref="IServiceCollection"/> for registering the Azure Service Bus transport.
+/// </summary>
+public static class AzureServiceBusServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the Azure Service Bus transport. Requires a prior call to
+    /// <c>AddOpinionatedEventing()</c> and a registered <see cref="IOutboxStore"/>.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="configure">Delegate to configure <see cref="AzureServiceBusOptions"/>.</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddAzureServiceBusTransport(
+        this IServiceCollection services,
+        Action<AzureServiceBusOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.Configure(configure);
+
+        // Capture the service collection for handler-type scanning at host startup.
+        services.TryAddSingleton(new ServiceCollectionAccessor(services));
+
+        services.TryAddSingleton(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<AzureServiceBusOptions>>().Value;
+            return BuildServiceBusClient(opts);
+        });
+
+        services.TryAddSingleton(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<AzureServiceBusOptions>>().Value;
+            return BuildAdministrationClient(opts);
+        });
+
+        services.TryAddSingleton<ITransport, AzureServiceBusTransport>();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, TopologyInitializer>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, AzureServiceBusConsumerWorker>());
+
+        return services;
+    }
+
+    private static ServiceBusClient BuildServiceBusClient(AzureServiceBusOptions opts)
+    {
+        if (!string.IsNullOrWhiteSpace(opts.ConnectionString))
+            return new ServiceBusClient(opts.ConnectionString);
+
+        if (!string.IsNullOrWhiteSpace(opts.FullyQualifiedNamespace))
+            return new ServiceBusClient(opts.FullyQualifiedNamespace, new DefaultAzureCredential());
+
+        throw new InvalidOperationException(
+            "AzureServiceBusOptions requires either ConnectionString or FullyQualifiedNamespace to be set.");
+    }
+
+    private static ServiceBusAdministrationClient BuildAdministrationClient(AzureServiceBusOptions opts)
+    {
+        if (!string.IsNullOrWhiteSpace(opts.ConnectionString))
+            return new ServiceBusAdministrationClient(opts.ConnectionString);
+
+        if (!string.IsNullOrWhiteSpace(opts.FullyQualifiedNamespace))
+            return new ServiceBusAdministrationClient(opts.FullyQualifiedNamespace, new DefaultAzureCredential());
+
+        throw new InvalidOperationException(
+            "AzureServiceBusOptions requires either ConnectionString or FullyQualifiedNamespace to be set.");
+    }
+}

--- a/src/OpinionatedEventing.AzureServiceBus/DependencyInjection/ServiceCollectionAccessor.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/DependencyInjection/ServiceCollectionAccessor.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpinionatedEventing.AzureServiceBus.DependencyInjection;
+
+/// <summary>
+/// Captures the <see cref="IServiceCollection"/> at registration time so that the consumer
+/// worker and topology initializer can scan registered handler types at host startup.
+/// </summary>
+internal sealed class ServiceCollectionAccessor
+{
+    internal IServiceCollection Services { get; }
+
+    internal ServiceCollectionAccessor(IServiceCollection services) => Services = services;
+}

--- a/src/OpinionatedEventing.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+#nullable enable
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpinionatedEventing.AzureServiceBus.Tests")]
+[assembly: InternalsVisibleTo("OpinionatedEventing.AzureServiceBus.Specs")]

--- a/src/OpinionatedEventing.AzureServiceBus/Routing/MessageNamingConvention.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/Routing/MessageNamingConvention.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using System.Text;
+using OpinionatedEventing.Attributes;
+
+namespace OpinionatedEventing.AzureServiceBus.Routing;
+
+/// <summary>
+/// Derives Azure Service Bus topic and queue names from CLR message types.
+/// </summary>
+internal static class MessageNamingConvention
+{
+    /// <summary>
+    /// Returns the topic name for the given event type.
+    /// Uses <see cref="MessageTopicAttribute"/> if present; otherwise converts the type name
+    /// from PascalCase to kebab-case (e.g. <c>OrderPlaced</c> → <c>order-placed</c>).
+    /// </summary>
+    internal static string GetTopicName(Type eventType)
+    {
+        var attr = (MessageTopicAttribute?)Attribute.GetCustomAttribute(
+            eventType, typeof(MessageTopicAttribute));
+        return attr?.TopicName ?? ToKebabCase(eventType.Name);
+    }
+
+    /// <summary>
+    /// Returns the queue name for the given command type.
+    /// Uses <see cref="MessageQueueAttribute"/> if present; otherwise converts the type name
+    /// from PascalCase to kebab-case (e.g. <c>ProcessPayment</c> → <c>process-payment</c>).
+    /// </summary>
+    internal static string GetQueueName(Type commandType)
+    {
+        var attr = (MessageQueueAttribute?)Attribute.GetCustomAttribute(
+            commandType, typeof(MessageQueueAttribute));
+        return attr?.QueueName ?? ToKebabCase(commandType.Name);
+    }
+
+    private static string ToKebabCase(string name)
+    {
+        var sb = new StringBuilder(name.Length + 4);
+        for (var i = 0; i < name.Length; i++)
+        {
+            if (char.IsUpper(name[i]) && i > 0)
+                sb.Append('-');
+            sb.Append(char.ToLower(name[i]));
+        }
+        return sb.ToString();
+    }
+}

--- a/src/OpinionatedEventing.AzureServiceBus/TopologyInitializer.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/TopologyInitializer.cs
@@ -1,0 +1,158 @@
+#nullable enable
+
+using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.AzureServiceBus.Attributes;
+using OpinionatedEventing.AzureServiceBus.DependencyInjection;
+using OpinionatedEventing.AzureServiceBus.Routing;
+
+namespace OpinionatedEventing.AzureServiceBus;
+
+/// <summary>
+/// Hosted service that idempotently creates or updates Azure Service Bus topics, subscriptions,
+/// and queues at application startup when
+/// <see cref="AzureServiceBusOptions.AutoCreateResources"/> is <see langword="true"/>.
+/// </summary>
+internal sealed class TopologyInitializer : IHostedService
+{
+    private readonly ServiceBusAdministrationClient _adminClient;
+    private readonly ServiceCollectionAccessor _accessor;
+    private readonly IOptions<AzureServiceBusOptions> _options;
+    private readonly ILogger<TopologyInitializer> _logger;
+
+    /// <summary>Initialises a new <see cref="TopologyInitializer"/>.</summary>
+    public TopologyInitializer(
+        ServiceBusAdministrationClient adminClient,
+        ServiceCollectionAccessor accessor,
+        IOptions<AzureServiceBusOptions> options,
+        ILogger<TopologyInitializer> logger)
+    {
+        _adminClient = adminClient;
+        _accessor = accessor;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var opts = _options.Value;
+        if (!opts.AutoCreateResources)
+            return;
+
+        var eventTypes = ScanHandlerTypes(typeof(IEventHandler<>));
+        var commandTypes = ScanHandlerTypes(typeof(ICommandHandler<>));
+
+        foreach (var eventType in eventTypes)
+        {
+            var topicName = MessageNamingConvention.GetTopicName(eventType);
+            await EnsureTopicExistsAsync(topicName, cancellationToken).ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(opts.ServiceName))
+                await EnsureSubscriptionExistsAsync(topicName, opts.ServiceName, cancellationToken)
+                    .ConfigureAwait(false);
+        }
+
+        foreach (var commandType in commandTypes)
+        {
+            var queueName = MessageNamingConvention.GetQueueName(commandType);
+            var requiresSession = opts.EnableSessions
+                && Attribute.IsDefined(commandType, typeof(SessionEnabledAttribute));
+            await EnsureQueueExistsAsync(queueName, requiresSession, opts.MaxDeliveryCount, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task EnsureTopicExistsAsync(string topicName, CancellationToken ct)
+    {
+        try
+        {
+            if (await _adminClient.TopicExistsAsync(topicName, ct).ConfigureAwait(false))
+            {
+                _logger.LogDebug("Topic '{Topic}' already exists.", topicName);
+                return;
+            }
+
+            await _adminClient.CreateTopicAsync(topicName, ct).ConfigureAwait(false);
+            _logger.LogInformation("Created topic '{Topic}'.", topicName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to ensure topic '{Topic}' exists.", topicName);
+            throw;
+        }
+    }
+
+    private async Task EnsureSubscriptionExistsAsync(string topicName, string subscriptionName, CancellationToken ct)
+    {
+        try
+        {
+            if (await _adminClient.SubscriptionExistsAsync(topicName, subscriptionName, ct).ConfigureAwait(false))
+            {
+                _logger.LogDebug("Subscription '{Subscription}' on topic '{Topic}' already exists.",
+                    subscriptionName, topicName);
+                return;
+            }
+
+            await _adminClient.CreateSubscriptionAsync(topicName, subscriptionName, ct).ConfigureAwait(false);
+            _logger.LogInformation("Created subscription '{Subscription}' on topic '{Topic}'.",
+                subscriptionName, topicName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to ensure subscription '{Subscription}' on topic '{Topic}' exists.",
+                subscriptionName, topicName);
+            throw;
+        }
+    }
+
+    private async Task EnsureQueueExistsAsync(
+        string queueName,
+        bool requiresSession,
+        int maxDeliveryCount,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (await _adminClient.QueueExistsAsync(queueName, ct).ConfigureAwait(false))
+            {
+                var existing = await _adminClient.GetQueueAsync(queueName, ct).ConfigureAwait(false);
+                if (existing.Value.MaxDeliveryCount != maxDeliveryCount)
+                    _logger.LogWarning(
+                        "Queue '{Queue}' already exists with MaxDeliveryCount={Existing} " +
+                        "but options specify {Configured}. Update the queue manually or enable AutoCreateResources on a fresh namespace.",
+                        queueName, existing.Value.MaxDeliveryCount, maxDeliveryCount);
+                else
+                    _logger.LogDebug("Queue '{Queue}' already exists.", queueName);
+                return;
+            }
+
+            var options = new CreateQueueOptions(queueName)
+            {
+                RequiresSession = requiresSession,
+                MaxDeliveryCount = maxDeliveryCount,
+            };
+            await _adminClient.CreateQueueAsync(options, ct).ConfigureAwait(false);
+            _logger.LogInformation("Created queue '{Queue}' (session={RequiresSession}).",
+                queueName, requiresSession);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to ensure queue '{Queue}' exists.", queueName);
+            throw;
+        }
+    }
+
+    private List<Type> ScanHandlerTypes(Type openGenericInterface)
+        => _accessor.Services
+            .Where(d => d.ServiceType.IsGenericType
+                && d.ServiceType.GetGenericTypeDefinition() == openGenericInterface)
+            .Select(d => d.ServiceType.GetGenericArguments()[0])
+            .Distinct()
+            .ToList();
+}

--- a/tests/OpinionatedEventing.AzureServiceBus.Specs/Features/AzureServiceBus.feature
+++ b/tests/OpinionatedEventing.AzureServiceBus.Specs/Features/AzureServiceBus.feature
@@ -1,8 +1,29 @@
-Feature: AzureServiceBus
-  Placeholder feature file for OpinionatedEventing.AzureServiceBus BDD specs.
-  Replace with real scenarios when implementing issue #8.
+Feature: AzureServiceBus Transport
+  As a developer using OpinionatedEventing
+  I want the Azure Service Bus transport to route events and commands correctly
+  So that my microservices can communicate reliably
 
-  Scenario: Placeholder
-    Given this is a placeholder scenario
-    When it is executed
-    Then it passes
+  Scenario: Message naming convention converts PascalCase to kebab-case
+    Given an event type named "OrderPlaced"
+    When I resolve the topic name
+    Then the topic name is "order-placed"
+
+  Scenario: Message naming convention respects explicit MessageTopic attribute
+    Given an event type with a MessageTopic attribute set to "my-custom-topic"
+    When I resolve the topic name
+    Then the topic name is "my-custom-topic"
+
+  Scenario: Message naming convention converts command type to queue name
+    Given a command type named "ProcessPayment"
+    When I resolve the queue name
+    Then the queue name is "process-payment"
+
+  Scenario: Transport registration wires up ITransport
+    Given the Azure Service Bus transport is registered with a connection string
+    When the service provider is built
+    Then ITransport is registered in the container
+
+  Scenario: Transport registration configures ServiceName option
+    Given the Azure Service Bus transport is registered with ServiceName "order-service"
+    When the service provider is built
+    Then the ServiceName option is "order-service"

--- a/tests/OpinionatedEventing.AzureServiceBus.Specs/OpinionatedEventing.AzureServiceBus.Specs.csproj
+++ b/tests/OpinionatedEventing.AzureServiceBus.Specs/OpinionatedEventing.AzureServiceBus.Specs.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Testcontainers" />
   </ItemGroup>
 

--- a/tests/OpinionatedEventing.AzureServiceBus.Specs/StepDefinitions/AzureServiceBusSteps.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Specs/StepDefinitions/AzureServiceBusSteps.cs
@@ -1,3 +1,9 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.AzureServiceBus;
+using OpinionatedEventing.AzureServiceBus.Routing;
+using OpinionatedEventing.Attributes;
+using OpinionatedEventing.Outbox;
 using Reqnroll;
 
 namespace OpinionatedEventing.AzureServiceBus.Specs.StepDefinitions;
@@ -5,12 +11,115 @@ namespace OpinionatedEventing.AzureServiceBus.Specs.StepDefinitions;
 [Binding]
 public sealed class AzureServiceBusSteps
 {
-    [Given("this is a placeholder scenario")]
-    public void GivenPlaceholder() { }
+    private Type? _messageType;
+    private string? _resolvedName;
+    private IServiceCollection? _services;
+    private IServiceProvider? _serviceProvider;
 
-    [When("it is executed")]
-    public void WhenExecuted() { }
+    // --- Given ---
 
-    [Then("it passes")]
-    public void ThenPasses() { }
+    [Given("an event type named {string}")]
+    public void GivenAnEventTypeNamed(string typeName)
+    {
+        _messageType = typeName switch
+        {
+            "OrderPlaced" => typeof(OrderPlaced),
+            _ => throw new NotSupportedException($"Unknown type '{typeName}'.")
+        };
+    }
+
+    [Given("an event type with a MessageTopic attribute set to {string}")]
+    public void GivenAnEventTypeWithMessageTopicAttribute(string _)
+    {
+        _messageType = typeof(CustomTopicEvent);
+    }
+
+    [Given("a command type named {string}")]
+    public void GivenACommandTypeNamed(string typeName)
+    {
+        _messageType = typeName switch
+        {
+            "ProcessPayment" => typeof(ProcessPayment),
+            _ => throw new NotSupportedException($"Unknown type '{typeName}'.")
+        };
+    }
+
+    [Given("the Azure Service Bus transport is registered with a connection string")]
+    public void GivenTransportRegisteredWithConnectionString()
+    {
+        _services = new ServiceCollection();
+        _services.AddOpinionatedEventing();
+        _services.AddAzureServiceBusTransport(o =>
+        {
+            o.ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+            o.ServiceName = "test-service";
+        });
+    }
+
+    [Given("the Azure Service Bus transport is registered with ServiceName {string}")]
+    public void GivenTransportRegisteredWithServiceName(string serviceName)
+    {
+        _services = new ServiceCollection();
+        _services.AddOpinionatedEventing();
+        _services.AddAzureServiceBusTransport(o =>
+        {
+            o.ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+            o.ServiceName = serviceName;
+        });
+    }
+
+    // --- When ---
+
+    [When("I resolve the topic name")]
+    public void WhenIResolveTheTopicName()
+    {
+        _resolvedName = MessageNamingConvention.GetTopicName(_messageType!);
+    }
+
+    [When("I resolve the queue name")]
+    public void WhenIResolveTheQueueName()
+    {
+        _resolvedName = MessageNamingConvention.GetQueueName(_messageType!);
+    }
+
+    [When("the service provider is built")]
+    public void WhenServiceProviderIsBuilt()
+    {
+        _serviceProvider = _services!.BuildServiceProvider();
+    }
+
+    // --- Then ---
+
+    [Then("the topic name is {string}")]
+    public void ThenTheTopicNameIs(string expected)
+    {
+        Xunit.Assert.Equal(expected, _resolvedName);
+    }
+
+    [Then("the queue name is {string}")]
+    public void ThenTheQueueNameIs(string expected)
+    {
+        Xunit.Assert.Equal(expected, _resolvedName);
+    }
+
+    [Then("ITransport is registered in the container")]
+    public void ThenITransportIsRegistered()
+    {
+        Xunit.Assert.NotNull(_serviceProvider!.GetService<ITransport>());
+    }
+
+    [Then("the ServiceName option is {string}")]
+    public void ThenServiceNameOptionIs(string expected)
+    {
+        var opts = _serviceProvider!.GetRequiredService<IOptions<AzureServiceBusOptions>>().Value;
+        Xunit.Assert.Equal(expected, opts.ServiceName);
+    }
+
+    // --- message types ---
+
+    private sealed record OrderPlaced(string OrderId = "") : IEvent;
+    private sealed record ProcessPayment(string PaymentId = "", decimal Amount = 0) : ICommand;
+
+    [MessageTopic("my-custom-topic")]
+    private sealed record CustomTopicEvent : IEvent;
 }

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
@@ -1,0 +1,176 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpinionatedEventing.AzureServiceBus.Tests.TestSupport;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Testing;
+using Xunit;
+
+namespace OpinionatedEventing.AzureServiceBus.Tests;
+
+/// <summary>
+/// Integration tests for the Azure Service Bus transport.
+/// Require Docker with the Azure Service Bus Emulator image available.
+/// Run with: dotnet test --filter "Category=Integration"
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class AzureServiceBusIntegrationTests : IAsyncLifetime
+{
+    private AzureServiceBusEmulatorContainer? _emulator;
+
+    public async ValueTask InitializeAsync()
+    {
+        _emulator = await AzureServiceBusEmulatorContainer.StartAsync(
+            TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_emulator is not null)
+            await _emulator.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Published_event_is_consumed_by_handler()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var received = new List<OrderPlaced>();
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ =>
+                new CapturingEventHandler<OrderPlaced>(received));
+        });
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new OrderPlaced("order-1"), "Event"), ct);
+
+        await WaitForConditionAsync(() => received.Count == 1, ct);
+
+        Assert.Single(received);
+        Assert.Equal("order-1", received[0].OrderId);
+
+        await host.StopAsync(ct);
+    }
+
+    [Fact]
+    public async Task Sent_command_is_consumed_by_single_handler()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var received = new List<ProcessPayment>();
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<ICommandHandler<ProcessPayment>>(_ =>
+                new CapturingCommandHandler<ProcessPayment>(received));
+        });
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new ProcessPayment("payment-1", 99m), "Command"), ct);
+
+        await WaitForConditionAsync(() => received.Count == 1, ct);
+
+        Assert.Single(received);
+        Assert.Equal("payment-1", received[0].PaymentId);
+
+        await host.StopAsync(ct);
+    }
+
+    [Fact]
+    public async Task Dead_lettered_message_is_recorded_in_outbox()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outboxStore = new InMemoryOutboxStore();
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ => new ThrowingHandler<OrderPlaced>());
+            services.AddSingleton<IOutboxStore>(outboxStore);
+        }, maxDeliveryCount: 1);
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new OrderPlaced("dead-order"), "Event"), ct);
+
+        await WaitForConditionAsync(() => outboxStore.Messages.Any(m => m.FailedAt.HasValue), ct);
+
+        var deadLetter = outboxStore.Messages.Single(m => m.FailedAt.HasValue);
+        Assert.NotNull(deadLetter.Error);
+
+        await host.StopAsync(ct);
+    }
+
+    // --- helpers ---
+
+    private IHost BuildHost(Action<IServiceCollection>? configureExtra = null, int maxDeliveryCount = 5)
+        => Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddOpinionatedEventing();
+                services.AddAzureServiceBusTransport(o =>
+                {
+                    o.ConnectionString = _emulator!.ConnectionString;
+                    o.ServiceName = "test-service";
+                    o.AutoCreateResources = true;
+                    o.MaxDeliveryCount = maxDeliveryCount;
+                });
+                configureExtra?.Invoke(services);
+            })
+            .Build();
+
+    private static OutboxMessage BuildOutboxMessage<T>(T payload, string kind) where T : notnull
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            MessageType = typeof(T).AssemblyQualifiedName!,
+            MessageKind = kind,
+            Payload = System.Text.Json.JsonSerializer.Serialize(payload),
+            CorrelationId = Guid.NewGuid(),
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+    private static async Task WaitForConditionAsync(
+        Func<bool> condition, CancellationToken ct, int timeoutMs = 10_000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition() && DateTime.UtcNow < deadline)
+            await Task.Delay(100, ct);
+        Assert.True(condition(), "Condition was not met within the timeout.");
+    }
+
+    // --- test message types ---
+
+    private sealed record OrderPlaced(string OrderId) : IEvent;
+    private sealed record ProcessPayment(string PaymentId, decimal Amount) : ICommand;
+
+    // --- handler implementations ---
+
+    private sealed class CapturingEventHandler<T> : IEventHandler<T> where T : class, IEvent
+    {
+        private readonly List<T> _captured;
+        public CapturingEventHandler(List<T> captured) => _captured = captured;
+        public Task HandleAsync(T @event, CancellationToken ct) { _captured.Add(@event); return Task.CompletedTask; }
+    }
+
+    private sealed class CapturingCommandHandler<T> : ICommandHandler<T> where T : class, ICommand
+    {
+        private readonly List<T> _captured;
+        public CapturingCommandHandler(List<T> captured) => _captured = captured;
+        public Task HandleAsync(T command, CancellationToken ct) { _captured.Add(command); return Task.CompletedTask; }
+    }
+
+    private sealed class ThrowingHandler<T> : IEventHandler<T> where T : class, IEvent
+    {
+        public Task HandleAsync(T @event, CancellationToken ct)
+            => throw new InvalidOperationException("Simulated handler failure.");
+    }
+}

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/MessageNamingConventionTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/MessageNamingConventionTests.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+using OpinionatedEventing.AzureServiceBus.Routing;
+using OpinionatedEventing.Attributes;
+using Xunit;
+
+namespace OpinionatedEventing.AzureServiceBus.Tests;
+
+public sealed class MessageNamingConventionTests
+{
+    [Theory]
+    [InlineData(typeof(OrderPlaced), "order-placed")]
+    [InlineData(typeof(PaymentReceived), "payment-received")]
+    [InlineData(typeof(SimpleEvent), "simple-event")]
+    [InlineData(typeof(ABCEvent), "a-b-c-event")]
+    public void GetTopicName_derives_kebab_case_from_type_name(Type type, string expected)
+    {
+        Assert.Equal(expected, MessageNamingConvention.GetTopicName(type));
+    }
+
+    [Fact]
+    public void GetTopicName_uses_attribute_when_present()
+    {
+        Assert.Equal("my-custom-topic", MessageNamingConvention.GetTopicName(typeof(CustomTopicEvent)));
+    }
+
+    [Theory]
+    [InlineData(typeof(ProcessPayment), "process-payment")]
+    [InlineData(typeof(CancelOrder), "cancel-order")]
+    public void GetQueueName_derives_kebab_case_from_type_name(Type type, string expected)
+    {
+        Assert.Equal(expected, MessageNamingConvention.GetQueueName(type));
+    }
+
+    [Fact]
+    public void GetQueueName_uses_attribute_when_present()
+    {
+        Assert.Equal("my-custom-queue", MessageNamingConvention.GetQueueName(typeof(CustomQueueCommand)));
+    }
+
+    // --- test types ---
+
+    private sealed record OrderPlaced : IEvent;
+    private sealed record PaymentReceived : IEvent;
+    private sealed record SimpleEvent : IEvent;
+    private sealed record ABCEvent : IEvent;
+
+    [MessageTopic("my-custom-topic")]
+    private sealed record CustomTopicEvent : IEvent;
+
+    private sealed record ProcessPayment : ICommand;
+    private sealed record CancelOrder : ICommand;
+
+    [MessageQueue("my-custom-queue")]
+    private sealed record CustomQueueCommand : ICommand;
+}

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/OpinionatedEventing.AzureServiceBus.Tests.csproj
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/OpinionatedEventing.AzureServiceBus.Tests.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Testcontainers" />
   </ItemGroup>
 

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/RegistrationTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/RegistrationTests.cs
@@ -1,0 +1,49 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.AzureServiceBus;
+using OpinionatedEventing.Outbox;
+using Xunit;
+
+namespace OpinionatedEventing.AzureServiceBus.Tests;
+
+public sealed class RegistrationTests
+{
+    [Fact]
+    public void AddAzureServiceBusTransport_registers_ITransport()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+        services.AddAzureServiceBusTransport(o =>
+        {
+            o.ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+            o.ServiceName = "test-service";
+        });
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ITransport));
+        Assert.NotNull(descriptor);
+    }
+
+    [Fact]
+    public void AddAzureServiceBusTransport_configures_options()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+        services.AddAzureServiceBusTransport(o =>
+        {
+            o.ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+            o.ServiceName = "order-service";
+            o.AutoCreateResources = true;
+            o.EnableSessions = false;
+            o.MaxDeliveryCount = 3;
+        });
+
+        var sp = services.BuildServiceProvider();
+        var opts = sp.GetRequiredService<IOptions<AzureServiceBusOptions>>().Value;
+
+        Assert.Equal("order-service", opts.ServiceName);
+        Assert.True(opts.AutoCreateResources);
+        Assert.Equal(3, opts.MaxDeliveryCount);
+    }
+}

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
@@ -1,0 +1,84 @@
+#nullable enable
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace OpinionatedEventing.AzureServiceBus.Tests.TestSupport;
+
+/// <summary>
+/// Manages a local Azure Service Bus Emulator Docker container for integration tests.
+/// </summary>
+internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
+{
+    private const string Image = "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest";
+    private const int AmqpPort = 5672;
+
+    // The emulator's hardcoded development connection string.
+    private const string EmulatorConnectionStringTemplate =
+        "Endpoint=sb://localhost:{0};SharedAccessKeyName=RootManageSharedAccessKey;" +
+        "SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+
+    private readonly IContainer _container;
+    private readonly string _configPath;
+
+    private AzureServiceBusEmulatorContainer(IContainer container, string configPath)
+    {
+        _container = container;
+        _configPath = configPath;
+    }
+
+    /// <summary>
+    /// Creates and starts the emulator with a namespace that has no pre-defined entities.
+    /// Resources are created at runtime by the transport's auto-create feature.
+    /// </summary>
+    public static async Task<AzureServiceBusEmulatorContainer> StartAsync(
+        CancellationToken ct = default)
+    {
+        var configJson = """
+            {
+              "UserConfig": {
+                "Namespaces": [
+                  {
+                    "Name": "sbemulator",
+                    "Queues": [],
+                    "Topics": []
+                  }
+                ],
+                "Logging": { "Type": "File" }
+              }
+            }
+            """;
+
+        // Write config to a temp file for volume mount.
+        var configPath = Path.Combine(Path.GetTempPath(), $"asb-emulator-config-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(configPath, configJson, ct);
+
+        var container = new ContainerBuilder()
+            .WithImage(Image)
+            .WithPortBinding(AmqpPort, true)
+            .WithEnvironment("ACCEPT_EULA", "Y")
+            .WithBindMount(configPath, "/ServiceBus_Emulator/ConfigFiles/Config.json")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(AmqpPort))
+            .Build();
+
+        await container.StartAsync(ct);
+        return new AzureServiceBusEmulatorContainer(container, configPath);
+    }
+
+    /// <summary>Gets the connection string pointing at the running emulator.</summary>
+    public string ConnectionString
+    {
+        get
+        {
+            var port = _container.GetMappedPublicPort(AmqpPort);
+            return string.Format(EmulatorConnectionStringTemplate, port);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync();
+        try { File.Delete(_configPath); } catch { /* best-effort cleanup */ }
+    }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Implements the full `OpinionatedEventing.AzureServiceBus` package per issue #8
- `AzureServiceBusTransport : ITransport` — send path; routes events to topics and commands to queues using PascalCase→kebab-case naming (overridable via `MessageTopicAttribute` / `MessageQueueAttribute`)
- `AzureServiceBusConsumerWorker : BackgroundService` — receive path; scans registered `IEventHandler<>` / `ICommandHandler<>` types at startup, creates one `ServiceBusProcessor` per topic subscription / queue; dead-lettered messages are written back to `IOutboxStore`
- `TopologyInitializer : IHostedService` — idempotently creates topics, subscriptions, and queues on startup when `AutoCreateResources = true`; warns if an existing queue's `MaxDeliveryCount` diverges from options
- `[SessionEnabled]` attribute + `EnableSessions` option for session-enabled command queues
- `DefaultAzureCredential` support via `FullyQualifiedNamespace` option
- `AddAzureServiceBusTransport(Action<AzureServiceBusOptions>)` DI extension
- Unit tests: naming convention (kebab-case, attribute overrides), DI registration
- Integration tests using the ASB emulator via Testcontainers (event consumed, command consumed, dead-letter → outbox)
- BDD feature file and step definitions updated

## Test plan

- [ ] `dotnet test --filter "Category!=Integration"` — all unit/BDD tests pass (30 green, integration tests skipped)
- [ ] Integration tests run automatically on merge to `main` via CI (Docker available on `ubuntu-latest`)
- [ ] Verify emulator container starts, topics/queues are auto-created, messages round-trip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)