### PR TITLE
chore(deps): bump Microsoft.Extensions packages from 10.0.5 to 10.0.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,12 +6,12 @@
 
   <!-- Microsoft.Extensions -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.6" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Combines Dependabot PRs #38 and #48 into a single change:

- Bump `Microsoft.Extensions.Hosting.Abstractions` 10.0.5 → 10.0.6 (closes #38)
- Bump `Microsoft.Extensions.Logging.Abstractions` 10.0.5 → 10.0.6 (closes #48)
- Bump `Microsoft.Extensions.Configuration.Abstractions` 10.0.5 → 10.0.6 (transitive — required by `Hosting.Abstractions 10.0.6`)

## Test plan

- [x] `dotnet build` — no CS/NuGet errors (pre-existing MSB3030 net9.0 apphost errors are unrelated)
- [x] Unit tests pass on net8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)