### PR TITLE
Implement OpinionatedEventing.Aspire — local development extensions (#10)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize all text files to LF in the repo and on checkout.
+* text=auto eol=lf
+
+# Explicitly mark binary files.
+*.png binary
+*.jpg binary
+*.ico binary
+*.dll binary
+*.exe binary

--- a/src/OpinionatedEventing.Aspire/AppHost/AzureServiceBusEmulatorExtensions.cs
+++ b/src/OpinionatedEventing.Aspire/AppHost/AzureServiceBusEmulatorExtensions.cs
@@ -1,0 +1,32 @@
+#nullable enable
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
+
+// Placed in this namespace so the extension is available without an extra using directive.
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Extension methods on <see cref="IDistributedApplicationBuilder"/> for adding an Azure Service Bus
+/// emulator resource to an Aspire AppHost.
+/// </summary>
+public static class AzureServiceBusEmulatorExtensions
+{
+    /// <summary>
+    /// Adds an Azure Service Bus emulator resource.
+    /// Referenced projects receive the emulator connection string, which
+    /// <c>OpinionatedEventing.AzureServiceBus</c> uses automatically — no managed identity or TLS required.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The resource name; also used as the connection string key.</param>
+    /// <returns>A resource builder for the Azure Service Bus resource configured to run as an emulator.</returns>
+    public static IResourceBuilder<AzureServiceBusResource> AddAzureServiceBusEmulator(
+        this IDistributedApplicationBuilder builder,
+        string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return builder.AddAzureServiceBus(name).RunAsEmulator();
+    }
+}

--- a/src/OpinionatedEventing.Aspire/AppHost/RabbitMqMessagingExtensions.cs
+++ b/src/OpinionatedEventing.Aspire/AppHost/RabbitMqMessagingExtensions.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using Aspire.Hosting.ApplicationModel;
+
+// Placed in this namespace so the extension is available without an extra using directive.
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Extension methods on <see cref="IDistributedApplicationBuilder"/> for adding a RabbitMQ
+/// messaging resource to an Aspire AppHost.
+/// </summary>
+public static class RabbitMqMessagingExtensions
+{
+    /// <summary>
+    /// Adds a RabbitMQ server resource with the management plugin enabled.
+    /// Referenced projects receive a <c>ConnectionStrings__<paramref name="name"/></c> environment
+    /// variable that <c>OpinionatedEventing.RabbitMQ</c> reads automatically via Aspire service discovery.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The resource name; also used as the connection string key.</param>
+    /// <returns>A resource builder for the RabbitMQ server resource.</returns>
+    public static IResourceBuilder<RabbitMQServerResource> AddRabbitMqMessaging(
+        this IDistributedApplicationBuilder builder,
+        string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return builder.AddRabbitMQ(name).WithManagementPlugin();
+    }
+}

--- a/src/OpinionatedEventing.Aspire/HealthChecks/BrokerConnectivityHealthCheck.cs
+++ b/src/OpinionatedEventing.Aspire/HealthChecks/BrokerConnectivityHealthCheck.cs
@@ -1,0 +1,54 @@
+#nullable enable
+
+using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using RabbitMQ.Client;
+
+namespace OpinionatedEventing.Aspire.HealthChecks;
+
+/// <summary>
+/// Liveness health check that verifies broker connectivity.
+/// Supports both RabbitMQ (<see cref="IConnection"/>) and Azure Service Bus
+/// (<see cref="ServiceBusAdministrationClient"/>). If neither is registered, reports healthy.
+/// </summary>
+internal sealed class BrokerConnectivityHealthCheck : IHealthCheck
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>Initialises a new <see cref="BrokerConnectivityHealthCheck"/>.</summary>
+    public BrokerConnectivityHealthCheck(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var rabbitConnection = _serviceProvider.GetService<IConnection>();
+        if (rabbitConnection is not null)
+        {
+            return rabbitConnection.IsOpen
+                ? HealthCheckResult.Healthy("RabbitMQ connection is open.")
+                : HealthCheckResult.Unhealthy("RabbitMQ connection is closed.");
+        }
+
+        var asbAdminClient = _serviceProvider.GetService<ServiceBusAdministrationClient>();
+        if (asbAdminClient is not null)
+        {
+            try
+            {
+                await asbAdminClient.GetNamespacePropertiesAsync(cancellationToken).ConfigureAwait(false);
+                return HealthCheckResult.Healthy("Azure Service Bus is reachable.");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy("Azure Service Bus connectivity check failed.", ex);
+            }
+        }
+
+        return HealthCheckResult.Healthy("No broker transport registered.");
+    }
+}

