### PR TITLE
Fix integration test failures: RabbitMQ nack race, TargetInvocationException, ASB emulator

### DIFF
--- a/src/OpinionatedEventing.Core/MessageHandlerRunner.cs
+++ b/src/OpinionatedEventing.Core/MessageHandlerRunner.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -85,7 +87,9 @@ public sealed class MessageHandlerRunner : IMessageHandlerRunner
         CancellationToken ct)
     {
         var handlerType = typeof(IEventHandler<>).MakeGenericType(eventType);
-        var handlers = sp.GetServices(handlerType).ToList();
+        // GetServices returns IEnumerable<object?> — filter nulls so InvokeHandlerAsync can
+        // safely assume a non-null target, giving a clear contract-violation error if DI is broken.
+        var handlers = sp.GetServices(handlerType).OfType<object>().ToList();
 
         if (handlers.Count == 0)
         {
@@ -98,8 +102,7 @@ public sealed class MessageHandlerRunner : IMessageHandlerRunner
 
         foreach (var handler in handlers)
         {
-            // Invoke returns Task (non-void), never null.
-            await ((Task)handleMethod.Invoke(handler, [message, ct])!).ConfigureAwait(false);
+            await InvokeHandlerAsync(handleMethod, handler, message, ct).ConfigureAwait(false);
         }
     }
 
@@ -114,7 +117,25 @@ public sealed class MessageHandlerRunner : IMessageHandlerRunner
 
         // HandleAsync is defined on ICommandHandler<T> — GetMethod never returns null here.
         var handleMethod = handlerType.GetMethod("HandleAsync")!;
-        // Invoke returns Task (non-void), never null.
-        await ((Task)handleMethod.Invoke(handler, [message, ct])!).ConfigureAwait(false);
+        await InvokeHandlerAsync(handleMethod, handler, message, ct).ConfigureAwait(false);
+    }
+
+    // Invokes a HandleAsync method via reflection, unwrapping TargetInvocationException so the
+    // original exception (not the reflection wrapper) propagates to callers.
+    private static async Task InvokeHandlerAsync(
+        MethodInfo method, object handler, object message, CancellationToken ct)
+    {
+        Task task;
+        try
+        {
+            task = (Task)method.Invoke(handler, [message, ct])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw; // unreachable — satisfies compiler
+        }
+
+        await task.ConfigureAwait(false);
     }
 }

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
@@ -168,9 +168,22 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
         {
             _logger.LogError(ex, "Failed to handle message with delivery tag {DeliveryTag}.", ea.DeliveryTag);
 
-            await WriteDeadLetterRecordAsync(ea, ex.Message, ct).ConfigureAwait(false);
-            await channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, ct)
-                .ConfigureAwait(false);
+            // Use CancellationToken.None for both the dead-letter write and the nack so that a
+            // host shutdown racing with handler failure does not silently drop the record or leave
+            // the message unacknowledged (causing redelivery into the next test or consumer).
+            await WriteDeadLetterRecordAsync(ea, ex.Message, CancellationToken.None).ConfigureAwait(false);
+
+            try
+            {
+                await channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception nackEx)
+            {
+                _logger.LogWarning(nackEx,
+                    "Failed to nack message with delivery tag {DeliveryTag}; message may be redelivered.",
+                    ea.DeliveryTag);
+            }
         }
     }
 

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/OpinionatedEventing.AzureServiceBus.Tests.csproj
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/OpinionatedEventing.AzureServiceBus.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Testcontainers.MsSql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
@@ -2,38 +2,54 @@
 
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Testcontainers.MsSql;
 
 namespace OpinionatedEventing.AzureServiceBus.Tests.TestSupport;
 
 /// <summary>
 /// Manages a local Azure Service Bus Emulator Docker container for integration tests.
