### PR TITLE
Fix integration test container setup for Azure Service Bus emulator

### DIFF
--- a/src/OpinionatedEventing.AzureServiceBus/DependencyInjection/AzureServiceBusServiceCollectionExtensions.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/DependencyInjection/AzureServiceBusServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class AzureServiceBusServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(configure);
 
         services.Configure(configure);
+        services.TryAddSingleton(TimeProvider.System);
 
         // Capture the service collection for handler-type scanning at host startup.
         services.TryAddSingleton(new ServiceCollectionAccessor(services));

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
@@ -120,7 +120,7 @@ public sealed class AzureServiceBusIntegrationTests : IAsyncLifetime
                 {
                     o.ConnectionString = _emulator!.ConnectionString;
                     o.ServiceName = "test-service";
-                    o.AutoCreateResources = true;
+                    o.AutoCreateResources = false;
                     o.MaxDeliveryCount = maxDeliveryCount;
                 });
                 configureExtra?.Invoke(services);

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
@@ -2,46 +2,79 @@
 
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
 
 namespace OpinionatedEventing.AzureServiceBus.Tests.TestSupport;
 
 /// <summary>
 /// Manages a local Azure Service Bus Emulator Docker container for integration tests.
+/// The emulator requires a companion SQL Edge container; both share a private Docker network.
 /// </summary>
 internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
 {
-    private const string Image = "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest";
+    private const string EmulatorImage = "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest";
+    private const string SqlEdgeImage = "mcr.microsoft.com/azure-sql-edge:latest";
     private const int AmqpPort = 5672;
+    private const int SqlPort = 1433;
+    private const string SqlAlias = "sqledge";
+    private const string SqlPassword = "SqlEdgeP@ssw0rd!";
 
     // The emulator's hardcoded development connection string.
     private const string EmulatorConnectionStringTemplate =
         "Endpoint=sb://localhost:{0};SharedAccessKeyName=RootManageSharedAccessKey;" +
         "SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
 
-    private readonly IContainer _container;
+    private readonly INetwork _network;
+    private readonly IContainer _sqlContainer;
+    private readonly IContainer _emulatorContainer;
     private readonly string _configPath;
 
-    private AzureServiceBusEmulatorContainer(IContainer container, string configPath)
+    private AzureServiceBusEmulatorContainer(
+        INetwork network,
+        IContainer sqlContainer,
+        IContainer emulatorContainer,
+        string configPath)
     {
-        _container = container;
+        _network = network;
+        _sqlContainer = sqlContainer;
+        _emulatorContainer = emulatorContainer;
         _configPath = configPath;
     }
 
     /// <summary>
-    /// Creates and starts the emulator with a namespace that has no pre-defined entities.
+    /// Creates and starts the SQL Edge sidecar and ASB emulator containers.
     /// Resources are created at runtime by the transport's auto-create feature.
     /// </summary>
     public static async Task<AzureServiceBusEmulatorContainer> StartAsync(
         CancellationToken ct = default)
     {
+        // The emulator only accepts the fixed namespace name "sbemulatorns".
+        // The admin REST API is not exposed on the AMQP port, so entities must be
+        // pre-defined here rather than created via ServiceBusAdministrationClient.
         var configJson = """
             {
               "UserConfig": {
                 "Namespaces": [
                   {
-                    "Name": "sbemulator",
-                    "Queues": [],
-                    "Topics": []
+                    "Name": "sbemulatorns",
+                    "Queues": [
+                      {
+                        "Name": "process-payment",
+                        "Properties": { "MaxDeliveryCount": 10 }
+                      }
+                    ],
+                    "Topics": [
+                      {
+                        "Name": "order-placed",
+                        "Properties": {},
+                        "Subscriptions": [
+                          {
+                            "Name": "test-service",
+                            "Properties": {}
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ],
                 "Logging": { "Type": "File" }
@@ -49,20 +82,40 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
             }
             """;
 
-        // Write config to a temp file for volume mount.
         var configPath = Path.Combine(Path.GetTempPath(), $"asb-emulator-config-{Guid.NewGuid():N}.json");
         await File.WriteAllTextAsync(configPath, configJson, ct);
 
-        var container = new ContainerBuilder()
-            .WithImage(Image)
-            .WithPortBinding(AmqpPort, true)
-            .WithEnvironment("ACCEPT_EULA", "Y")
-            .WithBindMount(configPath, "/ServiceBus_Emulator/ConfigFiles/Config.json")
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(AmqpPort))
+        var network = new NetworkBuilder().Build();
+        await network.CreateAsync(ct);
+
+        var sqlContainer = new ContainerBuilder()
+            .WithImage(SqlEdgeImage)
+            .WithNetwork(network)
+            .WithNetworkAliases(SqlAlias)
+            .WithEnvironment("ACCEPT_EULA", "1")
+            .WithEnvironment("MSSQL_SA_PASSWORD", SqlPassword)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(SqlPort))
             .Build();
 