--- a/src/OpinionatedEventing.Aspire/HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/OpinionatedEventing.Aspire/HealthChecks/HealthChecksBuilderExtensions.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using OpinionatedEventing.Aspire.HealthChecks;
+
+// Placed in this namespace so the extension is available without an extra using directive.
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods on <see cref="IHealthChecksBuilder"/> for registering OpinionatedEventing health checks.
+/// </summary>
+public static class OpinionatedEventingHealthChecksBuilderExtensions
+{
+    /// <summary>
+    /// Registers the following health checks:
+    /// <list type="bullet">
+    ///   <item><description>Broker connectivity (liveness) — checks RabbitMQ or Azure Service Bus.</description></item>
+    ///   <item><description>Outbox backlog — <see cref="HealthStatus.Degraded"/> if pending message count exceeds the configured threshold.</description></item>
+    ///   <item><description>Saga timeout backlog — <see cref="HealthStatus.Degraded"/> if expired-but-unprocessed saga count exceeds the configured threshold.</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="builder">The health checks builder to extend.</param>
+    /// <param name="configure">Optional delegate to configure <see cref="OpinionatedEventingHealthCheckOptions"/>.</param>
+    /// <returns>The same <paramref name="builder"/> for chaining.</returns>
+    public static IHealthChecksBuilder AddOpinionatedEventingHealthChecks(
+        this IHealthChecksBuilder builder,
+        Action<OpinionatedEventingHealthCheckOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (configure is not null)
+            builder.Services.Configure(configure);
+        else
+            builder.Services.AddOptions<OpinionatedEventingHealthCheckOptions>();
+
+        builder.Services.TryAddSingleton(TimeProvider.System);
+
+        builder.AddCheck<BrokerConnectivityHealthCheck>(
+            "opinionatedeventing-broker",
+            failureStatus: HealthStatus.Unhealthy,
+            tags: ["live", "broker"]);
+
+        builder.AddCheck<OutboxBacklogHealthCheck>(
+            "opinionatedeventing-outbox-backlog",
+            failureStatus: HealthStatus.Degraded,
+            tags: ["ready", "outbox"]);
+
+        builder.AddCheck<SagaTimeoutBacklogHealthCheck>(
+            "opinionatedeventing-saga-timeout-backlog",
+            failureStatus: HealthStatus.Degraded,
+            tags: ["ready", "saga"]);
+
+        return builder;
+    }
+}