+/// The emulator requires a SQL Server sidecar; both run on an isolated Docker network.
 /// </summary>
 internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
 {
-    private const string Image = "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest";
+    private const string EmulatorImage = "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest";
     private const int AmqpPort = 5672;
 
+    // SA password shared between SQL Server and the emulator's env vars.
+    private const string SqlPassword = "Strong@Passw0rd!";
+    private const string SqlAlias = "sqlserver";
+
     // The emulator's hardcoded development connection string.
-    private const string EmulatorConnectionStringTemplate =
+    private const string ConnectionStringTemplate =
         "Endpoint=sb://localhost:{0};SharedAccessKeyName=RootManageSharedAccessKey;" +
         "SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
 
-    private readonly IContainer _container;
+    private readonly INetwork _network;
+    private readonly MsSqlContainer _sqlContainer;
+    private readonly IContainer _emulatorContainer;
     private readonly string _configPath;
 
-    private AzureServiceBusEmulatorContainer(IContainer container, string configPath)
+    private AzureServiceBusEmulatorContainer(
+        INetwork network,
+        MsSqlContainer sqlContainer,
+        IContainer emulatorContainer,
+        string configPath)
     {
-        _container = container;
+        _network = network;
+        _sqlContainer = sqlContainer;
+        _emulatorContainer = emulatorContainer;
         _configPath = configPath;
     }
 
     /// <summary>
-    /// Creates and starts the emulator with a namespace that has no pre-defined entities.
-    /// Resources are created at runtime by the transport's auto-create feature.
+    /// Starts a SQL Server container and the ASB emulator on a shared Docker network.
+    /// The emulator is ready when port 5672 becomes available.
     /// </summary>
     public static async Task<AzureServiceBusEmulatorContainer> StartAsync(
         CancellationToken ct = default)
     {
+        // Config grants the emulator permission to auto-create entities at runtime.
         var configJson = """
             {
               "UserConfig": {
@@ -49,20 +65,50 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
             }
             """;
 
-        // Write config to a temp file for volume mount.
         var configPath = Path.Combine(Path.GetTempPath(), $"asb-emulator-config-{Guid.NewGuid():N}.json");
         await File.WriteAllTextAsync(configPath, configJson, ct);
 
-        var container = new ContainerBuilder()
-            .WithImage(Image)
-            .WithPortBinding(AmqpPort, true)
-            .WithEnvironment("ACCEPT_EULA", "Y")
-            .WithBindMount(configPath, "/ServiceBus_Emulator/ConfigFiles/Config.json")
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(AmqpPort))
-            .Build();
+        // Isolated network so the emulator container can resolve the SQL Server by alias.
+        var network = new NetworkBuilder().Build();
+        await network.CreateAsync(ct);
 
-        await container.StartAsync(ct);
-        return new AzureServiceBusEmulatorContainer(container, configPath);
+        // SQL Server — wait strategy built into MsSqlBuilder ensures it is accepting connections
+        // before StartAsync returns. Partial failures are cleaned up before propagating.
+        MsSqlContainer? sqlContainer = null;
+        IContainer? emulatorContainer = null;
+        try
+        {
+            sqlContainer = new MsSqlBuilder()
+                .WithNetwork(network)
+                .WithNetworkAliases(SqlAlias)
+                .WithPassword(SqlPassword)
+                .Build();
+
+            await sqlContainer.StartAsync(ct);
+
+            emulatorContainer = new ContainerBuilder()
+                .WithImage(EmulatorImage)
+                .WithNetwork(network)
+                .WithPortBinding(AmqpPort, true)
+                .WithEnvironment("ACCEPT_EULA", "Y")
+                .WithEnvironment("SQL_SERVER", SqlAlias)
+                .WithEnvironment("MSSQL_SA_PASSWORD", SqlPassword)
+                .WithBindMount(configPath, "/ServiceBus_Emulator/ConfigFiles/Config.json")
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(AmqpPort))
+                .Build();
+
+            await emulatorContainer.StartAsync(ct);
+        }
+        catch
+        {
+            if (emulatorContainer is not null) await emulatorContainer.DisposeAsync();
+            if (sqlContainer is not null) await sqlContainer.DisposeAsync();
+            await network.DeleteAsync();
+            try { File.Delete(configPath); } catch { /* best-effort */ }
+            throw;
+        }
+
+        return new AzureServiceBusEmulatorContainer(network, sqlContainer, emulatorContainer, configPath);
     }
 
     /// <summary>Gets the connection string pointing at the running emulator.</summary>
