### PR TITLE
Fix integration test Docker conflicts by lifting containers to class fixtures

### DIFF
--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
@@ -15,20 +15,15 @@ namespace OpinionatedEventing.AzureServiceBus.Tests;
 /// Run with: dotnet test --filter "Category=Integration"
 /// </summary>
 [Trait("Category", "Integration")]
-public sealed class AzureServiceBusIntegrationTests : IAsyncLifetime
+[Collection(AzureServiceBusCollection.Name)]
+public sealed class AzureServiceBusIntegrationTests
 {
-    private AzureServiceBusEmulatorContainer? _emulator;
+    private readonly AzureServiceBusFixture _fixture;
 
-    public async ValueTask InitializeAsync()
+    /// <summary>Initialises the test class with the shared Azure Service Bus emulator fixture.</summary>
+    public AzureServiceBusIntegrationTests(AzureServiceBusFixture fixture)
     {
-        _emulator = await AzureServiceBusEmulatorContainer.StartAsync(
-            TestContext.Current.CancellationToken);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_emulator is not null)
-            await _emulator.DisposeAsync();
+        _fixture = fixture;
     }
 
     [Fact]
@@ -118,7 +113,7 @@ public sealed class AzureServiceBusIntegrationTests : IAsyncLifetime
                 services.AddOpinionatedEventing();
                 services.AddAzureServiceBusTransport(o =>
                 {
-                    o.ConnectionString = _emulator!.ConnectionString;
+                    o.ConnectionString = _fixture.ConnectionString;
                     o.ServiceName = "test-service";
                     o.AutoCreateResources = true;
                     o.MaxDeliveryCount = maxDeliveryCount;

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusCollection.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusCollection.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+using Xunit;
+
+namespace OpinionatedEventing.AzureServiceBus.Tests.TestSupport;
+
+/// <summary>
+/// xUnit collection that serialises Azure Service Bus integration tests and shares a single emulator container.
+/// DisableParallelization prevents message cross-contamination between tests sharing the same namespace topology.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class AzureServiceBusCollection : ICollectionFixture<AzureServiceBusFixture>
+{
+    /// <summary>Collection name used on <see cref="CollectionAttribute"/>.</summary>
+    public const string Name = "AzureServiceBus integration";
+}

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusFixture.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusFixture.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using Xunit;
+
+namespace OpinionatedEventing.AzureServiceBus.Tests.TestSupport;
+
+/// <summary>Shared Azure Service Bus emulator fixture — one container for all integration tests.</summary>
+public sealed class AzureServiceBusFixture : IAsyncLifetime
+{
+    private AzureServiceBusEmulatorContainer? _emulator;
+
+    /// <summary>Gets the connection string for the running Azure Service Bus emulator.</summary>
+    // InitializeAsync guarantees _emulator is set before any test accesses this property
+    public string ConnectionString => _emulator!.ConnectionString;
+
+    /// <inheritdoc/>
+    public async ValueTask InitializeAsync()
+    {
+        _emulator = await AzureServiceBusEmulatorContainer.StartAsync(CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_emulator is not null)
+            await _emulator.DisposeAsync();
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
@@ -3,8 +3,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpinionatedEventing.Outbox;
+using OpinionatedEventing.RabbitMQ.Tests.TestSupport;
 using OpinionatedEventing.Testing;
-using Testcontainers.RabbitMq;
 using Xunit;
 
 namespace OpinionatedEventing.RabbitMQ.Tests;
@@ -15,20 +15,15 @@ namespace OpinionatedEventing.RabbitMQ.Tests;
 /// Run with: dotnet test --project tests/OpinionatedEventing.RabbitMQ.Tests/...
 /// </summary>
 [Trait("Category", "Integration")]
-public sealed class RabbitMQIntegrationTests : IAsyncLifetime
+[Collection(RabbitMqCollection.Name)]
+public sealed class RabbitMQIntegrationTests
 {
-    private RabbitMqContainer? _container;
+    private readonly RabbitMqFixture _fixture;
 
-    public async ValueTask InitializeAsync()
+    /// <summary>Initialises the test class with the shared RabbitMQ fixture.</summary>
+    public RabbitMQIntegrationTests(RabbitMqFixture fixture)
     {
-        _container = new RabbitMqBuilder().Build();
-        await _container.StartAsync(TestContext.Current.CancellationToken);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_container is not null)
-            await _container.DisposeAsync();
+        _fixture = fixture;
     }
 
     [Fact]
@@ -153,7 +148,7 @@ public sealed class RabbitMQIntegrationTests : IAsyncLifetime
                 services.AddOpinionatedEventing();
                 services.AddRabbitMQTransport(o =>
                 {
-                    o.ConnectionString = _container!.GetConnectionString();
+                    o.ConnectionString = _fixture.ConnectionString;
                     o.ServiceName = serviceName;
                     o.AutoDeclareTopology = true;
                 });

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/TestSupport/RabbitMqCollection.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/TestSupport/RabbitMqCollection.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests.TestSupport;
+
+/// <summary>
+/// xUnit collection that serialises RabbitMQ integration tests and shares a single container.
+/// DisableParallelization prevents message cross-contamination between tests sharing the same topology.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class RabbitMqCollection : ICollectionFixture<RabbitMqFixture>
+{
+    /// <summary>Collection name used on <see cref="CollectionAttribute"/>.</summary>
+    public const string Name = "RabbitMQ integration";
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/TestSupport/RabbitMqFixture.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/TestSupport/RabbitMqFixture.cs
@@ -1,0 +1,30 @@
+#nullable enable
+
+using Testcontainers.RabbitMq;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests.TestSupport;
+
+/// <summary>Shared RabbitMQ container fixture — one container for all integration tests.</summary>
+public sealed class RabbitMqFixture : IAsyncLifetime
+{
+    private RabbitMqContainer? _container;
+
+    /// <summary>Gets the connection string for the running RabbitMQ container.</summary>
+    // InitializeAsync guarantees _container is set before any test accesses this property
+    public string ConnectionString => _container!.GetConnectionString();
+
+    /// <inheritdoc/>
+    public async ValueTask InitializeAsync()
+    {
+        _container = new RabbitMqBuilder().Build();
+        await _container.StartAsync(CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_container is not null)
+            await _container.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## Summary

- Lifts Testcontainers container lifetime from per-test to class fixture (`AzureServiceBusFixture`, `AzureServiceBusCollection`, `RabbitMqFixture`, `RabbitMqCollection`) so a single container is shared across all tests in a class, eliminating Docker port/name conflicts when tests run in parallel
- Adds `TestSupport` infrastructure for both AzureServiceBus and RabbitMQ integration test projects

## Test plan

- [ ] `dotnet test -- --filter-trait "Category=Integration"` passes without Docker conflicts for both AzureServiceBus and RabbitMQ suites
- [ ] `dotnet test -- --filter-trait "Category!=Integration"` still passes (no regressions in unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)