--- a/src/OpinionatedEventing.Aspire/HealthChecks/OpinionatedEventingHealthCheckOptions.cs
+++ b/src/OpinionatedEventing.Aspire/HealthChecks/OpinionatedEventingHealthCheckOptions.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+namespace OpinionatedEventing.Aspire.HealthChecks;
+
+/// <summary>
+/// Configures thresholds for <c>AddOpinionatedEventingHealthChecks()</c>.
+/// </summary>
+public sealed class OpinionatedEventingHealthCheckOptions
+{
+    /// <summary>
+    /// Gets or sets the outbox pending-message count above which the outbox backlog check reports
+    /// <see cref="Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded"/>.
+    /// Defaults to <c>100</c>.
+    /// </summary>
+    public int OutboxBacklogThreshold { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the expired-but-unprocessed saga count above which the saga timeout backlog check
+    /// reports <see cref="Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded"/>.
+    /// Defaults to <c>10</c>.
+    /// </summary>
+    public int SagaTimeoutBacklogThreshold { get; set; } = 10;
+}

--- a/src/OpinionatedEventing.Aspire/HealthChecks/OutboxBacklogHealthCheck.cs
+++ b/src/OpinionatedEventing.Aspire/HealthChecks/OutboxBacklogHealthCheck.cs
@@ -1,0 +1,46 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.Aspire.HealthChecks;
+
+/// <summary>
+/// Health check that reports <see cref="HealthStatus.Degraded"/> when the number of pending
+/// outbox messages exceeds <see cref="OpinionatedEventingHealthCheckOptions.OutboxBacklogThreshold"/>.
+/// Requires <see cref="IOutboxMonitor"/> to be registered; skips the check if it is not.
+/// </summary>
+internal sealed class OutboxBacklogHealthCheck : IHealthCheck
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IOptions<OpinionatedEventingHealthCheckOptions> _options;
+
+    /// <summary>Initialises a new <see cref="OutboxBacklogHealthCheck"/>.</summary>
+    public OutboxBacklogHealthCheck(
+        IServiceProvider serviceProvider,
+        IOptions<OpinionatedEventingHealthCheckOptions> options)
+    {
+        _serviceProvider = serviceProvider;
+        _options = options;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var monitor = _serviceProvider.GetService<IOutboxMonitor>();
+        if (monitor is null)
+            return HealthCheckResult.Healthy("IOutboxMonitor not registered; outbox backlog check skipped.");
+
+        var pending = await monitor.GetPendingCountAsync(cancellationToken).ConfigureAwait(false);
+        var threshold = _options.Value.OutboxBacklogThreshold;
+
+        return pending > threshold
+            ? HealthCheckResult.Degraded(
+                $"Outbox backlog is {pending} messages, exceeding the threshold of {threshold}.")
+            : HealthCheckResult.Healthy($"Outbox backlog is {pending} messages.");
+    }
+}

--- a/src/OpinionatedEventing.Aspire/HealthChecks/SagaTimeoutBacklogHealthCheck.cs
+++ b/src/OpinionatedEventing.Aspire/HealthChecks/SagaTimeoutBacklogHealthCheck.cs
@@ -1,0 +1,51 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Sagas;
+
+namespace OpinionatedEventing.Aspire.HealthChecks;
+
+/// <summary>
+/// Health check that reports <see cref="HealthStatus.Degraded"/> when the number of expired-but-unprocessed
+/// sagas exceeds <see cref="OpinionatedEventingHealthCheckOptions.SagaTimeoutBacklogThreshold"/>.
+/// Requires <see cref="ISagaStateStore"/> to be registered; skips the check if it is not.
+/// </summary>
+internal sealed class SagaTimeoutBacklogHealthCheck : IHealthCheck
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IOptions<OpinionatedEventingHealthCheckOptions> _options;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initialises a new <see cref="SagaTimeoutBacklogHealthCheck"/>.</summary>
+    public SagaTimeoutBacklogHealthCheck(
+        IServiceProvider serviceProvider,
+        IOptions<OpinionatedEventingHealthCheckOptions> options,
+        TimeProvider timeProvider)
+    {
+        _serviceProvider = serviceProvider;
+        _options = options;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var store = _serviceProvider.GetService<ISagaStateStore>();
+        if (store is null)
+            return HealthCheckResult.Healthy("ISagaStateStore not registered; saga timeout backlog check skipped.");
+
+        var now = _timeProvider.GetUtcNow();
+        var expired = await store.GetExpiredAsync(now, cancellationToken).ConfigureAwait(false);
+        var count = expired.Count;
+        var threshold = _options.Value.SagaTimeoutBacklogThreshold;
+
+        return count > threshold
+            ? HealthCheckResult.Degraded(
+                $"Saga timeout backlog is {count} expired sagas, exceeding the threshold of {threshold}.")
+            : HealthCheckResult.Healthy($"Saga timeout backlog is {count} expired sagas.");
+    }
+}