@@ -70,15 +116,18 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
     {
         get
         {
-            var port = _container.GetMappedPublicPort(AmqpPort);
-            return string.Format(EmulatorConnectionStringTemplate, port);
+            var port = _emulatorContainer.GetMappedPublicPort(AmqpPort);
+            return string.Format(ConnectionStringTemplate, port);
         }
     }
 
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        await _container.DisposeAsync();
-        try { File.Delete(_configPath); } catch { /* best-effort cleanup */ }
+        // Attempt every cleanup step so that a failure in one does not leak the others.
+        try { await _emulatorContainer.DisposeAsync(); } catch { /* best-effort */ }
+        try { await _sqlContainer.DisposeAsync(); } catch { /* best-effort */ }
+        try { await _network.DeleteAsync(); } catch { /* best-effort */ }
+        try { File.Delete(_configPath); } catch { /* best-effort */ }
     }
 }


### PR DESCRIPTION
## Summary

Three root causes diagnosed from the failing `.NET 10` integration test run ([run 24603840050](https://github.com/SierraNL/OpinionatedEventing/actions/runs/24603840050/job/71946780517#step:8:437)):

### 1. RabbitMQ nack race condition (primary fix)

`ProcessDeliveryAsync` used the `stoppingToken` for both `WriteDeadLetterRecordAsync` and `BasicNackAsync` in the catch block. `WaitForConditionAsync` polls on `FailedAt` being set (written inside `WriteDeadLetterRecordAsync`), so `host.StopAsync` can cancel the token before `BasicNackAsync` runs. The message is left unacknowledged; RabbitMQ redelivers it into the next test's consumer, causing `Published_event_is_consumed_by_handler` to fail with the previous test's `ThrowingHandler` exception.

**Fix:** Both calls in the catch block now use `CancellationToken.None`, matching the pattern already used for `BasicAckAsync` on the success path.

### 2. `TargetInvocationException` wrapping in `MessageHandlerRunner`

`handleMethod.Invoke()` wraps a synchronous handler throw in `TargetInvocationException`. This meant the `OperationCanceledException` guard in `ProcessDeliveryAsync` never fired for cancelled handlers, and dead-letter records received the unhelpful wrapper message instead of the real error.

**Fix:** Extracted `InvokeHandlerAsync` that catches `TargetInvocationException` and re-throws the inner exception via `ExceptionDispatchInfo`, preserving the original stack trace. Also filters `null` entries from `GetServices` so `InvokeHandlerAsync` keeps a non-nullable `handler` parameter.

### 3. Azure Service Bus Emulator container crash

`mcr.microsoft.com/azure-messaging/servicebus-emulator` requires a SQL Server sidecar to initialise its schema. Without it the container exited before port 5672 opened, causing `AzureServiceBusFixture.InitializeAsync` to fail with `"container is not running"` after a 1-minute wait.

**Fix:** `AzureServiceBusEmulatorContainer` now starts a `Testcontainers.MsSql` container on an isolated Docker network and passes `SQL_SERVER` / `MSSQL_SA_PASSWORD` env vars to the emulator. Partial-failure cleanup in `StartAsync` and best-effort disposal of all three resources in `DisposeAsync` prevent Docker resource leaks on error.

## Files changed

| File | Change |
|---|---|
| `src/OpinionatedEventing.Core/MessageHandlerRunner.cs` | Unwrap `TargetInvocationException`; filter null handlers; fix `using` order |
| `src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs` | Use `CancellationToken.None` for dead-letter write and nack in catch block |
| `tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs` | Add SQL Server sidecar; cleanup on startup failure; resilient `DisposeAsync` |
| `tests/OpinionatedEventing.AzureServiceBus.Tests/*.csproj` | Add `Testcontainers.MsSql` package reference |

## Test plan

- [ ] `dotnet test --filter-trait "Category!=Integration"` — all unit/BDD tests green
- [ ] `dotnet test --filter-trait "Category=Integration"` on `.NET 10` — RabbitMQ and ASB integration tests green (requires Docker)
- [ ] Verify CI pipeline passes on this branch