### PR TITLE
fix(asb): register TimeProvider.System in AddAzureServiceBusTransport

### DIFF
--- a/src/OpinionatedEventing.AzureServiceBus/DependencyInjection/AzureServiceBusServiceCollectionExtensions.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/DependencyInjection/AzureServiceBusServiceCollectionExtensions.cs
@@ -33,6 +33,8 @@ public static class AzureServiceBusServiceCollectionExtensions
 
         services.Configure(configure);
 
+        services.TryAddSingleton(TimeProvider.System);
+
         // Capture the service collection for handler-type scanning at host startup.
         services.TryAddSingleton(new ServiceCollectionAccessor(services));
 


### PR DESCRIPTION
## Summary

- `AzureServiceBusConsumerWorker` constructor-injects `TimeProvider` but `AddAzureServiceBusTransport` never registered it in DI
- This caused `InvalidOperationException: Unable to resolve service for type 'System.TimeProvider'` at host startup, failing all ASB integration tests on .NET 10
- Fix: add `services.TryAddSingleton(TimeProvider.System)` — mirrors the identical line already in `RabbitMQServiceCollectionExtensions`

Using `TryAdd` ensures tests can still override with `FakeTimeProvider` by registering before calling `AddAzureServiceBusTransport`.

## Test plan

- [ ] Integration tests in `OpinionatedEventing.AzureServiceBus.Tests` pass on .NET 10 (CI)
- [ ] RabbitMQ tests unaffected