--- a/src/OpinionatedEventing.Aspire/OpinionatedEventing.Aspire.csproj
+++ b/src/OpinionatedEventing.Aspire/OpinionatedEventing.Aspire.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Aspire.Hosting" />
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,6 +16,7 @@
     <ProjectReference Include="..\OpinionatedEventing.Outbox\OpinionatedEventing.Outbox.csproj" />
     <ProjectReference Include="..\OpinionatedEventing.AzureServiceBus\OpinionatedEventing.AzureServiceBus.csproj" />
     <ProjectReference Include="..\OpinionatedEventing.RabbitMQ\OpinionatedEventing.RabbitMQ.csproj" />
+    <ProjectReference Include="..\OpinionatedEventing.Sagas\OpinionatedEventing.Sagas.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OpinionatedEventing.Outbox/IOutboxMonitor.cs
+++ b/src/OpinionatedEventing.Outbox/IOutboxMonitor.cs
@@ -4,10 +4,14 @@ namespace OpinionatedEventing.Outbox;
 
 /// <summary>
 /// Optional service that exposes outbox health metrics.
-/// Register an implementation to surface dead-letter counts in health checks and metrics dashboards.
+/// Register an implementation to surface outbox counts in health checks and metrics dashboards.
 /// </summary>
 public interface IOutboxMonitor
 {
+    /// <summary>Returns the current count of pending (unprocessed, non-dead-lettered) outbox messages.</summary>
+    /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
+    Task<int> GetPendingCountAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Returns the current count of dead-lettered (permanently failed) outbox messages.</summary>
     /// <param name="cancellationToken">Propagates notification that the operation should be cancelled.</param>
     Task<int> GetDeadLetterCountAsync(CancellationToken cancellationToken = default);

--- a/src/OpinionatedEventing.Testing/FakeOutboxMonitor.cs
+++ b/src/OpinionatedEventing.Testing/FakeOutboxMonitor.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.Testing;
+
+/// <summary>
+/// Configurable in-memory implementation of <see cref="IOutboxMonitor"/> for use in unit tests.
+/// Not for production use.
+/// </summary>
+public sealed class FakeOutboxMonitor : IOutboxMonitor
+{
+    /// <summary>Gets or sets the value returned by <see cref="GetPendingCountAsync"/>.</summary>
+    public int PendingCount { get; set; }
+
+    /// <summary>Gets or sets the value returned by <see cref="GetDeadLetterCountAsync"/>.</summary>
+    public int DeadLetterCount { get; set; }
+
+    /// <inheritdoc/>
+    public Task<int> GetPendingCountAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(PendingCount);
+
+    /// <inheritdoc/>
+    public Task<int> GetDeadLetterCountAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(DeadLetterCount);
+}

--- a/tests/OpinionatedEventing.Aspire.Specs/Features/Aspire.feature
+++ b/tests/OpinionatedEventing.Aspire.Specs/Features/Aspire.feature
@@ -1,8 +1,35 @@
-Feature: Aspire
-  Placeholder feature file for OpinionatedEventing.Aspire BDD specs.
-  Replace with real scenarios when implementing issue #10.
+Feature: Aspire — OpinionatedEventing.Aspire health checks
 
-  Scenario: Placeholder
-    Given this is a placeholder scenario
-    When it is executed
-    Then it passes
+  Scenario: Outbox backlog health check is healthy when pending messages are below threshold
+    Given the outbox has 50 pending messages
+    And the outbox backlog threshold is 100
+    When the outbox backlog health check runs
+    Then the result is Healthy
+
+  Scenario: Outbox backlog health check degrades when pending messages exceed threshold
+    Given the outbox has 150 pending messages
+    And the outbox backlog threshold is 100
+    When the outbox backlog health check runs
+    Then the result is Degraded
+
+  Scenario: Outbox backlog health check is healthy when no IOutboxMonitor is registered
+    Given no IOutboxMonitor is registered
+    When the outbox backlog health check runs
+    Then the result is Healthy
+
+  Scenario: Saga timeout backlog health check is healthy when expired sagas are below threshold
+    Given there are 3 expired sagas
+    And the saga timeout backlog threshold is 10
+    When the saga timeout backlog health check runs
+    Then the result is Healthy
+
+  Scenario: Saga timeout backlog health check degrades when expired sagas exceed threshold
+    Given there are 15 expired sagas
+    And the saga timeout backlog threshold is 10
+    When the saga timeout backlog health check runs
+    Then the result is Degraded
+
+  Scenario: Broker connectivity health check is healthy when no broker transport is registered
+    Given no broker transport is registered
+    When the broker connectivity health check runs
+    Then the result is Healthy

--- a/tests/OpinionatedEventing.Aspire.Specs/StepDefinitions/AspireSteps.cs
+++ b/tests/OpinionatedEventing.Aspire.Specs/StepDefinitions/AspireSteps.cs
@@ -1,16 +1,110 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Sagas;
+using OpinionatedEventing.Testing;
 using Reqnroll;
+using Xunit;
 
 namespace OpinionatedEventing.Aspire.Specs.StepDefinitions;
 
 [Binding]
 public sealed class AspireSteps
 {
-    [Given("this is a placeholder scenario")]
-    public void GivenPlaceholder() { }
+    private readonly ServiceCollection _services = new();
+    private HealthReportEntry _result;
 
-    [When("it is executed")]
-    public void WhenExecuted() { }
+    // ── Given steps ──────────────────────────────────────────────────────────
 
-    [Then("it passes")]
-    public void ThenPasses() { }
+    [Given("the outbox has (\\d+) pending messages")]
+    public void GivenOutboxHasPendingMessages(int count)
+    {
+        _services.AddSingleton<IOutboxMonitor>(new FakeOutboxMonitor { PendingCount = count });
+    }
+
+    [Given("the outbox backlog threshold is (\\d+)")]
+    public void GivenOutboxBacklogThreshold(int threshold)
+    {
+        _services.AddHealthChecks().AddOpinionatedEventingHealthChecks(
+            o => o.OutboxBacklogThreshold = threshold);
+    }
+
+    [Given("no IOutboxMonitor is registered")]
+    public void GivenNoOutboxMonitor()
+    {
+        _services.AddHealthChecks().AddOpinionatedEventingHealthChecks();
+    }
+
+    [Given("there are (\\d+) expired sagas")]
+    public void GivenExpiredSagas(int count)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var store = new InMemorySagaStateStore();
+        for (var i = 0; i < count; i++)
+        {
+            store.SaveAsync(new SagaState
+            {
+                SagaType = "TestSaga",
+                CorrelationId = Guid.NewGuid().ToString(),
+                Status = SagaStatus.Active,
+                ExpiresAt = now.AddMinutes(-1),
+                State = "{}",
+            }).GetAwaiter().GetResult();
+        }
+        _services.AddSingleton<ISagaStateStore>(store);
+        _services.AddSingleton<TimeProvider>(new FakeTimeProvider(now));
+    }
+
+    [Given("the saga timeout backlog threshold is (\\d+)")]
+    public void GivenSagaTimeoutBacklogThreshold(int threshold)
+    {
+        _services.AddHealthChecks().AddOpinionatedEventingHealthChecks(
+            o => o.SagaTimeoutBacklogThreshold = threshold);
+    }
+
+    [Given("no broker transport is registered")]
+    public void GivenNoBrokerTransport()
+    {
+        _services.AddHealthChecks().AddOpinionatedEventingHealthChecks();
+    }
+
+    // ── When steps ───────────────────────────────────────────────────────────
+
+    [When("the outbox backlog health check runs")]
+    public async Task WhenOutboxBacklogHealthCheckRuns()
+    {
+        _services.AddLogging();
+        var sp = _services.BuildServiceProvider();
+        var svc = sp.GetRequiredService<HealthCheckService>();
+        var report = await svc.CheckHealthAsync(r => r.Name == "opinionatedeventing-outbox-backlog");
+        _result = report.Entries["opinionatedeventing-outbox-backlog"];
+    }
+
+    [When("the saga timeout backlog health check runs")]
+    public async Task WhenSagaTimeoutBacklogHealthCheckRuns()
+    {
+        _services.AddLogging();
+        var sp = _services.BuildServiceProvider();
+        var svc = sp.GetRequiredService<HealthCheckService>();
+        var report = await svc.CheckHealthAsync(r => r.Name == "opinionatedeventing-saga-timeout-backlog");
+        _result = report.Entries["opinionatedeventing-saga-timeout-backlog"];
+    }
+
+    [When("the broker connectivity health check runs")]
+    public async Task WhenBrokerConnectivityHealthCheckRuns()
+    {
+        _services.AddLogging();
+        var sp = _services.BuildServiceProvider();
+        var svc = sp.GetRequiredService<HealthCheckService>();
+        var report = await svc.CheckHealthAsync(r => r.Name == "opinionatedeventing-broker");
+        _result = report.Entries["opinionatedeventing-broker"];
+    }
+
+    // ── Then steps ───────────────────────────────────────────────────────────
+
+    [Then("the result is Healthy")]
+    public void ThenResultIsHealthy() => Assert.Equal(HealthStatus.Healthy, _result.Status);
+
+    [Then("the result is Degraded")]
+    public void ThenResultIsDegraded() => Assert.Equal(HealthStatus.Degraded, _result.Status);
 }

