### PR TITLE
Implement OpinionatedEventing.RabbitMQ transport (#9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,11 @@ On Windows, use `pwsh` (PowerShell) for scripting tasks — never Python. Exampl
 ```bash
 dotnet restore
 dotnet build
-dotnet test --filter "Category!=Integration"   # fast, no Docker needed
-dotnet test --filter "Category=Integration"    # requires Docker (Testcontainers)
+dotnet test -- --filter-trait "Category!=Integration"   # fast, no Docker needed
+dotnet test -- --filter-trait "Category=Integration"    # requires Docker (Testcontainers)
 ```
+
+> **Note:** Use `-- --filter-trait` (MTP syntax), not `--filter`. The CI pipeline uses the same syntax.
 
 ### dotnet CLI gotchas
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
 
   <!-- Microsoft.Extensions -->
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />

--- a/src/OpinionatedEventing.RabbitMQ/DependencyInjection/RabbitMQServiceCollectionExtensions.cs
+++ b/src/OpinionatedEventing.RabbitMQ/DependencyInjection/RabbitMQServiceCollectionExtensions.cs
@@ -1,0 +1,71 @@
+#nullable enable
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.RabbitMQ;
+using OpinionatedEventing.RabbitMQ.DependencyInjection;
+using RabbitMQ.Client;
+
+// Placed in this namespace so the extension is available without an extra using directive.
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods on <see cref="IServiceCollection"/> for registering the RabbitMQ transport.
+/// </summary>
+public static class RabbitMQServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the RabbitMQ transport. Requires a prior call to
+    /// <c>AddOpinionatedEventing()</c> and a registered <see cref="IOutboxStore"/>.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="configure">Delegate to configure <see cref="RabbitMQOptions"/>.</param>
+    /// <returns>The same <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddRabbitMQTransport(
+        this IServiceCollection services,
+        Action<RabbitMQOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.Configure(configure);
+        services.TryAddSingleton(TimeProvider.System);
+
+        // Capture the service collection for handler-type scanning at host startup.
+        services.TryAddSingleton(new ServiceCollectionAccessor(services));
+
+        services.TryAddSingleton<IConnection>(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<RabbitMQOptions>>().Value;
+            var config = sp.GetService<IConfiguration>();
+            var connectionString = ResolveConnectionString(opts, config);
+            var factory = new ConnectionFactory { Uri = new Uri(connectionString) };
+            return factory.CreateConnectionAsync().GetAwaiter().GetResult();
+        });
+
+        services.TryAddSingleton<ITransport, RabbitMQTransport>();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, RabbitMQTopologyInitializer>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, RabbitMQConsumerWorker>());
+
+        return services;
+    }
+
+    private static string ResolveConnectionString(RabbitMQOptions opts, IConfiguration? config)
+    {
+        if (!string.IsNullOrWhiteSpace(opts.ConnectionString))
+            return opts.ConnectionString;
+
+        var aspireConnectionString = config?["ConnectionStrings:rabbitmq"];
+        if (!string.IsNullOrWhiteSpace(aspireConnectionString))
+            return aspireConnectionString;
+
+        throw new InvalidOperationException(
+            "RabbitMQOptions requires either ConnectionString to be set, " +
+            "or a 'ConnectionStrings:rabbitmq' entry in IConfiguration (Aspire service discovery).");
+    }
+}

--- a/src/OpinionatedEventing.RabbitMQ/DependencyInjection/ServiceCollectionAccessor.cs
+++ b/src/OpinionatedEventing.RabbitMQ/DependencyInjection/ServiceCollectionAccessor.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpinionatedEventing.RabbitMQ.DependencyInjection;
+
+/// <summary>
+/// Captures the <see cref="IServiceCollection"/> at registration time so that the consumer
+/// worker and topology initializer can scan registered handler types at host startup.
+/// </summary>
+internal sealed class ServiceCollectionAccessor
+{
+    internal IServiceCollection Services { get; }
+
+    internal ServiceCollectionAccessor(IServiceCollection services) => Services = services;
+}

--- a/src/OpinionatedEventing.RabbitMQ/OpinionatedEventing.RabbitMQ.csproj
+++ b/src/OpinionatedEventing.RabbitMQ/OpinionatedEventing.RabbitMQ.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="RabbitMQ.Client" />
   </ItemGroup>
 

