### PR TITLE
GitHub CI/CD plumbing (#29)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  # Temporary: opt into Node.js 24 runners ahead of the June 2026 forced migration.
-  # Remove once actions/checkout, actions/setup-dotnet, and actions/upload-artifact
-  # ship versions that bundle Node 24 natively (Dependabot will raise those PRs).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-and-test:
     name: Build & Test (.NET ${{ matrix.dotnet }})
@@ -34,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET ${{ matrix.dotnet }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
@@ -73,7 +67,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-dotnet-${{ matrix.dotnet }}
           path: "**/*.trx"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  # Temporary: opt into Node.js 24 runners ahead of the June 2026 forced migration.
+  # Remove once actions/checkout, actions/setup-dotnet, and actions/upload-artifact
+  # ship versions that bundle Node 24 natively (Dependabot will raise those PRs).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-test:
     name: Build & Test (.NET ${{ matrix.dotnet }})
@@ -48,8 +54,18 @@ jobs:
           --report-trx
           --coverage --coverage-output-format cobertura --ignore-exit-code "7;8"
 
-      - name: Integration tests (Testcontainers — Docker required)
-        if: github.event_name == 'push'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: "**/*.cobertura.xml"
+          flags: dotnet-${{ matrix.tfm }}
+          fail_ci_if_error: false
+
+      # Integration tests run on net10.0 only to avoid Docker container name conflicts
+      # that occur when all three TFM legs run Testcontainers concurrently on the same runner.
+      - name: Integration tests (Testcontainers — Docker required, .NET 10 only)
+        if: github.event_name == 'push' && matrix.tfm == 'net10.0'
         run: >
           dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
           --filter-trait "Category=Integration"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # OpinionatedEventing
+
+[![CI](https://github.com/SierraNL/OpinionatedEventing/actions/workflows/ci.yml/badge.svg)](https://github.com/SierraNL/OpinionatedEventing/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/SierraNL/OpinionatedEventing/branch/main/graph/badge.svg)](https://codecov.io/gh/SierraNL/OpinionatedEventing)
+
 A set of libraries to make life easy for dotnet developers that need eventing.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 [![CI](https://github.com/SierraNL/OpinionatedEventing/actions/workflows/ci.yml/badge.svg)](https://github.com/SierraNL/OpinionatedEventing/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/SierraNL/OpinionatedEventing/branch/main/graph/badge.svg)](https://codecov.io/gh/SierraNL/OpinionatedEventing)
+[![License: MIT](https://img.shields.io/github/license/SierraNL/OpinionatedEventing)](LICENSE)
+[![.NET](https://img.shields.io/badge/.NET-8%20%7C%209%20%7C%2010-512BD4)](https://dotnet.microsoft.com)
 
 A set of libraries to make life easy for dotnet developers that need eventing.


### PR DESCRIPTION
Closes #29

## Summary

- **Integration tests scope**: restricted to `net10.0` only to prevent Docker container name conflicts when all three TFM legs run Testcontainers concurrently on the same runner
- **Code coverage**: uploads Cobertura reports to codecov.io via `codecov/codecov-action@v5` after every unit/BDD test run; flagged per TFM; requires `CODECOV_TOKEN` repo secret
- **Node.js 24**: added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workflow env var to silence Node 20 deprecation warnings ahead of the June 2026 forced migration; Dependabot will raise PRs once the action versions bundle Node 24 natively, at which point the env var can be removed
- **Dependabot**: enabled weekly updates for NuGet (limit 10 PRs) and GitHub Actions (limit 5 PRs)
- **README badges**: CI pipeline status and codecov coverage badges added

## Test plan

- [ ] Verify CI pipeline passes on this PR (unit + BDD tests on all three TFMs, integration tests skipped on PR builds)
- [ ] Merge to `main` and confirm integration tests run only on the `net10.0` leg
- [ ] Confirm codecov.io receives coverage reports and badge renders correctly
- [ ] Confirm Dependabot PRs appear within the next weekly cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)