--- a/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/BrokerConnectivityHealthCheckTests.cs
+++ b/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/BrokerConnectivityHealthCheckTests.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace OpinionatedEventing.Aspire.Tests.HealthChecks;
+
+public sealed class BrokerConnectivityHealthCheckTests
+{
+    [Fact]
+    public async Task Returns_Healthy_when_no_broker_registered()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks();
+        var sp = services.BuildServiceProvider();
+
+        var healthService = sp.GetRequiredService<HealthCheckService>();
+        var report = await healthService.CheckHealthAsync(
+            r => r.Name == "opinionatedeventing-broker", ct);
+
+        var entry = report.Entries["opinionatedeventing-broker"];
+        Assert.Equal(HealthStatus.Healthy, entry.Status);
+    }
+}

--- a/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/OutboxBacklogHealthCheckTests.cs
+++ b/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/OutboxBacklogHealthCheckTests.cs
@@ -1,0 +1,64 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Testing;
+using Xunit;
+
+namespace OpinionatedEventing.Aspire.Tests.HealthChecks;
+
+public sealed class OutboxBacklogHealthCheckTests
+{
+    private static async Task<HealthReportEntry> RunOutboxCheckAsync(IServiceProvider sp, CancellationToken ct)
+    {
+        var healthService = sp.GetRequiredService<HealthCheckService>();
+        var report = await healthService.CheckHealthAsync(
+            r => r.Name == "opinionatedeventing-outbox-backlog", ct);
+        return report.Entries["opinionatedeventing-outbox-backlog"];
+    }
+
+    [Fact]
+    public async Task Returns_Healthy_when_pending_below_threshold()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IOutboxMonitor>(new FakeOutboxMonitor { PendingCount = 50 });
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks(o => o.OutboxBacklogThreshold = 100);
+        var sp = services.BuildServiceProvider();
+
+        var entry = await RunOutboxCheckAsync(sp, ct);
+
+        Assert.Equal(HealthStatus.Healthy, entry.Status);
+    }
+
+    [Fact]
+    public async Task Returns_Degraded_when_pending_exceeds_threshold()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IOutboxMonitor>(new FakeOutboxMonitor { PendingCount = 101 });
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks(o => o.OutboxBacklogThreshold = 100);
+        var sp = services.BuildServiceProvider();
+
+        var entry = await RunOutboxCheckAsync(sp, ct);
+
+        Assert.Equal(HealthStatus.Degraded, entry.Status);
+    }
+
+    [Fact]
+    public async Task Returns_Healthy_when_IOutboxMonitor_not_registered()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks();
+        var sp = services.BuildServiceProvider();
+
+        var entry = await RunOutboxCheckAsync(sp, ct);
+
+        Assert.Equal(HealthStatus.Healthy, entry.Status);
+    }
+}