--- a/src/OpinionatedEventing.RabbitMQ/Properties/AssemblyInfo.cs
+++ b/src/OpinionatedEventing.RabbitMQ/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+#nullable enable
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpinionatedEventing.RabbitMQ.Tests")]
+[assembly: InternalsVisibleTo("OpinionatedEventing.RabbitMQ.Specs")]

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
@@ -1,0 +1,249 @@
+#nullable enable
+
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.RabbitMQ.DependencyInjection;
+using OpinionatedEventing.RabbitMQ.Routing;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace OpinionatedEventing.RabbitMQ;
+
+/// <summary>
+/// Background service that consumes messages from RabbitMQ fanout exchanges (events) and direct
+/// queues (commands), then dispatches them to registered handlers via
+/// <see cref="IMessageHandlerRunner"/>.
+/// </summary>
+internal sealed class RabbitMQConsumerWorker : BackgroundService
+{
+    private readonly IConnection _connection;
+    private readonly IMessageHandlerRunner _handlerRunner;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ServiceCollectionAccessor _accessor;
+    private readonly IOptions<RabbitMQOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<RabbitMQConsumerWorker> _logger;
+
+    private readonly List<IChannel> _consumerChannels = new();
+
+    /// <summary>Initialises a new <see cref="RabbitMQConsumerWorker"/>.</summary>
+    public RabbitMQConsumerWorker(
+        IConnection connection,
+        IMessageHandlerRunner handlerRunner,
+        IServiceScopeFactory scopeFactory,
+        ServiceCollectionAccessor accessor,
+        IOptions<RabbitMQOptions> options,
+        TimeProvider timeProvider,
+        ILogger<RabbitMQConsumerWorker> logger)
+    {
+        _connection = connection;
+        _handlerRunner = handlerRunner;
+        _scopeFactory = scopeFactory;
+        _accessor = accessor;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var opts = _options.Value;
+        var eventTypes = ScanHandlerTypes(typeof(IEventHandler<>));
+        var commandTypes = ScanHandlerTypes(typeof(ICommandHandler<>));
+
+        foreach (var eventType in eventTypes)
+        {
+            if (string.IsNullOrEmpty(opts.ServiceName))
+            {
+                _logger.LogWarning(
+                    "ServiceName is not configured — skipping consumer for event '{EventType}'.",
+                    eventType.Name);
+                continue;
+            }
+
+            var queueName = MessageNamingConvention.GetEventQueueName(eventType, opts.ServiceName);
+            var exchangeName = MessageNamingConvention.GetExchangeName(eventType);
+            await StartConsumerAsync(queueName, stoppingToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Consuming event '{EventType}' from queue '{Queue}' (exchange '{Exchange}').",
+                eventType.Name, queueName, exchangeName);
+        }
+
+        foreach (var commandType in commandTypes)
+        {
+            var queueName = MessageNamingConvention.GetQueueName(commandType);
+            await StartConsumerAsync(queueName, stoppingToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Consuming command '{CommandType}' from queue '{Queue}'.",
+                commandType.Name, queueName);
+        }
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // normal shutdown
+        }
+
+        await CloseConsumerChannelsAsync().ConfigureAwait(false);
+    }
+
+    private async Task StartConsumerAsync(
+        string queueName,
+        CancellationToken ct)
+    {
+        var channel = await _connection.CreateChannelAsync(cancellationToken: ct).ConfigureAwait(false);
+        _consumerChannels.Add(channel);
+
+        await channel.BasicQosAsync(
+            prefetchSize: 0,
+            prefetchCount: _options.Value.PrefetchCount,
+            global: false,
+            cancellationToken: ct).ConfigureAwait(false);
+
+        var consumer = new AsyncEventingBasicConsumer(channel);
+        consumer.ReceivedAsync += (_, ea) => ProcessDeliveryAsync(channel, ea, ct);
+
+        await channel.BasicConsumeAsync(
+            queue: queueName,
+            autoAck: false,
+            consumer: consumer,
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    private async Task ProcessDeliveryAsync(
+        IChannel channel,
+        BasicDeliverEventArgs ea,
+        CancellationToken ct)
+    {
+        try
+        {
+            var messageType = GetHeader(ea.BasicProperties, "MessageType");
+            var messageKind = GetHeader(ea.BasicProperties, "MessageKind");
+            var correlationIdStr = GetHeader(ea.BasicProperties, "CorrelationId");
+            var causationIdStr = GetHeader(ea.BasicProperties, "CausationId");
+
+            if (messageType is null || messageKind is null || correlationIdStr is null)
+            {
+                _logger.LogWarning(
+                    "Received message is missing required headers; nacking without requeue.");
+                await channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, CancellationToken.None)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            if (!Guid.TryParse(correlationIdStr, out var correlationId))
+            {
+                _logger.LogWarning(
+                    "Received message has invalid CorrelationId '{CorrelationId}'; nacking without requeue.",
+                    correlationIdStr);
+                await channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, CancellationToken.None)
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            Guid? causationId = Guid.TryParse(causationIdStr, out var c) ? c : null;
+            var payload = Encoding.UTF8.GetString(ea.Body.Span);
+
+            await _handlerRunner
+                .RunAsync(messageType, messageKind, payload, correlationId, causationId, ct)
+                .ConfigureAwait(false);
+
+            await channel.BasicAckAsync(ea.DeliveryTag, multiple: false, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to handle message with delivery tag {DeliveryTag}.", ea.DeliveryTag);
+
+            await WriteDeadLetterRecordAsync(ea, ex.Message, ct).ConfigureAwait(false);
+            await channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, ct)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async Task WriteDeadLetterRecordAsync(
+        BasicDeliverEventArgs ea,
+        string error,
+        CancellationToken ct)
+    {
+        try
+        {
+            var messageType = GetHeader(ea.BasicProperties, "MessageType") ?? string.Empty;
+            var messageKind = GetHeader(ea.BasicProperties, "MessageKind") ?? string.Empty;
+            var correlationIdStr = GetHeader(ea.BasicProperties, "CorrelationId");
+            var causationIdStr = GetHeader(ea.BasicProperties, "CausationId");
+
+            _ = Guid.TryParse(correlationIdStr, out var correlationId);
+            Guid? causationId = Guid.TryParse(causationIdStr, out var c) ? c : null;
+
+            var record = new OutboxMessage
+            {
+                Id = Guid.NewGuid(),
+                MessageType = messageType,
+                MessageKind = messageKind,
+                Payload = Encoding.UTF8.GetString(ea.Body.Span),
+                CorrelationId = correlationId,
+                CausationId = causationId,
+                CreatedAt = _timeProvider.GetUtcNow(),
+                AttemptCount = 1,
+            };
+
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var store = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+            await store.SaveAsync(record, ct).ConfigureAwait(false);
+            await store.MarkFailedAsync(record.Id, error, ct).ConfigureAwait(false);
+
+            _logger.LogWarning(
+                "Dead-lettered message recorded in outbox as {RecordId}.", record.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to write dead-letter record to outbox.");
+        }
+    }
+
+    private async Task CloseConsumerChannelsAsync()
+    {
+        foreach (var channel in _consumerChannels)
+        {
+            try
+            {
+                await channel.CloseAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error closing consumer channel.");
+            }
+            await channel.DisposeAsync().ConfigureAwait(false);
+        }
+        _consumerChannels.Clear();
+    }
+
+    private List<Type> ScanHandlerTypes(Type openGenericInterface)
+        => _accessor.Services
+            .Where(d => d.ServiceType.IsGenericType
+                && d.ServiceType.GetGenericTypeDefinition() == openGenericInterface)
+            .Select(d => d.ServiceType.GetGenericArguments()[0])
+            .Distinct()
+            .ToList();
+
+    private static string? GetHeader(IReadOnlyBasicProperties properties, string key)
+    {
+        if (properties.Headers is null || !properties.Headers.TryGetValue(key, out var value))
+            return null;
+        return value is byte[] bytes ? Encoding.UTF8.GetString(bytes) : value?.ToString();
+    }
+}

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQOptions.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQOptions.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+namespace OpinionatedEventing.RabbitMQ;
+
+/// <summary>
+/// Configuration options for the RabbitMQ transport.
+/// </summary>
+public sealed class RabbitMQOptions
+{
+    /// <summary>
+    /// Gets or sets the AMQP connection string (e.g. <c>amqp://guest:guest@localhost:5672/</c>).
+    /// When set, takes precedence over Aspire service discovery.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the logical name of this consuming service.
+    /// Used to derive event queue names: <c>{ServiceName}.{event-name}</c>.
+    /// </summary>
+    public string ServiceName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether exchanges, queues, and bindings should be declared
+    /// idempotently at application startup. Defaults to <see langword="true"/>.
+    /// Safe to enable in development; disable in production where topology is managed externally.
+    /// </summary>
+    public bool AutoDeclareTopology { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the number of messages to prefetch per consumer channel. Defaults to <c>10</c>.
+    /// </summary>
+    public ushort PrefetchCount { get; set; } = 10;
+}

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQTopologyInitializer.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQTopologyInitializer.cs
@@ -1,0 +1,172 @@
+#nullable enable
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.RabbitMQ.DependencyInjection;
+using OpinionatedEventing.RabbitMQ.Routing;
+using RabbitMQ.Client;
+
+namespace OpinionatedEventing.RabbitMQ;
+
+/// <summary>
+/// Hosted service that idempotently declares RabbitMQ exchanges, queues, and bindings at
+/// application startup when <see cref="RabbitMQOptions.AutoDeclareTopology"/> is
+/// <see langword="true"/>.
+/// </summary>
+internal sealed class RabbitMQTopologyInitializer : IHostedService
+{
+    private readonly IConnection _connection;
+    private readonly ServiceCollectionAccessor _accessor;
+    private readonly IOptions<RabbitMQOptions> _options;
+    private readonly ILogger<RabbitMQTopologyInitializer> _logger;
+
+    /// <summary>Initialises a new <see cref="RabbitMQTopologyInitializer"/>.</summary>
+    public RabbitMQTopologyInitializer(
+        IConnection connection,
+        ServiceCollectionAccessor accessor,
+        IOptions<RabbitMQOptions> options,
+        ILogger<RabbitMQTopologyInitializer> logger)
+    {
+        _connection = connection;
+        _accessor = accessor;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var opts = _options.Value;
+        if (!opts.AutoDeclareTopology)
+            return;
+
+        var eventTypes = ScanHandlerTypes(typeof(IEventHandler<>));
+        var commandTypes = ScanHandlerTypes(typeof(ICommandHandler<>));
+
+        await using var channel = await _connection
+            .CreateChannelAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var eventType in eventTypes)
+        {
+            var exchangeName = MessageNamingConvention.GetExchangeName(eventType);
+            await DeclareEventTopologyAsync(channel, exchangeName, opts.ServiceName, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        foreach (var commandType in commandTypes)
+        {
+            var queueName = MessageNamingConvention.GetQueueName(commandType);
+            await DeclareCommandTopologyAsync(channel, queueName, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task DeclareEventTopologyAsync(
+        IChannel channel,
+        string exchangeName,
+        string serviceName,
+        CancellationToken ct)
+    {
+        try
+        {
+            await channel.ExchangeDeclareAsync(
+                exchange: exchangeName,
+                type: ExchangeType.Fanout,
+                durable: true,
+                autoDelete: false,
+                arguments: null,
+                cancellationToken: ct).ConfigureAwait(false);
+
+            _logger.LogDebug("Declared fanout exchange '{Exchange}'.", exchangeName);
+
+            if (string.IsNullOrEmpty(serviceName))
+            {
+                _logger.LogWarning(
+                    "ServiceName is not configured — skipping queue declaration for exchange '{Exchange}'.",
+                    exchangeName);
+                return;
+            }
+
+            var queueName = $"{serviceName}.{exchangeName}";
+            await channel.QueueDeclareAsync(
+                queue: queueName,
+                durable: true,
+                exclusive: false,
+                autoDelete: false,
+                arguments: null,
+                cancellationToken: ct).ConfigureAwait(false);
+
+            await channel.QueueBindAsync(
+                queue: queueName,
+                exchange: exchangeName,
+                routingKey: string.Empty,
+                arguments: null,
+                cancellationToken: ct).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Declared queue '{Queue}' bound to exchange '{Exchange}'.",
+                queueName, exchangeName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to declare event topology for exchange '{Exchange}'.", exchangeName);
+            throw;
+        }
+    }
+
+    private async Task DeclareCommandTopologyAsync(
+        IChannel channel,
+        string queueName,
+        CancellationToken ct)
+    {
+        try
+        {
+            await channel.ExchangeDeclareAsync(
+                exchange: queueName,
+                type: ExchangeType.Direct,
+                durable: true,
+                autoDelete: false,
+                arguments: null,
+                cancellationToken: ct).ConfigureAwait(false);
+
+            await channel.QueueDeclareAsync(
+                queue: queueName,
+                durable: true,
+                exclusive: false,
+                autoDelete: false,
+                arguments: null,
+                cancellationToken: ct).ConfigureAwait(false);
+
+            await channel.QueueBindAsync(
+                queue: queueName,
+                exchange: queueName,
+                routingKey: queueName,
+                arguments: null,
+                cancellationToken: ct).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Declared command queue '{Queue}' bound to direct exchange '{Exchange}'.",
+                queueName, queueName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to declare command topology for queue '{Queue}'.", queueName);
+            throw;
+        }
+    }
+
+    private List<Type> ScanHandlerTypes(Type openGenericInterface)
+        => _accessor.Services
+            .Where(d => d.ServiceType.IsGenericType
+                && d.ServiceType.GetGenericTypeDefinition() == openGenericInterface)
+            .Select(d => d.ServiceType.GetGenericArguments()[0])
+            .Distinct()
+            .ToList();
+}

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQTransport.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQTransport.cs
@@ -1,0 +1,103 @@
+#nullable enable
+
+using System.Text;
+using Microsoft.Extensions.Logging;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.RabbitMQ.Routing;
+using RabbitMQ.Client;
+
+namespace OpinionatedEventing.RabbitMQ;
+
+/// <summary>
+/// RabbitMQ implementation of <see cref="ITransport"/>.
+/// Forwards outbox messages to the correct RabbitMQ exchange (events) or queue (commands).
+/// </summary>
+internal sealed class RabbitMQTransport : ITransport, IAsyncDisposable
+{
+    private readonly IConnection _connection;
+    private readonly ILogger<RabbitMQTransport> _logger;
+
+    private IChannel? _publishChannel;
+    private readonly SemaphoreSlim _channelLock = new(1, 1);
+
+    /// <summary>Initialises a new <see cref="RabbitMQTransport"/>.</summary>
+    public RabbitMQTransport(
+        IConnection connection,
+        ILogger<RabbitMQTransport> logger)
+    {
+        _connection = connection;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default)
+    {
+        var type = Type.GetType(message.MessageType)
+            ?? throw new InvalidOperationException(
+                $"Cannot resolve CLR type '{message.MessageType}' for outbox message {message.Id}.");
+
+        string exchange;
+        string routingKey;
+
+        if (message.MessageKind == "Event")
+        {
+            exchange = MessageNamingConvention.GetExchangeName(type);
+            routingKey = string.Empty;
+        }
+        else
+        {
+            exchange = MessageNamingConvention.GetQueueName(type);
+            routingKey = MessageNamingConvention.GetQueueName(type);
+        }
+
+        var body = Encoding.UTF8.GetBytes(message.Payload);
+        var properties = new BasicProperties
+        {
+            MessageId = message.Id.ToString(),
+            ContentType = "application/json",
+            CorrelationId = message.CorrelationId.ToString(),
+            DeliveryMode = DeliveryModes.Persistent,
+            Headers = new Dictionary<string, object?>
+            {
+                ["MessageType"] = message.MessageType,
+                ["MessageKind"] = message.MessageKind,
+                ["CorrelationId"] = message.CorrelationId.ToString(),
+            },
+        };
+        if (message.CausationId.HasValue)
+            properties.Headers["CausationId"] = message.CausationId.Value.ToString();
+
+        await _channelLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_publishChannel is null || !_publishChannel.IsOpen)
+                _publishChannel = await _connection
+                    .CreateChannelAsync(cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+
+            await _publishChannel.BasicPublishAsync(
+                exchange: exchange,
+                routingKey: routingKey,
+                mandatory: false,
+                basicProperties: properties,
+                body: body,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _channelLock.Release();
+        }
+
+        _logger.LogDebug(
+            "Forwarded outbox message {MessageId} ({MessageKind}: {MessageType}) to exchange '{Exchange}'.",
+            message.Id, message.MessageKind, message.MessageType, exchange);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        _channelLock.Dispose();
+        if (_publishChannel is not null)
+            await _publishChannel.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/OpinionatedEventing.RabbitMQ/Routing/MessageNamingConvention.cs
+++ b/src/OpinionatedEventing.RabbitMQ/Routing/MessageNamingConvention.cs
@@ -1,0 +1,55 @@
+#nullable enable
+
+using System.Text;
+using OpinionatedEventing.Attributes;
+
+namespace OpinionatedEventing.RabbitMQ.Routing;
+
+/// <summary>
+/// Derives RabbitMQ exchange and queue names from CLR message types.
+/// </summary>
+internal static class MessageNamingConvention
+{
+    /// <summary>
+    /// Returns the exchange name for the given event type.
+    /// Uses <see cref="MessageTopicAttribute"/> if present; otherwise converts the type name
+    /// from PascalCase to kebab-case (e.g. <c>OrderPlaced</c> → <c>order-placed</c>).
+    /// </summary>
+    internal static string GetExchangeName(Type eventType)
+    {
+        var attr = (MessageTopicAttribute?)Attribute.GetCustomAttribute(
+            eventType, typeof(MessageTopicAttribute));
+        return attr?.TopicName ?? ToKebabCase(eventType.Name);
+    }
+
+    /// <summary>
+    /// Returns the queue name for the given command type.
+    /// Uses <see cref="MessageQueueAttribute"/> if present; otherwise converts the type name
+    /// from PascalCase to kebab-case (e.g. <c>ProcessPayment</c> → <c>process-payment</c>).
+    /// </summary>
+    internal static string GetQueueName(Type commandType)
+    {
+        var attr = (MessageQueueAttribute?)Attribute.GetCustomAttribute(
+            commandType, typeof(MessageQueueAttribute));
+        return attr?.QueueName ?? ToKebabCase(commandType.Name);
+    }
+
+    /// <summary>
+    /// Returns the event consumer queue name for the given event type and service name.
+    /// Format: <c>{serviceName}.{event-name}</c>.
+    /// </summary>
+    internal static string GetEventQueueName(Type eventType, string serviceName)
+        => $"{serviceName}.{GetExchangeName(eventType)}";
+
+    private static string ToKebabCase(string name)
+    {
+        var sb = new StringBuilder(name.Length + 4);
+        for (var i = 0; i < name.Length; i++)
+        {
+            if (char.IsUpper(name[i]) && i > 0)
+                sb.Append('-');
+            sb.Append(char.ToLower(name[i]));
+        }
+        return sb.ToString();
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/MessageNamingConventionTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/MessageNamingConventionTests.cs
@@ -1,0 +1,63 @@
+#nullable enable
+
+using OpinionatedEventing.Attributes;
+using OpinionatedEventing.RabbitMQ.Routing;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests;
+
+public sealed class MessageNamingConventionTests
+{
+    [Theory]
+    [InlineData(typeof(OrderPlaced), "order-placed")]
+    [InlineData(typeof(PaymentReceived), "payment-received")]
+    [InlineData(typeof(SimpleEvent), "simple-event")]
+    [InlineData(typeof(ABCEvent), "a-b-c-event")]
+    public void GetExchangeName_derives_kebab_case_from_type_name(Type type, string expected)
+    {
+        Assert.Equal(expected, MessageNamingConvention.GetExchangeName(type));
+    }
+
+    [Fact]
+    public void GetExchangeName_uses_attribute_when_present()
+    {
+        Assert.Equal("my-custom-topic", MessageNamingConvention.GetExchangeName(typeof(CustomTopicEvent)));
+    }
+
+    [Theory]
+    [InlineData(typeof(ProcessPayment), "process-payment")]
+    [InlineData(typeof(CancelOrder), "cancel-order")]
+    public void GetQueueName_derives_kebab_case_from_type_name(Type type, string expected)
+    {
+        Assert.Equal(expected, MessageNamingConvention.GetQueueName(type));
+    }
+
+    [Fact]
+    public void GetQueueName_uses_attribute_when_present()
+    {
+        Assert.Equal("my-custom-queue", MessageNamingConvention.GetQueueName(typeof(CustomQueueCommand)));
+    }
+
+    [Fact]
+    public void GetEventQueueName_prefixes_with_service_name()
+    {
+        Assert.Equal("my-service.order-placed",
+            MessageNamingConvention.GetEventQueueName(typeof(OrderPlaced), "my-service"));
+    }
+
+    // --- test types ---
+
+    private sealed record OrderPlaced : IEvent;
+    private sealed record PaymentReceived : IEvent;
+    private sealed record SimpleEvent : IEvent;
+    private sealed record ABCEvent : IEvent;
+
+    [MessageTopic("my-custom-topic")]
+    private sealed record CustomTopicEvent : IEvent;
+
+    private sealed record ProcessPayment : ICommand;
+    private sealed record CancelOrder : ICommand;
+
+    [MessageQueue("my-custom-queue")]
+    private sealed record CustomQueueCommand : ICommand;
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/OpinionatedEventing.RabbitMQ.Tests.csproj
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/OpinionatedEventing.RabbitMQ.Tests.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Testcontainers.RabbitMq" />
   </ItemGroup>
 

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
@@ -1,0 +1,210 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Testing;
+using Testcontainers.RabbitMq;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests;
+
+/// <summary>
+/// Integration tests for the RabbitMQ transport.
+/// Require Docker with the RabbitMQ image available.
+/// Run with: dotnet test --project tests/OpinionatedEventing.RabbitMQ.Tests/...
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class RabbitMQIntegrationTests : IAsyncLifetime
+{
+    private RabbitMqContainer? _container;
+
+    public async ValueTask InitializeAsync()
+    {
+        _container = new RabbitMqBuilder().Build();
+        await _container.StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_container is not null)
+            await _container.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Published_event_is_consumed_by_handler()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var received = new List<OrderPlaced>();
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ =>
+                new CapturingEventHandler<OrderPlaced>(received));
+        });
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new OrderPlaced("order-1"), "Event"), ct);
+
+        await WaitForConditionAsync(() => received.Count == 1, ct);
+
+        Assert.Single(received);
+        Assert.Equal("order-1", received[0].OrderId);
+
+        await host.StopAsync(ct);
+    }
+
+    [Fact]
+    public async Task Published_event_is_consumed_by_multiple_handlers()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var receivedA = new List<OrderPlaced>();
+        var receivedB = new List<OrderPlaced>();
+
+        using var hostA = BuildHost(
+            services => services.AddScoped<IEventHandler<OrderPlaced>>(
+                _ => new CapturingEventHandler<OrderPlaced>(receivedA)),
+            serviceName: "service-a");
+
+        using var hostB = BuildHost(
+            services => services.AddScoped<IEventHandler<OrderPlaced>>(
+                _ => new CapturingEventHandler<OrderPlaced>(receivedB)),
+            serviceName: "service-b");
+
+        await hostA.StartAsync(ct);
+        await hostB.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = hostA.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new OrderPlaced("order-fanout"), "Event"), ct);
+
+        await WaitForConditionAsync(() => receivedA.Count == 1 && receivedB.Count == 1, ct);
+
+        Assert.Single(receivedA);
+        Assert.Single(receivedB);
+
+        await hostA.StopAsync(ct);
+        await hostB.StopAsync(ct);
+    }
+
+    [Fact]
+    public async Task Sent_command_is_consumed_by_single_handler()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var received = new List<ProcessPayment>();
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<ICommandHandler<ProcessPayment>>(_ =>
+                new CapturingCommandHandler<ProcessPayment>(received));
+        });
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new ProcessPayment("payment-1", 99m), "Command"), ct);
+
+        await WaitForConditionAsync(() => received.Count == 1, ct);
+
+        Assert.Single(received);
+        Assert.Equal("payment-1", received[0].PaymentId);
+
+        await host.StopAsync(ct);
+    }
+
+    [Fact]
+    public async Task Dead_lettered_message_is_recorded_in_outbox()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outboxStore = new InMemoryOutboxStore();
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ => new ThrowingHandler<OrderPlaced>());
+            services.AddSingleton<IOutboxStore>(outboxStore);
+        });
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new OrderPlaced("dead-order"), "Event"), ct);
+
+        await WaitForConditionAsync(() => outboxStore.Messages.Any(m => m.FailedAt.HasValue), ct);
+
+        var deadLetter = outboxStore.Messages.Single(m => m.FailedAt.HasValue);
+        Assert.NotNull(deadLetter.Error);
+
+        await host.StopAsync(ct);
+    }
+
+    // --- helpers ---
+
+    private IHost BuildHost(
+        Action<IServiceCollection>? configureExtra = null,
+        string serviceName = "test-service")
+        => Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddOpinionatedEventing();
+                services.AddRabbitMQTransport(o =>
+                {
+                    o.ConnectionString = _container!.GetConnectionString();
+                    o.ServiceName = serviceName;
+                    o.AutoDeclareTopology = true;
+                });
+                configureExtra?.Invoke(services);
+            })
+            .Build();
+
+    private static OutboxMessage BuildOutboxMessage<T>(T payload, string kind) where T : notnull
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            MessageType = typeof(T).AssemblyQualifiedName!,
+            MessageKind = kind,
+            Payload = System.Text.Json.JsonSerializer.Serialize(payload),
+            CorrelationId = Guid.NewGuid(),
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+    private static async Task WaitForConditionAsync(
+        Func<bool> condition, CancellationToken ct, int timeoutMs = 10_000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition() && DateTime.UtcNow < deadline)
+            await Task.Delay(100, ct);
+        Assert.True(condition(), "Condition was not met within the timeout.");
+    }
+
+    // --- test message types ---
+
+    private sealed record OrderPlaced(string OrderId) : IEvent;
+    private sealed record ProcessPayment(string PaymentId, decimal Amount) : ICommand;
+
+    // --- handler implementations ---
+
+    private sealed class CapturingEventHandler<T> : IEventHandler<T> where T : class, IEvent
+    {
+        private readonly List<T> _captured;
+        public CapturingEventHandler(List<T> captured) => _captured = captured;
+        public Task HandleAsync(T @event, CancellationToken ct) { _captured.Add(@event); return Task.CompletedTask; }
+    }
+
+    private sealed class CapturingCommandHandler<T> : ICommandHandler<T> where T : class, ICommand
+    {
+        private readonly List<T> _captured;
+        public CapturingCommandHandler(List<T> captured) => _captured = captured;
+        public Task HandleAsync(T command, CancellationToken ct) { _captured.Add(command); return Task.CompletedTask; }
+    }
+
+    private sealed class ThrowingHandler<T> : IEventHandler<T> where T : class, IEvent
+    {
+        public Task HandleAsync(T @event, CancellationToken ct)
+            => throw new InvalidOperationException("Simulated handler failure.");
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RegistrationTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RegistrationTests.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.RabbitMQ;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests;
+
+public sealed class RegistrationTests
+{
+    [Fact]
+    public void AddRabbitMQTransport_registers_ITransport()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+        services.AddRabbitMQTransport(o =>
+        {
+            o.ConnectionString = "amqp://guest:guest@localhost:5672/";
+            o.ServiceName = "test-service";
+        });
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ITransport));
+        Assert.NotNull(descriptor);
+    }
+
+    [Fact]
+    public void AddRabbitMQTransport_configures_options()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+        services.AddRabbitMQTransport(o =>
+        {
+            o.ConnectionString = "amqp://guest:guest@localhost:5672/";
+            o.ServiceName = "order-service";
+            o.AutoDeclareTopology = false;
+            o.PrefetchCount = 5;
+        });
+
+        var sp = services.BuildServiceProvider();
+        var opts = sp.GetRequiredService<IOptions<RabbitMQOptions>>().Value;
+
+        Assert.Equal("order-service", opts.ServiceName);
+        Assert.False(opts.AutoDeclareTopology);
+        Assert.Equal(5, opts.PrefetchCount);
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `RabbitMQTransport : ITransport` — publishes events to per-event-type fanout exchanges, commands to per-command-type direct exchanges; sets `CorrelationId`/`CausationId` as AMQP headers
- Implements `RabbitMQTopologyInitializer` — idempotently declares exchanges, queues, and bindings at startup when `AutoDeclareTopology = true`
- Implements `RabbitMQConsumerWorker` — per-queue channels with configurable prefetch; acks on handler success; writes dead-letter record to `IOutboxStore` and nacks (requeue=false) on unhandled exception; graceful shutdown via channel close
- `AddRabbitMQTransport(options => ...)` DI extension with Aspire service discovery fallback (`ConnectionStrings:rabbitmq`)
- Adds `Microsoft.Extensions.Configuration.Abstractions` to central package management

## Test plan

- [ ] `RegistrationTests` — `AddRabbitMQTransport` registers `ITransport` and configures `RabbitMQOptions`
- [ ] `MessageNamingConventionTests` — kebab-case derivation and attribute overrides for exchange/queue names
- [ ] `RabbitMQIntegrationTests` (requires Docker):
  - Published event consumed by single handler
  - Published event consumed by multiple handlers (fan-out via separate service names)
  - Command consumed by exactly one handler
  - Nack path — unhandled exception writes dead-letter record to outbox

All 45 tests (15 per target framework: net8/net9/net10) pass locally.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)