-        await container.StartAsync(ct);
-        return new AzureServiceBusEmulatorContainer(container, configPath);
+        await sqlContainer.StartAsync(ct);
+
+        var emulatorContainer = new ContainerBuilder()
+            .WithImage(EmulatorImage)
+            .WithNetwork(network)
+            .WithPortBinding(AmqpPort, true)
+            .WithEnvironment("ACCEPT_EULA", "Y")
+            .WithEnvironment("SQL_SERVER", SqlAlias)
+            .WithEnvironment("MSSQL_SA_PASSWORD", SqlPassword)
+            .WithBindMount(configPath, "/ServiceBus_Emulator/ConfigFiles/Config.json")
+            // The emulator image is distroless (no sh/nc/grep), so port-scan wait strategies
+            // never succeed. Wait for the log line the emulator emits when it is ready instead.
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilMessageIsLogged("Emulator Service is Successfully Up!"))
+            .Build();
+
+        await emulatorContainer.StartAsync(ct);
+
+        return new AzureServiceBusEmulatorContainer(network, sqlContainer, emulatorContainer, configPath);
     }
 
     /// <summary>Gets the connection string pointing at the running emulator.</summary>
@@ -70,7 +123,7 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
     {
         get
         {
-            var port = _container.GetMappedPublicPort(AmqpPort);
+            var port = _emulatorContainer.GetMappedPublicPort(AmqpPort);
             return string.Format(EmulatorConnectionStringTemplate, port);
         }
     }
@@ -78,7 +131,9 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        await _container.DisposeAsync();
+        await _emulatorContainer.DisposeAsync();
+        await _sqlContainer.DisposeAsync();
+        await _network.DisposeAsync();
         try { File.Delete(_configPath); } catch { /* best-effort cleanup */ }
     }
 }


### PR DESCRIPTION
## Summary

Fixes three root causes that prevented the integration tests from passing in CI:

- **SQL Edge sidecar missing** — the ASB emulator exits (SIGSEGV) without a companion SQL Server; adds `mcr.microsoft.com/azure-sql-edge` on a shared Docker network and passes `SQL_SERVER` / `MSSQL_SA_PASSWORD` env vars to the emulator
- **Wrong wait strategy** — the emulator image is distroless (no `sh`, `nc`, `grep`), so `UntilPortIsAvailable` never succeeds; switched to `UntilMessageIsLogged("Emulator Service is Successfully Up!")`
- **Admin API unreachable** — `ServiceBusAdministrationClient` sends HTTP to the AMQP port (5672), getting `ResponseEnded`; entities are now pre-defined in the emulator config JSON and `AutoCreateResources = false` in tests
- **`TimeProvider` not registered** — `AddAzureServiceBusTransport` now registers `TimeProvider.System` via `TryAddSingleton` so callers that skip `AddOutbox()` don't get a DI resolution failure
- **Wrong namespace name** — the emulator only accepts `sbemulatorns`; corrected from `sbemulator`

All 3 integration tests pass locally (3/3, exit code 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)