--- a/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/RegistrationTests.cs
+++ b/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/RegistrationTests.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Aspire.HealthChecks;
+using Xunit;
+
+namespace OpinionatedEventing.Aspire.Tests.HealthChecks;
+
+public sealed class RegistrationTests
+{
+    [Fact]
+    public void AddOpinionatedEventingHealthChecks_registers_three_checks()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks();
+
+        var sp = services.BuildServiceProvider();
+        var registrations = sp.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+
+        Assert.Contains(registrations, r => r.Name == "opinionatedeventing-broker");
+        Assert.Contains(registrations, r => r.Name == "opinionatedeventing-outbox-backlog");
+        Assert.Contains(registrations, r => r.Name == "opinionatedeventing-saga-timeout-backlog");
+    }
+
+    [Fact]
+    public void AddOpinionatedEventingHealthChecks_uses_default_options()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks();
+
+        var sp = services.BuildServiceProvider();
+        var opts = sp.GetRequiredService<IOptions<OpinionatedEventingHealthCheckOptions>>().Value;
+
+        Assert.Equal(100, opts.OutboxBacklogThreshold);
+        Assert.Equal(10, opts.SagaTimeoutBacklogThreshold);
+    }
+
+    [Fact]
+    public void AddOpinionatedEventingHealthChecks_applies_custom_options()
+    {
+        var services = new ServiceCollection();
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks(o =>
+        {
+            o.OutboxBacklogThreshold = 50;
+            o.SagaTimeoutBacklogThreshold = 5;
+        });
+
+        var sp = services.BuildServiceProvider();
+        var opts = sp.GetRequiredService<IOptions<OpinionatedEventingHealthCheckOptions>>().Value;
+
+        Assert.Equal(50, opts.OutboxBacklogThreshold);
+        Assert.Equal(5, opts.SagaTimeoutBacklogThreshold);
+    }
+}

