### PR TITLE
fix(tests): repair RabbitMQ cross-test contamination and ASB emulator hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       # that occur when all three TFM legs run Testcontainers concurrently on the same runner.
       - name: Integration tests (Testcontainers — Docker required, .NET 10 only)
         if: github.event_name == 'push' && matrix.tfm == 'net10.0'
+        timeout-minutes: 20
         run: >
           dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
           --filter-trait "Category=Integration"

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
@@ -93,7 +93,10 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
                 .WithEnvironment("SQL_SERVER", SqlAlias)
                 .WithEnvironment("MSSQL_SA_PASSWORD", SqlPassword)
                 .WithBindMount(configPath, "/ServiceBus_Emulator/ConfigFiles/Config.json")
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(AmqpPort))
+                // Port 5672 opens before SQL Server init completes; the log message is the
+                // definitive signal that the emulator is ready to accept AMQP connections.
+                .WithWaitStrategy(Wait.ForUnixContainer()
+                    .UntilMessageIsLogged("Emulator Service is Successfully Up!"))
                 .Build();
 
             await emulatorContainer.StartAsync(ct);

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
@@ -20,6 +20,9 @@ public sealed class RabbitMQIntegrationTests
 {
     private readonly RabbitMqFixture _fixture;
 
+    // Unique per instance (xUnit creates one per test) → isolated durable queues, no cross-test contamination.
+    private readonly string _testRunId = Guid.NewGuid().ToString("N")[..8];
+
     /// <summary>Initialises the test class with the shared RabbitMQ fixture.</summary>
     public RabbitMQIntegrationTests(RabbitMqFixture fixture)
     {
@@ -149,7 +152,7 @@ public sealed class RabbitMQIntegrationTests
                 services.AddRabbitMQTransport(o =>
                 {
                     o.ConnectionString = _fixture.ConnectionString;
-                    o.ServiceName = serviceName;
+                    o.ServiceName = $"{serviceName}-{_testRunId}";
                     o.AutoDeclareTopology = true;
                 });
                 configureExtra?.Invoke(services);


### PR DESCRIPTION
## Summary

- **RabbitMQ:** \`Published_event_is_consumed_by_handler\` was receiving \`"order-fanout"\` instead of \`"order-1"\` because durable fanout queues persist across tests in the same session. After the dead-letter test creates \`test-service.order-placed\` and binds it to the \`order-placed\` exchange, the fanout test's publish routes into that queue too — so when the single-handler test starts its consumer, the wrong message is already waiting. Fix: append a per-instance GUID suffix to \`ServiceName\` in \`BuildHost\`; xUnit creates one class instance per test, giving every test its own isolated queue.

- **ASB emulator hang:** \`UntilInternalTcpPortIsAvailable(5672)\` fired as soon as the AMQP port bound inside the container, which happens *before* SQL Server initialisation completes. The emulator was not yet ready to accept connections, so the fixture startup silently stalled — causing the integration test step to run until GitHub's 6-hour runner limit. Fix: switch to \`UntilMessageIsLogged("Emulator Service is Successfully Up!")\`, the definitive ready signal logged by the emulator once SQL Server init is done. Also adds a \`timeout-minutes: 20\` guard on the CI step so any future startup failure surfaces as a clear error within 20 minutes rather than hanging indefinitely.

## Test plan

- [x] RabbitMQ integration tests verified locally: all 4 pass (net10.0)
- [x] ASB test project builds clean on net10.0
- [ ] ASB integration tests will be verified by CI (emulator image is too large to pull conveniently locally)
- [ ] Confirm the CI integration test step completes within the 20-minute budget on the next push