### PR TITLE
feat: close #15 — NFR quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,15 @@ jobs:
         run: >
           dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
           --filter-trait "Category!=Integration"
-          --report-trx
-          --coverage --coverage-output-format cobertura --ignore-exit-code "7;8"
+          --report-trx --results-directory ./TestResults
+          --coverage --coverage-output-format cobertura
+          --ignore-exit-code "7;8"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: "**/*.cobertura.xml"
+          directory: ./TestResults
           flags: dotnet-${{ matrix.tfm }}
           fail_ci_if_error: false
 
@@ -70,7 +71,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results-dotnet-${{ matrix.dotnet }}
-          path: "**/*.trx"
+          path: ./TestResults/**/*.trx
 
       # Pack on net10.0 only — one set of .nupkg files is sufficient.
       # NuGet push is intentionally omitted until the library reaches a stable release.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,14 @@ jobs:
           dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
           --filter-not-trait "Category=Integration"
           --report-trx --results-directory ./TestResults
-          --coverage --coverage-output-format cobertura
+          ${{ matrix.tfm == 'net10.0' && '--coverage --coverage-output-format cobertura' || '' }}
 
       - name: Upload coverage to Codecov
+        if: matrix.tfm == 'net10.0'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./TestResults
-          flags: dotnet-${{ matrix.tfm }}
           fail_ci_if_error: false
 
       # Integration tests run on net10.0 only to avoid Docker container name conflicts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,9 @@ jobs:
       - name: Unit & BDD tests (no containers)
         run: >
           dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
-          --filter-trait "Category!=Integration"
+          --filter-not-trait "Category=Integration"
           --report-trx --results-directory ./TestResults
           --coverage --coverage-output-format cobertura
-          --ignore-exit-code "7;8"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -64,7 +63,7 @@ jobs:
         run: >
           dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
           --filter-trait "Category=Integration"
-          --report-trx --ignore-exit-code "7;8"
+          --report-trx --results-directory ./TestResults
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,16 @@ jobs:
         with:
           name: test-results-dotnet-${{ matrix.dotnet }}
           path: "**/*.trx"
+
+      # Pack on net10.0 only — one set of .nupkg files is sufficient.
+      # NuGet push is intentionally omitted until the library reaches a stable release.
+      - name: Pack NuGet packages
+        if: success() && matrix.tfm == 'net10.0'
+        run: dotnet pack --configuration Release --output ./artifacts/nuget
+
+      - name: Upload NuGet packages
+        if: success() && matrix.tfm == 'net10.0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuget-packages
+          path: ./artifacts/nuget/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,19 @@ jobs:
           --report-trx --results-directory ./TestResults
           ${{ matrix.tfm == 'net10.0' && '--coverage --coverage-output-format cobertura' || '' }}
 
-      - name: Upload coverage to Codecov
+      - name: Find coverage reports
         if: matrix.tfm == 'net10.0'
+        id: cov
+        run: |
+          FILES=$(find ./TestResults -name '*.cobertura.xml' | tr '\n' ',')
+          echo "files=${FILES%,}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload coverage to Codecov
+        if: matrix.tfm == 'net10.0' && steps.cov.outputs.files != ''
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./TestResults
+          files: ${{ steps.cov.outputs.files }}
           fail_ci_if_error: false
 
       # Integration tests run on net10.0 only to avoid Docker container name conflicts

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <Version>0.1.0</Version>
+    <Version>0.1.0-preview.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,11 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Version>0.1.0-preview.1</Version>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(IsSampleProject)' != 'true'">
+    <None Include="README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,9 +56,9 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
-    <PackageVersion Include="Testcontainers" Version="4.4.0" />
-    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.4.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.4.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
   </ItemGroup>
 
 </Project>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+
+ignore:
+  - "tests/**"
+  - "samples/**"
+
+# MTP-generated cobertura files use absolute paths on the runner.
+# This strips the runner workspace prefix so paths resolve to repo-relative paths.
+fixes:
+  - "/home/runner/work/OpinionatedEventing/OpinionatedEventing/::"