--- a/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/SagaTimeoutBacklogHealthCheckTests.cs
+++ b/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/SagaTimeoutBacklogHealthCheckTests.cs
@@ -1,0 +1,89 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using OpinionatedEventing.Sagas;
+using OpinionatedEventing.Testing;
+using Xunit;
+
+namespace OpinionatedEventing.Aspire.Tests.HealthChecks;
+
+public sealed class SagaTimeoutBacklogHealthCheckTests
+{
+    private static async Task<HealthReportEntry> RunSagaCheckAsync(IServiceProvider sp, CancellationToken ct)
+    {
+        var healthService = sp.GetRequiredService<HealthCheckService>();
+        var report = await healthService.CheckHealthAsync(
+            r => r.Name == "opinionatedeventing-saga-timeout-backlog", ct);
+        return report.Entries["opinionatedeventing-saga-timeout-backlog"];
+    }
+
+    private static InMemorySagaStateStore StoreWithExpiredSagas(int count, DateTimeOffset now)
+    {
+        var store = new InMemorySagaStateStore();
+        for (var i = 0; i < count; i++)
+        {
+            store.SaveAsync(new SagaState
+            {
+                SagaType = "TestSaga",
+                CorrelationId = Guid.NewGuid().ToString(),
+                Status = SagaStatus.Active,
+                ExpiresAt = now.AddMinutes(-1),
+                State = "{}",
+            }).GetAwaiter().GetResult();
+        }
+        return store;
+    }
+
+    [Fact]
+    public async Task Returns_Healthy_when_expired_sagas_below_threshold()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var now = DateTimeOffset.UtcNow;
+        var fakeTime = new FakeTimeProvider(now);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ISagaStateStore>(StoreWithExpiredSagas(5, now));
+        services.AddSingleton<TimeProvider>(fakeTime);
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks(o => o.SagaTimeoutBacklogThreshold = 10);
+        var sp = services.BuildServiceProvider();
+
+        var entry = await RunSagaCheckAsync(sp, ct);
+
+        Assert.Equal(HealthStatus.Healthy, entry.Status);
+    }
+
+    [Fact]
+    public async Task Returns_Degraded_when_expired_sagas_exceed_threshold()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var now = DateTimeOffset.UtcNow;
+        var fakeTime = new FakeTimeProvider(now);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ISagaStateStore>(StoreWithExpiredSagas(15, now));
+        services.AddSingleton<TimeProvider>(fakeTime);
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks(o => o.SagaTimeoutBacklogThreshold = 10);
+        var sp = services.BuildServiceProvider();
+
+        var entry = await RunSagaCheckAsync(sp, ct);
+
+        Assert.Equal(HealthStatus.Degraded, entry.Status);
+    }
+
+    [Fact]
+    public async Task Returns_Healthy_when_ISagaStateStore_not_registered()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHealthChecks().AddOpinionatedEventingHealthChecks();
+        var sp = services.BuildServiceProvider();
+
+        var entry = await RunSagaCheckAsync(sp, ct);
+
+        Assert.Equal(HealthStatus.Healthy, entry.Status);
+    }
+}


