### PR TITLE
ci: collect integration test coverage and upload together with unit coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,17 @@ jobs:
           --report-trx --results-directory ./TestResults
           ${{ matrix.tfm == 'net10.0' && '--coverage --coverage-output-format cobertura' || '' }}
 
+      # Integration tests run on net10.0 only to avoid Docker container name conflicts
+      # that occur when all three TFM legs run Testcontainers concurrently on the same runner.
+      - name: Integration tests (Testcontainers — Docker required, .NET 10 only)
+        if: github.event_name == 'push' && matrix.tfm == 'net10.0'
+        timeout-minutes: 20
+        run: >
+          dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
+          --filter-trait "Category=Integration"
+          --report-trx --results-directory ./TestResults
+          --coverage --coverage-output-format cobertura
+
       - name: Find coverage reports
         if: matrix.tfm == 'net10.0'
         id: cov
@@ -62,16 +73,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.cov.outputs.files }}
           fail_ci_if_error: false
-
-      # Integration tests run on net10.0 only to avoid Docker container name conflicts
-      # that occur when all three TFM legs run Testcontainers concurrently on the same runner.
-      - name: Integration tests (Testcontainers — Docker required, .NET 10 only)
-        if: github.event_name == 'push' && matrix.tfm == 'net10.0'
-        timeout-minutes: 20
-        run: >
-          dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
-          --filter-trait "Category=Integration"
-          --report-trx --results-directory ./TestResults
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary

- Adds `--coverage --coverage-output-format cobertura` to the integration test step so transport-layer code paths (RabbitMQ, ASB) are instrumented
- Moves the "Find coverage reports" and "Upload coverage to Codecov" steps to **after** the integration test step, so a single `find` pass picks up cobertura files from both unit and integration runs
- No behaviour change on PRs (integration tests still skipped there); on pushes to `main` Codecov now receives a combined report

## Test plan

- [ ] Verify CI passes on this PR (unit tests only — no containers)
- [ ] After merge, confirm the next push-to-main run uploads a higher line count to Codecov than the current baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)