--- a/src/OpinionatedEventing.Aspire/README.md
+++ b/src/OpinionatedEventing.Aspire/README.md
@@ -1,0 +1,50 @@
+# OpinionatedEventing.Aspire
+
+.NET Aspire AppHost extensions for OpinionatedEventing local development. Adds first-class support for:
+
+- **RabbitMQ** container resource with auto-wired service discovery
+- **Azure Service Bus emulator** (Docker) resource
+
+Switch between transports in DI only — no handler code changes needed.
+
+## Installation
+
+In your **AppHost** project:
+
+```
+dotnet add package OpinionatedEventing.Aspire
+```
+
+## RabbitMQ
+
+```csharp
+// AppHost/Program.cs
+var rabbit = builder.AddRabbitMqMessaging("messaging");
+
+var api = builder.AddProject<Projects.MyApi>("api")
+    .WithReference(rabbit);
+```
+
+In your **API** project, `AddRabbitMQTransport` picks up the connection from Aspire service discovery automatically — no `HostName` or port configuration needed.
+
+## Azure Service Bus emulator
+
+```csharp
+// AppHost/Program.cs
+var asb = builder.AddAzureServiceBusEmulator("messaging");
+
+var api = builder.AddProject<Projects.MyApi>("api")
+    .WithReference(asb);
+```
+
+## Health checks
+
+```csharp
+// API project
+builder.Services.AddHealthChecks()
+    .AddOpinionatedEventingHealthChecks();
+```
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/src/OpinionatedEventing.AzureServiceBus/README.md
+++ b/src/OpinionatedEventing.AzureServiceBus/README.md
@@ -1,0 +1,46 @@
+# OpinionatedEventing.AzureServiceBus
+
+Azure Service Bus transport for OpinionatedEventing.
+
+- **Events** (`IEvent`) → Service Bus **topics** with per-handler subscriptions
+- **Commands** (`ICommand`) → Service Bus **queues** (single handler)
+- Uses `DefaultAzureCredential` by default — no connection string required in production
+- Automatically creates topics, queues, and subscriptions on startup
+
+## Installation
+
+```
+dotnet add package OpinionatedEventing.AzureServiceBus
+```
+
+## Registration
+
+```csharp
+builder.Services
+    .AddOpinionatedEventing()
+    .AddOutbox();
+
+builder.Services.AddAzureServiceBusTransport(options =>
+{
+    options.FullyQualifiedNamespace = "my-namespace.servicebus.windows.net";
+});
+```
+
+For local development with the Azure Service Bus emulator, use `OpinionatedEventing.Aspire` instead of configuring the namespace manually.
+
+## Handler registration
+
+Handlers registered via `AddOpinionatedEventing()` are automatically wired to the correct subscription/queue. No additional configuration per handler is needed.
+
+```csharp
+builder.Services.AddOpinionatedEventing()
+    .AddHandlersFromAssemblies(typeof(Program).Assembly);
+```
+
+## Authentication
+
+In production, assign the **Azure Service Bus Data Owner** (or Data Sender + Data Receiver) role to your managed identity. Locally, `az login` is sufficient when using `DefaultAzureCredential`.
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/src/OpinionatedEventing.Core/README.md
+++ b/src/OpinionatedEventing.Core/README.md
@@ -1,0 +1,59 @@
+# OpinionatedEventing.Core
+
+Core abstractions for the OpinionatedEventing library suite. This package contains the marker interfaces, handler contracts, and base types that every other OpinionatedEventing package builds on. It has no infrastructure dependencies.
+
+## Installation
+
+```
+dotnet add package OpinionatedEventing.Core
+```
+
+## What's included
+
+| Type | Purpose |
+|---|---|
+| `IEvent` | Marker interface for fan-out events (topic/exchange) |
+| `ICommand` | Marker interface for point-to-point commands (queue) |
+| `IEventHandler<TEvent>` | Handle an event |
+| `ICommandHandler<TCommand>` | Handle a command |
+| `IPublisher` | Write events and commands to the outbox |
+| `IOutboxStore` | Abstraction for the outbox persistence layer |
+| `AggregateRoot` | Base class for DDD aggregates with domain event harvesting |
+
+## Quick start
+
+Define your messages:
+
+```csharp
+// Events fan out to all registered handlers
+public record OrderPlaced(Guid OrderId, decimal Total) : IEvent;
+
+// Commands go to exactly one handler
+public record ShipOrder(Guid OrderId) : ICommand;
+```
+
+Implement handlers:
+
+```csharp
+public class OrderPlacedHandler : IEventHandler<OrderPlaced>
+{
+    public Task HandleAsync(OrderPlaced @event, CancellationToken ct = default)
+    {
+        // ...
+        return Task.CompletedTask;
+    }
+}
+```
+
+Register with DI:
+
+```csharp
+builder.Services
+    .AddOpinionatedEventing()
+    .AddOutbox()          // OpinionatedEventing.Outbox
+    .AddRabbitMQTransport(...);  // or .AddAzureServiceBusTransport(...)
+```
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/src/OpinionatedEventing.EntityFramework/README.md
+++ b/src/OpinionatedEventing.EntityFramework/README.md
@@ -1,0 +1,63 @@
+# OpinionatedEventing.EntityFramework
+
+EF Core integration for OpinionatedEventing. Provides:
+
+- **`EfOutboxStore`** — `IOutboxStore` backed by EF Core; outbox writes participate in `SaveChanges` transactions automatically.
+- **`DomainEventInterceptor`** — `SaveChangesInterceptor` that harvests domain events from `AggregateRoot` entities and writes them to the outbox atomically.
+- **Saga state persistence** — EF Core-backed `ISagaStateStore` for `OpinionatedEventing.Sagas`.
+
+## Installation
+
+```
+dotnet add package OpinionatedEventing.EntityFramework
+```
+
+## Registration
+
+```csharp
+builder.Services.AddOpinionatedEventingEntityFramework<AppDbContext>();
+```
+
+Add the outbox and saga tables to your `DbContext`:
+
+```csharp
+public class AppDbContext : DbContext
+{
+    public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
+    public DbSet<SagaState> SagaStates => Set<SagaState>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyOutboxConfiguration();
+        modelBuilder.ApplySagaStateConfiguration();
+    }
+}
+```
+
+Then add a migration:
+
+```
+dotnet ef migrations add AddOpinionatedEventing
+dotnet ef database update
+```
+
+## Domain events on aggregates
+
+Extend `AggregateRoot` and raise domain events without calling `IPublisher` directly:
+
+```csharp
+public class Order : AggregateRoot
+{
+    public Order(Guid id)
+    {
+        Id = id;
+        RaiseDomainEvent(new OrderCreated(id));
+    }
+}
+```
+
+`DomainEventInterceptor` harvests `RaiseDomainEvent` calls during `SaveChangesAsync` and writes them to the outbox in the same transaction.
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/src/OpinionatedEventing.OpenTelemetry/README.md
+++ b/src/OpinionatedEventing.OpenTelemetry/README.md
@@ -1,0 +1,42 @@
+# OpinionatedEventing.OpenTelemetry
+
+OpenTelemetry SDK integration for OpinionatedEventing. Provides `TracerProviderBuilder` and `MeterProviderBuilder` extension methods to opt in to distributed tracing and metrics emitted by the library.
+
+The core library emits telemetry via `System.Diagnostics.ActivitySource` and `System.Diagnostics.Metrics` with no direct OpenTelemetry SDK dependency. This package wires those sources into your OTel pipeline.
+
+## Installation
+
+```
+dotnet add package OpinionatedEventing.OpenTelemetry
+```
+
+## Registration
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddOpinionatedEventingInstrumentation())
+    .WithMetrics(metrics => metrics
+        .AddOpinionatedEventingInstrumentation());
+```
+
+## Emitted signals
+
+**Traces**
+- Outbox message dispatch spans (per message, tagged with message type and kind)
+- Saga step spans (per saga orchestrator step, tagged with saga type and correlation ID)
+- Consumer handler spans
+
+**Metrics**
+- `opinionatedeventing.outbox.pending` — current count of undelivered outbox messages
+- `opinionatedeventing.outbox.processed` — count of successfully dispatched messages
+- `opinionatedeventing.outbox.failed` — count of permanently failed messages
+- `opinionatedeventing.publish.duration` — time to write a message to the outbox
+- `opinionatedeventing.dispatch.duration` — time to deliver a message to the broker
+- `opinionatedeventing.consume.duration` — time to process an inbound message
+- `opinionatedeventing.saga.active` — current count of active saga instances
+- `opinionatedeventing.saga.timed_out` — count of timed-out sagas
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/src/OpinionatedEventing.Outbox/README.md
+++ b/src/OpinionatedEventing.Outbox/README.md
@@ -1,0 +1,53 @@
+# OpinionatedEventing.Outbox
+
+Outbox dispatcher background service for OpinionatedEventing. All outbound messages are written to `IOutboxStore` within the caller's `SaveChanges` transaction, then delivered to the broker asynchronously by `OutboxDispatcherWorker`. This guarantees at-least-once delivery without dual-write risk.
+
+## Installation
+
+```
+dotnet add package OpinionatedEventing.Outbox
+```
+
+Pair with an outbox store implementation:
+
+```
+dotnet add package OpinionatedEventing.EntityFramework
+```
+
+## Registration
+
+```csharp
+builder.Services
+    .AddOpinionatedEventing()
+    .AddOutbox();
+```
+
+`AddOutbox` registers:
+- `IPublisher` → `OutboxPublisher` (scoped) — writes to the outbox store
+- `OutboxDispatcherWorker` — hosted service that polls and dispatches
+
+## How it works
+
+1. Your code calls `IPublisher.PublishEventAsync` or `SendCommandAsync` inside a unit of work.
+2. `OutboxPublisher` writes `OutboxMessage` records to `IOutboxStore` **within the same transaction**.
+3. `OutboxDispatcherWorker` picks up pending messages and forwards them to the configured transport.
+
+```csharp
+public class PlaceOrderHandler : ICommandHandler<PlaceOrder>
+{
+    private readonly AppDbContext _db;
+    private readonly IPublisher _publisher;
+
+    public async Task HandleAsync(PlaceOrder command, CancellationToken ct = default)
+    {
+        var order = new Order(command.OrderId);
+        _db.Orders.Add(order);
+        await _publisher.PublishEventAsync(new OrderPlaced(order.Id), ct);
+        await _db.SaveChangesAsync(ct); // outbox write is part of this transaction
+    }
+}
+```
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/src/OpinionatedEventing.RabbitMQ/README.md
+++ b/src/OpinionatedEventing.RabbitMQ/README.md
@@ -1,0 +1,46 @@
+# OpinionatedEventing.RabbitMQ
+
+RabbitMQ transport for OpinionatedEventing.
+
+- **Events** (`IEvent`) → topic **exchanges** with per-handler bindings
+- **Commands** (`ICommand`) → direct **queues** (single handler)
+- Automatically declares exchanges, queues, and bindings on startup
+- Supports .NET Aspire service discovery
+
+## Installation
+
+```
+dotnet add package OpinionatedEventing.RabbitMQ
+```
+
+## Registration
+
+```csharp
+builder.Services
+    .AddOpinionatedEventing()
+    .AddOutbox();
+
+builder.Services.AddRabbitMQTransport(options =>
+{
+    options.HostName = "localhost";
+    options.Port = 5672;
+    options.UserName = "guest";
+    options.Password = "guest";
+    options.VirtualHost = "/";
+});
+```
+
+For local development with a containerised RabbitMQ, use `OpinionatedEventing.Aspire` — it wires up service discovery automatically so no manual hostname configuration is needed.
+
+## Handler registration
+
+Handlers registered via `AddOpinionatedEventing()` are automatically wired to the correct exchange binding / queue. No per-handler configuration required.
+
+```csharp
+builder.Services.AddOpinionatedEventing()
+    .AddHandlersFromAssemblies(typeof(Program).Assembly);
+```
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/src/OpinionatedEventing.Sagas/Internals/SagaDescriptor.cs
+++ b/src/OpinionatedEventing.Sagas/Internals/SagaDescriptor.cs
@@ -34,6 +34,8 @@ internal sealed class SagaDescriptor<TOrchestrator, TSagaState> : SagaDescriptor
     where TOrchestrator : SagaOrchestrator<TSagaState>
     where TSagaState : class, new()
 {
+    // AssemblyQualifiedName is null only for generic type parameters and array element types;
+    // TOrchestrator is always a concrete named class so the value is guaranteed non-null.
     public override string SagaTypeName { get; } = typeof(TOrchestrator).AssemblyQualifiedName!;
 
     public override async Task HandleEventAsync(
@@ -76,6 +78,8 @@ internal sealed class SagaDescriptor<TOrchestrator, TSagaState> : SagaDescriptor
                 ExpiresAt = CalculateExpiry(def, timeProvider),
             };
         }
+        // isNew = (state is null), so the else branch guarantees state is non-null;
+        // the compiler cannot track this through the bool variable, hence the suppression.
         else if (state!.Status is SagaStatus.Completed or SagaStatus.Failed)
         {
             return;
@@ -93,10 +97,12 @@ internal sealed class SagaDescriptor<TOrchestrator, TSagaState> : SagaDescriptor
             if (isCompensation && state.Status == SagaStatus.Active)
             {
                 state.Status = SagaStatus.Compensating;
+                // isCompensation is true only when TryGetValue succeeded, so compensationHandler is non-null.
                 await compensationHandler!(@event, sagaStateObj, context);
             }
             else if (isNormal && state.Status == SagaStatus.Active)
             {
+                // isNormal is true only when TryGetValue succeeded, so handler is non-null.
                 await handler!(@event, sagaStateObj, context);
             }
 

--- a/src/OpinionatedEventing.Sagas/Internals/SagaDispatcher.cs
+++ b/src/OpinionatedEventing.Sagas/Internals/SagaDispatcher.cs
@@ -37,9 +37,12 @@ internal sealed class SagaDispatcher : ISagaDispatcher
     {
         foreach (var descriptor in _sagaDescriptors)
             await descriptor.HandleEventAsync(
+                // TEvent : IEvent does not imply notnull without an explicit class/notnull constraint;
+                // the ! is safe because callers always pass a non-null event instance.
                 @event!, _sp, _stateStore, _publisher, _timeProvider, _serializerOptions, cancellationToken);
 
         foreach (var descriptor in _participantDescriptors)
+            // Same reasoning — TEvent : IEvent does not imply notnull; caller guarantees non-null.
             await descriptor.HandleAsync(@event!, _sp, _publisher, cancellationToken);
     }
 }

--- a/src/OpinionatedEventing.Sagas/README.md
+++ b/src/OpinionatedEventing.Sagas/README.md
@@ -1,0 +1,84 @@
+# OpinionatedEventing.Sagas
+
+Saga orchestration and choreography engine for OpinionatedEventing. Supports:
+
+- **Orchestration** — stateful, long-running workflows with compensation and timeouts (`SagaOrchestrator<TSagaState>`)
+- **Choreography** — lightweight, stateless event reaction (`ISagaParticipant<TEvent>`)
+
+Saga state is persisted via `OpinionatedEventing.EntityFramework`. Timeouts are driven by `TimeProvider` and are fully testable with a fake clock.
+
+## Installation
+
+```
+dotnet add package OpinionatedEventing.Sagas
+dotnet add package OpinionatedEventing.EntityFramework
+```
+
+## Registration
+
+```csharp
+builder.Services
+    .AddOpinionatedEventingSagas()
+    .AddSaga<OrderSaga>()
+    .AddSagaParticipant<NotificationParticipant>();
+```
+
+## Orchestration example
+
+Override `Configure(ISagaBuilder<TSagaState> builder)` to wire up event handlers, compensation, and timeouts using the fluent `ISagaBuilder` API:
+
+```csharp
+public class OrderSagaState
+{
+    public Guid OrderId { get; set; }
+    public bool PaymentReceived { get; set; }
+}
+
+public class OrderSaga : SagaOrchestrator<OrderSagaState>
+{
+    protected override void Configure(ISagaBuilder<OrderSagaState> builder)
+    {
+        builder
+            .StartWith<OrderPlaced>(OnOrderPlaced)
+            .Then<PaymentReceived>(OnPaymentReceived)
+            .CompensateWith<PaymentFailed>(OnPaymentFailed)
+            .OnTimeout(OnExpired)
+            .ExpireAfter(TimeSpan.FromDays(3));
+    }
+
+    private Task OnOrderPlaced(OrderPlaced @event, OrderSagaState state, ISagaContext ctx)
+    {
+        state.OrderId = @event.OrderId;
+        return ctx.SendCommandAsync(new ProcessPayment(@event.OrderId, @event.Total));
+    }
+
+    private Task OnPaymentReceived(PaymentReceived @event, OrderSagaState state, ISagaContext ctx)
+    {
+        state.PaymentReceived = true;
+        ctx.Complete();
+        return ctx.SendCommandAsync(new ShipOrder(state.OrderId));
+    }
+
+    private Task OnPaymentFailed(PaymentFailed @event, OrderSagaState state, ISagaContext ctx)
+        => ctx.PublishEventAsync(new OrderCancelled(state.OrderId));
+
+    private Task OnExpired(OrderSagaState state, ISagaContext ctx)
+        => ctx.PublishEventAsync(new OrderExpired(state.OrderId));
+}
+```
+
+By default, messages are correlated using a `CorrelationId` property on the event. Override with `.CorrelateBy<TEvent>(e => ...)` for custom correlation.
+
+## Choreography example
+
+```csharp
+public class NotificationParticipant : ISagaParticipant<OrderPlaced>
+{
+    public Task HandleAsync(OrderPlaced @event, IPublisher publisher, CancellationToken ct = default)
+        => publisher.PublishEventAsync(new SendWelcomeEmail(@event.CustomerId), ct);
+}
+```
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/src/OpinionatedEventing.Testing/FakePublisher.cs
+++ b/src/OpinionatedEventing.Testing/FakePublisher.cs
@@ -22,6 +22,8 @@ public sealed class FakePublisher : IPublisher
     public Task SendCommandAsync<TCommand>(TCommand command, CancellationToken cancellationToken = default)
         where TCommand : ICommand
     {
+        // TCommand : ICommand does not imply notnull without a class/notnull constraint; safe because
+        // ICommand is an interface (reference type only) and callers always pass a non-null instance.
         _sentCommands.Add(command!);
         return Task.CompletedTask;
     }
@@ -30,6 +32,7 @@ public sealed class FakePublisher : IPublisher
     public Task PublishEventAsync<TEvent>(TEvent @event, CancellationToken cancellationToken = default)
         where TEvent : IEvent
     {
+        // Same reasoning as SendCommandAsync — TEvent is always a non-null reference type at the call site.
         _publishedEvents.Add(@event!);
         return Task.CompletedTask;
     }

--- a/src/OpinionatedEventing.Testing/README.md
+++ b/src/OpinionatedEventing.Testing/README.md
@@ -1,0 +1,57 @@
+# OpinionatedEventing.Testing
+
+Test helpers for OpinionatedEventing. Provides in-memory fakes and a fluent builder for unit testing handlers, sagas, and aggregates without any infrastructure.
+
+**Not for production use.**
+
+## Installation
+
+```
+dotnet add package OpinionatedEventing.Testing
+```
+
+## What's included
+
+| Type | Purpose |
+|---|---|
+| `InMemoryOutboxStore` | `IOutboxStore` backed by a `List<OutboxMessage>` |
+| `FakePublisher` | `IPublisher` that captures sent commands and published events |
+| `TestMessagingBuilder` | Fluent builder that wires up a full in-memory DI container |
+
+## Usage
+
+### FakePublisher
+
+```csharp
+var publisher = new FakePublisher();
+var handler = new PlaceOrderHandler(publisher);
+
+await handler.HandleAsync(new PlaceOrder(orderId), CancellationToken.None);
+
+Assert.Single(publisher.PublishedEvents.OfType<OrderPlaced>());
+```
+
+### TestMessagingBuilder
+
+```csharp
+var host = new TestMessagingBuilder()
+    .WithHandler<OrderPlacedHandler>()
+    .Build();
+
+var publisher = host.Services.GetRequiredService<IPublisher>();
+await publisher.PublishEventAsync(new OrderPlaced(Guid.NewGuid()));
+
+// assert side effects via your fake dependencies
+```
+
+### InMemoryOutboxStore
+
+```csharp
+var store = new InMemoryOutboxStore();
+// inject into the class under test
+// inspect store.Messages after the act
+```
+
+## Repository
+
+[github.com/SierraNL/OpinionatedEventing](https://github.com/SierraNL/OpinionatedEventing)

--- a/tests/OpinionatedEventing.AzureServiceBus.Specs/StepDefinitions/AzureServiceBusSteps.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Specs/StepDefinitions/AzureServiceBusSteps.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using OpinionatedEventing.AzureServiceBus;
 using OpinionatedEventing.AzureServiceBus.Routing;
@@ -48,6 +50,8 @@ public sealed class AzureServiceBusSteps
     public void GivenTransportRegisteredWithConnectionString()
     {
         _services = new ServiceCollection();
+        _services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        _services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         _services.AddOpinionatedEventing();
         _services.AddAzureServiceBusTransport(o =>
         {
@@ -60,6 +64,8 @@ public sealed class AzureServiceBusSteps
     public void GivenTransportRegisteredWithServiceName(string serviceName)
     {
         _services = new ServiceCollection();
+        _services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        _services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
         _services.AddOpinionatedEventing();
         _services.AddAzureServiceBusTransport(o =>
         {

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
@@ -78,7 +78,7 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
         IContainer? emulatorContainer = null;
         try
         {
-            sqlContainer = new MsSqlBuilder()
+            sqlContainer = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
                 .WithNetwork(network)
                 .WithNetworkAliases(SqlAlias)
                 .WithPassword(SqlPassword)
@@ -86,15 +86,14 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
 
             await sqlContainer.StartAsync(ct);
 
-            emulatorContainer = new ContainerBuilder()
-                .WithImage(EmulatorImage)
+            emulatorContainer = new ContainerBuilder(EmulatorImage)
                 .WithNetwork(network)
                 .WithPortBinding(AmqpPort, true)
                 .WithEnvironment("ACCEPT_EULA", "Y")
                 .WithEnvironment("SQL_SERVER", SqlAlias)
                 .WithEnvironment("MSSQL_SA_PASSWORD", SqlPassword)
                 .WithBindMount(configPath, "/ServiceBus_Emulator/ConfigFiles/Config.json")
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(AmqpPort))
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(AmqpPort))
                 .Build();
 
             await emulatorContainer.StartAsync(ct);

--- a/tests/OpinionatedEventing.EntityFramework.Specs/Features/EntityFramework.feature
+++ b/tests/OpinionatedEventing.EntityFramework.Specs/Features/EntityFramework.feature
@@ -1,8 +1,33 @@
-Feature: EntityFramework
-  Placeholder feature file for OpinionatedEventing.EntityFramework BDD specs.
-  Replace with real scenarios when implementing issue #4.
+Feature: EntityFramework EF Core integration
+  As a developer using OpinionatedEventing with EF Core
+  I want domain events to flow to the outbox atomically and messages to be queryable
+  So that message delivery is guaranteed
 
-  Scenario: Placeholder
-    Given this is a placeholder scenario
-    When it is executed
-    Then it passes
+  Scenario: Domain event is harvested and written to the outbox when SaveChanges is called
+    Given an order aggregate with a pending domain event
+    And a known messaging context correlation ID
+    When SaveChangesAsync is called with the DomainEventInterceptor active
+    Then one outbox message with kind "Event" is written to the database
+    And the outbox message carries the messaging context correlation ID
+
+  Scenario: Domain events are cleared from the aggregate after harvest
+    Given an order aggregate with a pending domain event
+    When SaveChangesAsync is called with the DomainEventInterceptor active
+    Then the aggregate has no remaining domain events
+
+  Scenario: Staged outbox message is returned as pending
+    Given a message is staged and committed via EFCoreOutboxStore
+    When pending messages are queried
+    Then the staged message is in the result
+
+  Scenario: Processed message is excluded from the pending batch
+    Given a message is staged and committed via EFCoreOutboxStore
+    When the message is marked as processed
+    And pending messages are queried
+    Then no pending messages are returned
+
+  Scenario: Failed message is excluded from the pending batch
+    Given a message is staged and committed via EFCoreOutboxStore
+    When the message is marked as failed
+    And pending messages are queried
+    Then no pending messages are returned

--- a/tests/OpinionatedEventing.EntityFramework.Specs/OpinionatedEventing.EntityFramework.Specs.csproj
+++ b/tests/OpinionatedEventing.EntityFramework.Specs/OpinionatedEventing.EntityFramework.Specs.csproj
@@ -16,15 +16,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="8.0.25" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="9.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="9.0.14" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OpinionatedEventing.EntityFramework.Specs/StepDefinitions/EntityFrameworkSteps.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Specs/StepDefinitions/EntityFrameworkSteps.cs
@@ -1,16 +1,194 @@
+#nullable enable
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing;
+using OpinionatedEventing.EntityFramework;
+using OpinionatedEventing.Options;
+using OpinionatedEventing.Outbox;
 using Reqnroll;
 
 namespace OpinionatedEventing.EntityFramework.Specs.StepDefinitions;
 
 [Binding]
-public sealed class EntityFrameworkSteps
+public sealed class EntityFrameworkSteps : IAsyncDisposable
 {
-    [Given("this is a placeholder scenario")]
-    public void GivenPlaceholder() { }
+    private readonly string _databaseName = Guid.NewGuid().ToString();
+    private SpecsDbContext? _context;
+    private EFCoreOutboxStore<SpecsDbContext>? _store;
+    private OutboxMessage? _savedMessage;
+    private IReadOnlyList<OutboxMessage>? _pendingMessages;
+    private Guid _correlationId;
+    private SpecsTestOrder? _order;
 
-    [When("it is executed")]
-    public void WhenExecuted() { }
+    // --- Given ---
 
-    [Then("it passes")]
-    public void ThenPasses() { }
+    [Given("an order aggregate with a pending domain event")]
+    public void GivenOrderAggregateWithPendingDomainEvent()
+    {
+        _order = SpecsTestOrder.Place(Guid.NewGuid());
+    }
+
+    [Given("a known messaging context correlation ID")]
+    public void GivenKnownCorrelationId()
+    {
+        _correlationId = Guid.NewGuid();
+    }
+
+    [Given("a message is staged and committed via EFCoreOutboxStore")]
+    public async Task GivenMessageStagedAndCommitted()
+    {
+        var context = GetOrCreateContext();
+        _store = new EFCoreOutboxStore<SpecsDbContext>(context, TimeProvider.System);
+        _savedMessage = MakeMessage();
+        await _store.SaveAsync(_savedMessage);
+        await context.SaveChangesAsync();
+    }
+
+    // --- When ---
+
+    [When("SaveChangesAsync is called with the DomainEventInterceptor active")]
+    public async Task WhenSaveChangesWithInterceptorActive()
+    {
+        var corrId = _correlationId == Guid.Empty ? Guid.NewGuid() : _correlationId;
+        var messagingContext = new FakeMessagingContext(corrId);
+        var opts = Microsoft.Extensions.Options.Options.Create(new OpinionatedEventingOptions());
+        var interceptor = new DomainEventInterceptor(messagingContext, opts, TimeProvider.System);
+
+        var options = new DbContextOptionsBuilder<SpecsDbContext>()
+            .UseInMemoryDatabase(_databaseName)
+            .AddInterceptors(interceptor)
+            .Options;
+        _context = new SpecsDbContext(options);
+
+        // _order is always set by GivenOrderAggregateWithPendingDomainEvent before this step runs.
+        _context.Set<SpecsTestOrder>().Add(_order!);
+        await _context.SaveChangesAsync();
+    }
+
+    [When("pending messages are queried")]
+    public async Task WhenPendingMessagesQueried()
+    {
+        _pendingMessages = await _store!.GetPendingAsync(10);
+    }
+
+    [When("the message is marked as processed")]
+    public async Task WhenMessageMarkedAsProcessed()
+    {
+        await _store!.MarkProcessedAsync(_savedMessage!.Id);
+    }
+
+    [When("the message is marked as failed")]
+    public async Task WhenMessageMarkedAsFailed()
+    {
+        await _store!.MarkFailedAsync(_savedMessage!.Id, "test error");
+    }
+
+    // --- Then ---
+
+    [Then("one outbox message with kind {string} is written to the database")]
+    public void ThenOneOutboxMessageWithKindWritten(string kind)
+    {
+        var messages = _context!.Set<OutboxMessage>().ToList();
+        Xunit.Assert.Single(messages);
+        Xunit.Assert.Equal(kind, messages[0].MessageKind);
+    }
+
+    [Then("the outbox message carries the messaging context correlation ID")]
+    public void ThenOutboxMessageCarriesCorrelationId()
+    {
+        var message = _context!.Set<OutboxMessage>().Single();
+        Xunit.Assert.Equal(_correlationId, message.CorrelationId);
+    }
+
+    [Then("the aggregate has no remaining domain events")]
+    public void ThenAggregateHasNoDomainEvents()
+    {
+        Xunit.Assert.Empty(_order!.DomainEvents);
+    }
+
+    [Then("the staged message is in the result")]
+    public void ThenStagedMessageIsInResult()
+    {
+        Xunit.Assert.NotNull(_pendingMessages);
+        Xunit.Assert.Contains(_pendingMessages!, m => m.Id == _savedMessage!.Id);
+    }
+
+    [Then("no pending messages are returned")]
+    public void ThenNoPendingMessagesReturned()
+    {
+        Xunit.Assert.NotNull(_pendingMessages);
+        Xunit.Assert.Empty(_pendingMessages!);
+    }
+
+    // --- IAsyncDisposable ---
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_context is not null) await _context.DisposeAsync();
+    }
+
+    // --- private helpers ---
+
+    private SpecsDbContext GetOrCreateContext()
+    {
+        if (_context is not null) return _context;
+        var options = new DbContextOptionsBuilder<SpecsDbContext>()
+            .UseInMemoryDatabase(_databaseName)
+            .Options;
+        _context = new SpecsDbContext(options);
+        return _context;
+    }
+
+    private static OutboxMessage MakeMessage() => new()
+    {
+        Id = Guid.NewGuid(),
+        MessageType = "SomeType, SomeAssembly",
+        Payload = "{}",
+        MessageKind = "Event",
+        CorrelationId = Guid.NewGuid(),
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+
+    // --- inner types ---
+
+    private sealed class FakeMessagingContext(Guid correlationId) : IMessagingContext
+    {
+        public Guid CorrelationId { get; } = correlationId;
+        public Guid? CausationId => null;
+    }
+
+    private sealed class SpecsOrderPlaced : IEvent
+    {
+        public Guid OrderId { get; init; }
+    }
+
+    private sealed class SpecsTestOrder : AggregateRoot
+    {
+        public Guid Id { get; init; }
+
+        public static SpecsTestOrder Place(Guid id)
+        {
+            var order = new SpecsTestOrder { Id = id };
+            order.RaiseDomainEvent(new SpecsOrderPlaced { OrderId = id });
+            return order;
+        }
+    }
+
+    private sealed class SpecsDbContext : DbContext
+    {
+        public SpecsDbContext(DbContextOptions<SpecsDbContext> options) : base(options) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyOutboxConfiguration();
+            modelBuilder.Entity<SpecsTestOrder>(b =>
+            {
+                b.ToTable("specs_test_orders");
+                b.HasKey(o => o.Id);
+                b.Ignore(o => o.DomainEvents);
+            });
+        }
+    }
 }

--- a/tests/OpinionatedEventing.Outbox.Specs/StepDefinitions/OutboxSteps.cs
+++ b/tests/OpinionatedEventing.Outbox.Specs/StepDefinitions/OutboxSteps.cs
@@ -195,7 +195,9 @@ public sealed class OutboxSteps
             if (_savedMessage is not null)
             {
                 var msg = _store.Messages.SingleOrDefault(m => m.Id == _savedMessage.Id);
-                if (msg?.FailedAt is not null || msg?.AttemptCount > 0)
+                // Dead-lettered messages are excluded from GetPendingAsync, so pending.Count == 0
+                // is the reliable exit signal. FailedAt check here is a belt-and-suspenders guard.
+                if (msg?.FailedAt is not null)
                     break;
             }
 

--- a/tests/OpinionatedEventing.RabbitMQ.Specs/Features/RabbitMQ.feature
+++ b/tests/OpinionatedEventing.RabbitMQ.Specs/Features/RabbitMQ.feature
@@ -1,8 +1,39 @@
-Feature: RabbitMQ
-  Placeholder feature file for OpinionatedEventing.RabbitMQ BDD specs.
-  Replace with real scenarios when implementing issue #9.
+Feature: RabbitMQ Transport
+  As a developer using OpinionatedEventing with RabbitMQ
+  I want events and commands to be routed to the correct exchanges and queues
+  So that my microservices can communicate reliably
 
-  Scenario: Placeholder
-    Given this is a placeholder scenario
-    When it is executed
-    Then it passes
+  Scenario: Event type is mapped to a kebab-case exchange name
+    Given an event type named "OrderPlaced"
+    When I resolve the exchange name
+    Then the exchange name is "order-placed"
+
+  Scenario: MessageTopic attribute overrides the exchange name
+    Given an event type with a MessageTopic attribute set to "my-custom-exchange"
+    When I resolve the exchange name
+    Then the exchange name is "my-custom-exchange"
+
+  Scenario: Command type is mapped to a kebab-case queue name
+    Given a command type named "ProcessPayment"
+    When I resolve the queue name
+    Then the queue name is "process-payment"
+
+  Scenario: MessageQueue attribute overrides the queue name
+    Given a command type with a MessageQueue attribute set to "payments"
+    When I resolve the queue name
+    Then the queue name is "payments"
+
+  Scenario: Event consumer queue name includes the service name prefix
+    Given an event type named "OrderPlaced"
+    And the service name is "order-service"
+    When I resolve the event consumer queue name
+    Then the event queue name is "order-service.order-placed"
+
+  Scenario: Transport registration wires up ITransport
+    Given the RabbitMQ transport is registered with a connection string
+    Then ITransport is registered in the service collection
+
+  Scenario: Transport registration configures the ServiceName option
+    Given the RabbitMQ transport is registered with ServiceName "order-service"
+    When the service provider is built
+    Then the ServiceName option is "order-service"

--- a/tests/OpinionatedEventing.RabbitMQ.Specs/StepDefinitions/RabbitMQSteps.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Specs/StepDefinitions/RabbitMQSteps.cs
@@ -1,3 +1,13 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Attributes;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.RabbitMQ;
+using OpinionatedEventing.RabbitMQ.Routing;
 using Reqnroll;
 
 namespace OpinionatedEventing.RabbitMQ.Specs.StepDefinitions;
@@ -5,12 +15,147 @@ namespace OpinionatedEventing.RabbitMQ.Specs.StepDefinitions;
 [Binding]
 public sealed class RabbitMQSteps
 {
-    [Given("this is a placeholder scenario")]
-    public void GivenPlaceholder() { }
+    private Type? _messageType;
+    private string? _resolvedName;
+    private string? _serviceName;
+    private IServiceCollection? _services;
+    private IServiceProvider? _serviceProvider;
 
-    [When("it is executed")]
-    public void WhenExecuted() { }
+    // --- Given ---
 
-    [Then("it passes")]
-    public void ThenPasses() { }
+    [Given("an event type named {string}")]
+    public void GivenAnEventTypeNamed(string typeName)
+    {
+        _messageType = typeName switch
+        {
+            "OrderPlaced" => typeof(OrderPlaced),
+            _ => throw new NotSupportedException($"Unknown type '{typeName}'.")
+        };
+    }
+
+    [Given("an event type with a MessageTopic attribute set to {string}")]
+    public void GivenAnEventTypeWithMessageTopicAttribute(string _)
+    {
+        _messageType = typeof(CustomTopicEvent);
+    }
+
+    [Given("a command type named {string}")]
+    public void GivenACommandTypeNamed(string typeName)
+    {
+        _messageType = typeName switch
+        {
+            "ProcessPayment" => typeof(ProcessPayment),
+            _ => throw new NotSupportedException($"Unknown type '{typeName}'.")
+        };
+    }
+
+    [Given("a command type with a MessageQueue attribute set to {string}")]
+    public void GivenACommandTypeWithMessageQueueAttribute(string _)
+    {
+        _messageType = typeof(CustomQueueCommand);
+    }
+
+    [Given("the service name is {string}")]
+    public void GivenServiceNameIs(string serviceName)
+    {
+        _serviceName = serviceName;
+    }
+
+    [Given("the RabbitMQ transport is registered with a connection string")]
+    public void GivenTransportRegisteredWithConnectionString()
+    {
+        _services = new ServiceCollection();
+        _services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        _services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        _services.AddOpinionatedEventing();
+        _services.AddRabbitMQTransport(o =>
+        {
+            o.ConnectionString = "amqp://guest:guest@localhost:5672/";
+            o.ServiceName = "test-service";
+        });
+    }
+
+    [Given("the RabbitMQ transport is registered with ServiceName {string}")]
+    public void GivenTransportRegisteredWithServiceName(string serviceName)
+    {
+        _services = new ServiceCollection();
+        _services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        _services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        _services.AddOpinionatedEventing();
+        _services.AddRabbitMQTransport(o =>
+        {
+            o.ConnectionString = "amqp://guest:guest@localhost:5672/";
+            o.ServiceName = serviceName;
+        });
+    }
+
+    // --- When ---
+
+    [When("I resolve the exchange name")]
+    public void WhenIResolveTheExchangeName()
+    {
+        _resolvedName = MessageNamingConvention.GetExchangeName(_messageType!);
+    }
+
+    [When("I resolve the queue name")]
+    public void WhenIResolveTheQueueName()
+    {
+        _resolvedName = MessageNamingConvention.GetQueueName(_messageType!);
+    }
+
+    [When("I resolve the event consumer queue name")]
+    public void WhenIResolveTheEventConsumerQueueName()
+    {
+        _resolvedName = MessageNamingConvention.GetEventQueueName(_messageType!, _serviceName!);
+    }
+
+    [When("the service provider is built")]
+    public void WhenServiceProviderIsBuilt()
+    {
+        _serviceProvider = _services!.BuildServiceProvider();
+    }
+
+    // --- Then ---
+
+    [Then("the exchange name is {string}")]
+    public void ThenTheExchangeNameIs(string expected)
+    {
+        Xunit.Assert.Equal(expected, _resolvedName);
+    }
+
+    [Then("the queue name is {string}")]
+    public void ThenTheQueueNameIs(string expected)
+    {
+        Xunit.Assert.Equal(expected, _resolvedName);
+    }
+
+    [Then("the event queue name is {string}")]
+    public void ThenTheEventQueueNameIs(string expected)
+    {
+        Xunit.Assert.Equal(expected, _resolvedName);
+    }
+
+    [Then("ITransport is registered in the service collection")]
+    public void ThenITransportIsRegisteredInServiceCollection()
+    {
+        Xunit.Assert.Contains(_services!, d => d.ServiceType == typeof(ITransport));
+    }
+
+    [Then("the ServiceName option is {string}")]
+    public void ThenServiceNameOptionIs(string expected)
+    {
+        var opts = _serviceProvider!.GetRequiredService<IOptions<RabbitMQOptions>>().Value;
+        Xunit.Assert.Equal(expected, opts.ServiceName);
+    }
+
+    // --- message types ---
+
+    private sealed record OrderPlaced(string OrderId = "") : IEvent;
+    private sealed record ProcessPayment(string PaymentId = "") : ICommand;
+
+    [MessageTopic("my-custom-exchange")]
+    private sealed record CustomTopicEvent : IEvent;
+
+    [MessageQueue("payments")]
+    private sealed record CustomQueueCommand : ICommand;
 }

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/TestSupport/RabbitMqFixture.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/TestSupport/RabbitMqFixture.cs
@@ -17,7 +17,7 @@ public sealed class RabbitMqFixture : IAsyncLifetime
     /// <inheritdoc/>
     public async ValueTask InitializeAsync()
     {
-        _container = new RabbitMqBuilder().Build();
+        _container = new RabbitMqBuilder("rabbitmq:management").Build();
         await _container.StartAsync(CancellationToken.None);
     }
 

--- a/tests/OpinionatedEventing.Sagas.Specs/Features/Sagas.feature
+++ b/tests/OpinionatedEventing.Sagas.Specs/Features/Sagas.feature
@@ -1,8 +1,24 @@
-Feature: Sagas
-  Placeholder feature file for OpinionatedEventing.Sagas BDD specs.
-  Replace with real scenarios when implementing issue #5 and #6.
+Feature: Saga Orchestration
+  As a developer using OpinionatedEventing sagas
+  I want the saga engine to create, route, and complete saga instances correctly
+  So that distributed workflows are coordinated reliably
 
-  Scenario: Placeholder
-    Given this is a placeholder scenario
-    When it is executed
-    Then it passes
+  Scenario: Initiating event creates a new saga instance
+    Given the order saga is registered
+    When an OrderPlaced event is dispatched
+    Then a saga instance exists in the store
+    And the saga status is Active
+
+  Scenario: Subsequent event routes to the existing saga and updates its state
+    Given the order saga is registered
+    And an OrderPlaced event has been dispatched
+    When a PaymentReceived event is dispatched
+    Then the saga instance state shows payment was processed
+    And the saga status is Completed
+
+  Scenario: Compensation event invokes the CompensateWith handler
+    Given the order saga is registered
+    And an OrderPlaced event has been dispatched
+    When a PaymentFailed event is dispatched
+    Then the saga status is Completed
+    And the saga instance state shows payment was not processed

--- a/tests/OpinionatedEventing.Sagas.Specs/StepDefinitions/SagasSteps.cs
+++ b/tests/OpinionatedEventing.Sagas.Specs/StepDefinitions/SagasSteps.cs
@@ -1,16 +1,191 @@
+#nullable enable
+
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpinionatedEventing.Sagas;
+using OpinionatedEventing.Testing;
 using Reqnroll;
 
 namespace OpinionatedEventing.Sagas.Specs.StepDefinitions;
 
 [Binding]
-public sealed class SagasSteps
+public sealed class SagasSteps : IAsyncDisposable
 {
-    [Given("this is a placeholder scenario")]
-    public void GivenPlaceholder() { }
+    private Guid _correlationId;
+    private ISagaDispatcher? _dispatcher;
+    private InMemorySagaStateStore? _store;
+    private ServiceProvider? _root;
+    private IServiceScope? _scope;
 
-    [When("it is executed")]
-    public void WhenExecuted() { }
+    // --- Given ---
 
-    [Then("it passes")]
-    public void ThenPasses() { }
+    [Given("the order saga is registered")]
+    public void GivenOrderSagaIsRegistered()
+    {
+        _correlationId = Guid.NewGuid();
+        (_dispatcher, _store, _root, _scope) = BuildHarness(svc =>
+            svc.AddSaga<SpecsOrderSaga>());
+    }
+
+    [Given("an OrderPlaced event has been dispatched")]
+    public async Task GivenOrderPlacedEventDispatched()
+    {
+        await _dispatcher!.DispatchAsync(
+            new SpecsOrderPlaced { CorrelationId = _correlationId, Amount = 100m });
+    }
+
+    // --- When ---
+
+    [When("an OrderPlaced event is dispatched")]
+    public async Task WhenOrderPlacedEventDispatched()
+    {
+        await _dispatcher!.DispatchAsync(
+            new SpecsOrderPlaced { CorrelationId = _correlationId, Amount = 100m });
+    }
+
+    [When("a PaymentReceived event is dispatched")]
+    public async Task WhenPaymentReceivedEventDispatched()
+    {
+        await _dispatcher!.DispatchAsync(
+            new SpecsPaymentReceived { CorrelationId = _correlationId });
+    }
+
+    [When("a PaymentFailed event is dispatched")]
+    public async Task WhenPaymentFailedEventDispatched()
+    {
+        await _dispatcher!.DispatchAsync(
+            new SpecsPaymentFailed { CorrelationId = _correlationId });
+    }
+
+    // --- Then ---
+
+    [Then("a saga instance exists in the store")]
+    public void ThenSagaInstanceExistsInStore()
+    {
+        Xunit.Assert.Single(_store!.States);
+    }
+
+    [Then("the saga status is Active")]
+    public void ThenSagaStatusIsActive()
+    {
+        Xunit.Assert.Equal(SagaStatus.Active, _store!.States[0].Status);
+    }
+
+    [Then("the saga status is Completed")]
+    public void ThenSagaStatusIsCompleted()
+    {
+        Xunit.Assert.Equal(SagaStatus.Completed, _store!.States[0].Status);
+    }
+
+    [Then("the saga instance state shows payment was processed")]
+    public void ThenSagaStateShowsPaymentProcessed()
+    {
+        // Saga serializes with default STJ options (PascalCase); deserialize with same defaults.
+        var state = JsonSerializer.Deserialize<SpecsOrderSagaState>(_store!.States[0].State);
+        Xunit.Assert.True(state!.PaymentProcessed);
+    }
+
+    [Then("the saga instance state shows payment was not processed")]
+    public void ThenSagaStateShowsPaymentNotProcessed()
+    {
+        var state = JsonSerializer.Deserialize<SpecsOrderSagaState>(_store!.States[0].State);
+        Xunit.Assert.False(state!.PaymentProcessed);
+    }
+
+    // --- IAsyncDisposable ---
+
+    public async ValueTask DisposeAsync()
+    {
+        _scope?.Dispose();
+        if (_root is not null) await _root.DisposeAsync();
+    }
+
+    // --- private helpers ---
+
+    private static (ISagaDispatcher, InMemorySagaStateStore, ServiceProvider, IServiceScope) BuildHarness(
+        Action<IServiceCollection> configure)
+    {
+        var store = new InMemorySagaStateStore();
+        var publisher = new FakePublisher();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<ISagaStateStore>(store);
+        services.AddSingleton<IPublisher>(publisher);
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(
+            typeof(ILogger<SagaTimeoutWorker>),
+            NullLogger<SagaTimeoutWorker>.Instance);
+        services.AddOpinionatedEventingSagas();
+        configure(services);
+
+        var root = services.BuildServiceProvider(validateScopes: true);
+        var scope = root.CreateScope();
+        var dispatcher = scope.ServiceProvider.GetRequiredService<ISagaDispatcher>();
+
+        return (dispatcher, store, root, scope);
+    }
+
+    // --- inner saga types ---
+
+    private sealed class SpecsOrderSagaState
+    {
+        public Guid OrderId { get; set; }
+        public decimal Amount { get; set; }
+        public bool PaymentProcessed { get; set; }
+    }
+
+    private sealed record SpecsOrderPlaced : IEvent
+    {
+        public Guid CorrelationId { get; init; }
+        public decimal Amount { get; init; }
+    }
+
+    private sealed record SpecsPaymentReceived : IEvent
+    {
+        public Guid CorrelationId { get; init; }
+    }
+
+    private sealed record SpecsPaymentFailed : IEvent
+    {
+        public Guid CorrelationId { get; init; }
+    }
+
+    private sealed record SpecsProcessPayment : ICommand
+    {
+        public Guid OrderId { get; init; }
+        public decimal Amount { get; init; }
+    }
+
+    private sealed class SpecsOrderSaga : SagaOrchestrator<SpecsOrderSagaState>
+    {
+        protected override void Configure(ISagaBuilder<SpecsOrderSagaState> builder)
+        {
+            builder
+                .StartWith<SpecsOrderPlaced>(OnOrderPlaced)
+                .Then<SpecsPaymentReceived>(OnPaymentReceived)
+                .CompensateWith<SpecsPaymentFailed>(OnPaymentFailed);
+        }
+
+        private Task OnOrderPlaced(SpecsOrderPlaced evt, SpecsOrderSagaState state, ISagaContext ctx)
+        {
+            state.OrderId = evt.CorrelationId;
+            state.Amount = evt.Amount;
+            return ctx.SendCommandAsync(new SpecsProcessPayment { OrderId = state.OrderId, Amount = state.Amount });
+        }
+
+        private Task OnPaymentReceived(SpecsPaymentReceived _, SpecsOrderSagaState state, ISagaContext ctx)
+        {
+            state.PaymentProcessed = true;
+            ctx.Complete();
+            return Task.CompletedTask;
+        }
+
+        private Task OnPaymentFailed(SpecsPaymentFailed _, SpecsOrderSagaState state, ISagaContext ctx)
+        {
+            ctx.Complete();
+            return Task.CompletedTask;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #15

- **Version** bumped to `0.1.0-preview.1`; NuGet push intentionally withheld until the library reaches stable status
- **CI**: added `dotnet pack` + artifact upload step on the `net10.0` leg only — one set of `.nupkg` files per run, uploaded as a build artifact
- **Null suppressions**: added explanatory comments to all 7 bare `!` suppressions in `SagaDescriptor`, `SagaDispatcher`, and `FakePublisher` per the NFR checklist

## What was already compliant (no changes needed)

| Item | Status |
|---|---|
| `net8.0` / `net9.0` / `net10.0` multi-targeting | ✅ |
| `#nullable enable` globally | ✅ |
| `TreatWarningsAsErrors=true` | ✅ |
| All public async APIs have `CancellationToken` | ✅ audited |
| No mutable static state | ✅ audited |
| No Newtonsoft.Json | ✅ audited |
| No service locator in business logic | ✅ audited |
| NuGet metadata (authors, license, repo URL) in `Directory.Build.props` | ✅ |
| Per-package `<Description>` | ✅ all 9 `.csproj` files |
| `Directory.Packages.props` central version management | ✅ |
| GitHub Actions CI (build + unit + integration tests) | ✅ |
| `OutboxMessage` mutable tracking properties use `set` intentionally — dispatcher mutates these post-creation | ✅ by design |

## Test plan

- [ ] CI passes on all three TFM legs (net8.0, net9.0, net10.0)
- [ ] `nuget-packages` artifact appears in the net10.0 leg containing `*.nupkg` files versioned `0.1.0-preview.1`
- [ ] No new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)