### PR DESCRIPTION
## Summary

- **AppHost extensions** — `AddRabbitMqMessaging(name)` wraps `AddRabbitMQ(name).WithManagementPlugin()` and `AddAzureServiceBusEmulator(name)` wraps `AddAzureServiceBus(name).RunAsEmulator()`, both in the `Aspire.Hosting` namespace for zero-import discoverability
- **Health checks** — `AddOpinionatedEventingHealthChecks()` on `IHealthChecksBuilder` registers three checks: broker connectivity (liveness), outbox backlog (`Degraded` above configurable threshold, default 100), and saga timeout backlog (`Degraded` above configurable threshold, default 10)
- **`IOutboxMonitor`** — added `GetPendingCountAsync` alongside the existing `GetDeadLetterCountAsync`; used by the outbox backlog health check (check is skipped if no `IOutboxMonitor` is registered)
- **`FakeOutboxMonitor`** — added to `OpinionatedEventing.Testing` for use in unit and integration tests
- **`.gitattributes`** — enforces LF line endings repo-wide to suppress `autocrlf` warnings on Windows

## Notes

- `BrokerConnectivityHealthCheck` resolves `IConnection` (RabbitMQ) or `ServiceBusAdministrationClient` (ASB) at check time via `IServiceProvider.GetService<T>()`. Returns `Healthy` if neither transport is registered.
- `OutboxBacklogHealthCheck` and `SagaTimeoutBacklogHealthCheck` both skip gracefully if their store/monitor isn't registered — safe to call `AddOpinionatedEventingHealthChecks()` in apps that don't use sagas or haven't wired up `IOutboxMonitor`.
- Adding `GetPendingCountAsync` to `IOutboxMonitor` is a non-additive interface change. No implementations exist in this repo yet; the EF Core implementation will add it in the EntityFramework package.

## Test plan

- [x] 30 xUnit unit tests across net8/9/10 — all pass
- [x] 6 Reqnroll BDD specs on net8 — all pass
- [x] `dotnet build src/OpinionatedEventing.Aspire` — clean, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)