### PR TITLE
Implement OpinionatedEventing.Testing — test helpers package (#14)

### DIFF
--- a/OpinionatedEventing.slnx
+++ b/OpinionatedEventing.slnx
@@ -26,5 +26,6 @@
     <Project Path="tests/OpinionatedEventing.RabbitMQ.Tests/OpinionatedEventing.RabbitMQ.Tests.csproj" />
     <Project Path="tests/OpinionatedEventing.Sagas.Specs/OpinionatedEventing.Sagas.Specs.csproj" />
     <Project Path="tests/OpinionatedEventing.Sagas.Tests/OpinionatedEventing.Sagas.Tests.csproj" />
+    <Project Path="tests/OpinionatedEventing.Testing.Tests/OpinionatedEventing.Testing.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/OpinionatedEventing.Testing/FakeMessagingContext.cs
+++ b/src/OpinionatedEventing.Testing/FakeMessagingContext.cs
@@ -1,0 +1,17 @@
+#nullable enable
+
+namespace OpinionatedEventing.Testing;
+
+/// <summary>
+/// Configurable implementation of <see cref="IMessagingContext"/> for use in unit tests.
+/// Allows tests to set a fixed <see cref="CorrelationId"/> and <see cref="CausationId"/>
+/// instead of relying on transport-populated values. Not for production use.
+/// </summary>
+public sealed class FakeMessagingContext : IMessagingContext
+{
+    /// <summary>Gets or sets the correlation identifier returned by this context.</summary>
+    public Guid CorrelationId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Gets or sets the causation identifier returned by this context.</summary>
+    public Guid? CausationId { get; set; }
+}

--- a/src/OpinionatedEventing.Testing/InMemoryOutboxStore.cs
+++ b/src/OpinionatedEventing.Testing/InMemoryOutboxStore.cs
@@ -16,6 +16,16 @@ public sealed class InMemoryOutboxStore : IOutboxStore
     /// <summary>Gets a snapshot of all messages currently in the store, regardless of status.</summary>
     public IReadOnlyList<OutboxMessage> Messages => _messages.Values.ToList();
 
+    /// <summary>Gets a snapshot of messages that have not yet been processed or dead-lettered.</summary>
+    public IReadOnlyList<OutboxMessage> PendingMessages => _messages.Values
+        .Where(m => m.ProcessedAt is null && m.FailedAt is null)
+        .ToList();
+
+    /// <summary>Gets a snapshot of messages that have been successfully processed.</summary>
+    public IReadOnlyList<OutboxMessage> ProcessedMessages => _messages.Values
+        .Where(m => m.ProcessedAt is not null)
+        .ToList();
+
     /// <inheritdoc/>
     public Task SaveAsync(OutboxMessage message, CancellationToken cancellationToken = default)
     {

--- a/src/OpinionatedEventing.Testing/OpinionatedEventing.Testing.csproj
+++ b/src/OpinionatedEventing.Testing/OpinionatedEventing.Testing.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\OpinionatedEventing.Core\OpinionatedEventing.Core.csproj" />
     <ProjectReference Include="..\OpinionatedEventing.Outbox\OpinionatedEventing.Outbox.csproj" />
     <ProjectReference Include="..\OpinionatedEventing.Sagas\OpinionatedEventing.Sagas.csproj" />

--- a/src/OpinionatedEventing.Testing/TestMessagingBuilder.cs
+++ b/src/OpinionatedEventing.Testing/TestMessagingBuilder.cs
@@ -1,0 +1,78 @@
+#nullable enable
+
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpinionatedEventing.DependencyInjection;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.Testing;
+
+/// <summary>
+/// Fluent builder that constructs a minimal <see cref="IServiceProvider"/> pre-wired with
+/// OpinionatedEventing fakes, ready for unit testing without any broker or database.
+/// Not for production use.
+/// </summary>
+/// <remarks>
+/// Registers <see cref="FakePublisher"/> as <see cref="IPublisher"/>,
+/// <see cref="FakeMessagingContext"/> as <see cref="IMessagingContext"/>, and
+/// <see cref="InMemoryOutboxStore"/> as <see cref="IOutboxStore"/>.
+/// Logging is wired to <see cref="NullLoggerFactory"/> so no log output is produced.
+/// </remarks>
+public sealed class TestMessagingBuilder
+{
+    private readonly IServiceCollection _services = new ServiceCollection();
+    private readonly OpinionatedEventingBuilder _builder;
+    private bool _built;
+
+    /// <summary>Gets the <see cref="FakePublisher"/> registered in the container.</summary>
+    public FakePublisher Publisher { get; } = new();
+
+    /// <summary>Gets the <see cref="FakeMessagingContext"/> registered in the container.</summary>
+    public FakeMessagingContext MessagingContext { get; } = new();
+
+    /// <summary>Gets the <see cref="InMemoryOutboxStore"/> registered in the container.</summary>
+    public InMemoryOutboxStore OutboxStore { get; } = new();
+
+    /// <summary>Initialises a new builder with fakes and null logging pre-registered.</summary>
+    public TestMessagingBuilder()
+    {
+        _services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        _services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+        // Register fakes before AddOpinionatedEventing so the TryAdd calls don't overwrite them.
+        _services.AddSingleton<IPublisher>(Publisher);
+        _services.AddSingleton<IOutboxStore>(OutboxStore);
+        _services.AddScoped<IMessagingContext>(_ => MessagingContext);
+
+        _builder = _services.AddOpinionatedEventing();
+    }
+
+    /// <summary>
+    /// Scans <paramref name="assemblies"/> for <see cref="IEventHandler{TEvent}"/> and
+    /// <see cref="ICommandHandler{TCommand}"/> implementations and registers them in DI.
+    /// </summary>
+    /// <param name="assemblies">Assemblies to scan for handler types.</param>
+    /// <returns>The same builder instance for chaining.</returns>
+    public TestMessagingBuilder AddHandlersFromAssemblies(params Assembly[] assemblies)
+    {
+        _builder.AddHandlersFromAssemblies(assemblies);
+        return this;
+    }
+
+    /// <summary>
+    /// Builds and returns the configured <see cref="IServiceProvider"/>.
+    /// The caller is responsible for disposing the returned provider.
+    /// This method may only be called once per builder instance.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if called more than once.</exception>
+    public IServiceProvider Build()
+    {
+        if (_built)
+            throw new InvalidOperationException("Build() has already been called on this TestMessagingBuilder instance.");
+
+        _built = true;
+        return _services.BuildServiceProvider();
+    }
+}

--- a/tests/OpinionatedEventing.Testing.Tests/FakeMessagingContextTests.cs
+++ b/tests/OpinionatedEventing.Testing.Tests/FakeMessagingContextTests.cs
@@ -1,0 +1,43 @@
+using OpinionatedEventing.Testing;
+using Xunit;
+
+namespace OpinionatedEventing.Tests;
+
+public sealed class FakeMessagingContextTests
+{
+    [Fact]
+    public void FakeMessagingContext_HasDefaultCorrelationId()
+    {
+        var ctx = new FakeMessagingContext();
+        Assert.NotEqual(Guid.Empty, ctx.CorrelationId);
+    }
+
+    [Fact]
+    public void FakeMessagingContext_DefaultCausationIdIsNull()
+    {
+        var ctx = new FakeMessagingContext();
+        Assert.Null(ctx.CausationId);
+    }
+
+    [Fact]
+    public void FakeMessagingContext_AllowsFixedCorrelationId()
+    {
+        var id = Guid.NewGuid();
+        var ctx = new FakeMessagingContext { CorrelationId = id };
+        Assert.Equal(id, ctx.CorrelationId);
+    }
+
+    [Fact]
+    public void FakeMessagingContext_AllowsFixedCausationId()
+    {
+        var id = Guid.NewGuid();
+        var ctx = new FakeMessagingContext { CausationId = id };
+        Assert.Equal(id, ctx.CausationId);
+    }
+
+    [Fact]
+    public void FakeMessagingContext_ImplementsIMessagingContext()
+    {
+        Assert.IsAssignableFrom<IMessagingContext>(new FakeMessagingContext());
+    }
+}

--- a/tests/OpinionatedEventing.Testing.Tests/FakePublisherTests.cs
+++ b/tests/OpinionatedEventing.Testing.Tests/FakePublisherTests.cs
@@ -1,0 +1,54 @@
+using OpinionatedEventing.Testing;
+using Xunit;
+
+namespace OpinionatedEventing.Tests;
+
+public sealed class FakePublisherTests
+{
+    public sealed record OrderPlaced(Guid OrderId) : IEvent;
+    public sealed record ProcessPayment(Guid OrderId) : ICommand;
+
+    [Fact]
+    public async Task PublishEventAsync_RecordsEvent()
+    {
+        var publisher = new FakePublisher();
+        await publisher.PublishEventAsync(new OrderPlaced(Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        Assert.Single(publisher.PublishedEvents);
+        Assert.IsType<OrderPlaced>(publisher.PublishedEvents[0]);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_RecordsCommand()
+    {
+        var publisher = new FakePublisher();
+        await publisher.SendCommandAsync(new ProcessPayment(Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        Assert.Single(publisher.SentCommands);
+        Assert.IsType<ProcessPayment>(publisher.SentCommands[0]);
+    }
+
+    [Fact]
+    public async Task PublishedEvents_PreservesOrder()
+    {
+        var publisher = new FakePublisher();
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        await publisher.PublishEventAsync(new OrderPlaced(id1), TestContext.Current.CancellationToken);
+        await publisher.PublishEventAsync(new OrderPlaced(id2), TestContext.Current.CancellationToken);
+
+        Assert.Equal(id1, ((OrderPlaced)publisher.PublishedEvents[0]).OrderId);
+        Assert.Equal(id2, ((OrderPlaced)publisher.PublishedEvents[1]).OrderId);
+    }
+
+    [Fact]
+    public async Task SentCommands_AndPublishedEvents_AreIndependent()
+    {
+        var publisher = new FakePublisher();
+        await publisher.PublishEventAsync(new OrderPlaced(Guid.NewGuid()), TestContext.Current.CancellationToken);
+        await publisher.SendCommandAsync(new ProcessPayment(Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        Assert.Single(publisher.PublishedEvents);
+        Assert.Single(publisher.SentCommands);
+    }
+}

--- a/tests/OpinionatedEventing.Testing.Tests/InMemoryOutboxStoreTests.cs
+++ b/tests/OpinionatedEventing.Testing.Tests/InMemoryOutboxStoreTests.cs
@@ -1,0 +1,80 @@
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Testing;
+using Xunit;
+
+namespace OpinionatedEventing.Tests;
+
+public sealed class InMemoryOutboxStoreTests
+{
+    private static OutboxMessage MakeMessage() => new()
+    {
+        Id = Guid.NewGuid(),
+        MessageType = "TestMessage",
+        MessageKind = "Event",
+        Payload = "{}",
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+
+    [Fact]
+    public async Task SaveAsync_MessageAppearsInPendingMessages()
+    {
+        var store = new InMemoryOutboxStore();
+        var msg = MakeMessage();
+        await store.SaveAsync(msg, TestContext.Current.CancellationToken);
+
+        Assert.Single(store.PendingMessages);
+        Assert.Empty(store.ProcessedMessages);
+    }
+
+    [Fact]
+    public async Task MarkProcessedAsync_MovesMessageToProcessedMessages()
+    {
+        var store = new InMemoryOutboxStore();
+        var msg = MakeMessage();
+        await store.SaveAsync(msg, TestContext.Current.CancellationToken);
+        await store.MarkProcessedAsync(msg.Id, TestContext.Current.CancellationToken);
+
+        Assert.Empty(store.PendingMessages);
+        Assert.Single(store.ProcessedMessages);
+    }
+
+    [Fact]
+    public async Task MarkFailedAsync_RemovesMessageFromPendingMessages()
+    {
+        var store = new InMemoryOutboxStore();
+        var msg = MakeMessage();
+        await store.SaveAsync(msg, TestContext.Current.CancellationToken);
+        await store.MarkFailedAsync(msg.Id, "boom", TestContext.Current.CancellationToken);
+
+        Assert.Empty(store.PendingMessages);
+        Assert.Empty(store.ProcessedMessages);
+    }
+
+    [Fact]
+    public async Task Messages_ContainsAllMessagesRegardlessOfStatus()
+    {
+        var store = new InMemoryOutboxStore();
+        var pending = MakeMessage();
+        var processed = MakeMessage();
+        var failed = MakeMessage();
+
+        await store.SaveAsync(pending, TestContext.Current.CancellationToken);
+        await store.SaveAsync(processed, TestContext.Current.CancellationToken);
+        await store.SaveAsync(failed, TestContext.Current.CancellationToken);
+        await store.MarkProcessedAsync(processed.Id, TestContext.Current.CancellationToken);
+        await store.MarkFailedAsync(failed.Id, "err", TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, store.Messages.Count);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_ReturnsPendingMessagesUpToBatchSize()
+    {
+        var store = new InMemoryOutboxStore();
+        for (var i = 0; i < 5; i++)
+            await store.SaveAsync(MakeMessage(), TestContext.Current.CancellationToken);
+
+        var batch = await store.GetPendingAsync(3, TestContext.Current.CancellationToken);
+        Assert.Equal(3, batch.Count);
+    }
+}

--- a/tests/OpinionatedEventing.Testing.Tests/OpinionatedEventing.Testing.Tests.csproj
+++ b/tests/OpinionatedEventing.Testing.Tests/OpinionatedEventing.Testing.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpinionatedEventing.Testing\OpinionatedEventing.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OpinionatedEventing.Testing.Tests/TestMessagingBuilderTests.cs
+++ b/tests/OpinionatedEventing.Testing.Tests/TestMessagingBuilderTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Testing;
+using Xunit;
+
+namespace OpinionatedEventing.Tests;
+
+public sealed class TestMessagingBuilderTests
+{
+    public sealed record ItemShipped(Guid OrderId) : IEvent;
+    public sealed record ShipOrder(Guid OrderId) : ICommand;
+
+    private sealed class ItemShippedHandler : IEventHandler<ItemShipped>
+    {
+        public Task HandleAsync(ItemShipped @event, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    private sealed class ShipOrderHandler : ICommandHandler<ShipOrder>
+    {
+        public Task HandleAsync(ShipOrder command, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    [Fact]
+    public void Build_ReturnsServiceProvider()
+    {
+        var provider = new TestMessagingBuilder().Build();
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void Build_ResolvesIPublisherAsFakePublisher()
+    {
+        var builder = new TestMessagingBuilder();
+        var provider = builder.Build();
+
+        var publisher = provider.GetRequiredService<IPublisher>();
+        Assert.Same(builder.Publisher, publisher);
+    }
+
+    [Fact]
+    public void Build_ResolvesIMessagingContextAsFakeMessagingContext()
+    {
+        var builder = new TestMessagingBuilder();
+        var provider = builder.Build();
+
+        using var scope = provider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<IMessagingContext>();
+        Assert.Same(builder.MessagingContext, ctx);
+    }
+
+    [Fact]
+    public void Build_ResolvesIOutboxStoreAsInMemoryOutboxStore()
+    {
+        var builder = new TestMessagingBuilder();
+        var provider = builder.Build();
+
+        var store = provider.GetRequiredService<IOutboxStore>();
+        Assert.Same(builder.OutboxStore, store);
+    }
+
+    [Fact]
+    public void AddHandlersFromAssemblies_RegistersEventHandler()
+    {
+        var provider = new TestMessagingBuilder()
+            .AddHandlersFromAssemblies(typeof(TestMessagingBuilderTests).Assembly)
+            .Build();
+
+        using var scope = provider.CreateScope();
+        var handlers = scope.ServiceProvider.GetServices<IEventHandler<ItemShipped>>();
+        Assert.Single(handlers);
+    }
+
+    [Fact]
+    public void AddHandlersFromAssemblies_RegistersCommandHandler()
+    {
+        var provider = new TestMessagingBuilder()
+            .AddHandlersFromAssemblies(typeof(TestMessagingBuilderTests).Assembly)
+            .Build();
+
+        using var scope = provider.CreateScope();
+        var handler = scope.ServiceProvider.GetService<ICommandHandler<ShipOrder>>();
+        Assert.NotNull(handler);
+    }
+
+    [Fact]
+    public void Build_ThrowsIfCalledTwice()
+    {
+        var builder = new TestMessagingBuilder();
+        builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void AddHandlersFromAssemblies_IsChainable()
+    {
+        var builder = new TestMessagingBuilder();
+        var result = builder.AddHandlersFromAssemblies(typeof(TestMessagingBuilderTests).Assembly);
+        Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public async Task Publisher_CapturesPublishedEvents()
+    {
+        var builder = new TestMessagingBuilder();
+        await builder.Publisher.PublishEventAsync(new ItemShipped(Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        Assert.Single(builder.Publisher.PublishedEvents);
+    }
+
+    [Fact]
+    public void MessagingContext_AllowsFixedCorrelationId()
+    {
+        var id = Guid.NewGuid();
+        var builder = new TestMessagingBuilder();
+        builder.MessagingContext.CorrelationId = id;
+
+        var provider = builder.Build();
+        using var scope = provider.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<IMessagingContext>();
+
+        Assert.Equal(id, ctx.CorrelationId);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `FakeMessagingContext : IMessagingContext` — allows tests to set a fixed `CorrelationId` and `CausationId` instead of relying on transport-populated values
- Adds `TestMessagingBuilder` — fluent builder that wires a minimal `IServiceProvider` with `FakePublisher`, `FakeMessagingContext`, and `InMemoryOutboxStore` pre-registered; supports `AddHandlersFromAssemblies` for handler scanning; `Build()` is guarded against double-calls
- Extends `InMemoryOutboxStore` with `PendingMessages` and `ProcessedMessages` convenience properties for assertions
- Adds `Microsoft.Extensions.DependencyInjection` package reference to `OpinionatedEventing.Testing` (required by `TestMessagingBuilder`; no `Version` attribute — managed centrally)
- Adds `OpinionatedEventing.Testing.Tests` project with 24 unit tests covering all new types and the new store properties

## Test plan

- [x] `dotnet test --project tests/OpinionatedEventing.Testing.Tests -f net10.0` — 24/24 green
- [x] Full solution build on net10.0 — 0 warnings, 0 errors (pre-existing Docker/ASB integration failures unchanged)
- [x] `TreatWarningsAsErrors=true` passes cleanly
- [x] No mocking frameworks — hand-written fakes only
- [x] No integration tests (no `[Trait("Category", "Integration")]` needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)