### PR TITLE
fix(tests): expose ASB emulator management port 5300 for admin client

### DIFF
--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using Azure.Messaging.ServiceBus.Administration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpinionatedEventing.AzureServiceBus.Tests.TestSupport;
@@ -111,6 +112,12 @@ public sealed class AzureServiceBusIntegrationTests
             .ConfigureServices(services =>
             {
                 services.AddOpinionatedEventing();
+                // Register the admin client before AddAzureServiceBusTransport so the TryAddSingleton
+                // inside skips it. The management API is on port 5300; with UseDevelopmentEmulator=true
+                // the SDK derives the HTTP endpoint from the port in the connection string, so using
+                // the AMQP connection string (port 5672) would send HTTP to the AMQP listener.
+                services.AddSingleton(
+                    new ServiceBusAdministrationClient(_fixture.ManagementConnectionString));
                 services.AddAzureServiceBusTransport(o =>
                 {
                     o.ConnectionString = _fixture.ConnectionString;

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusEmulatorContainer.cs
@@ -15,6 +15,7 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
 {
     private const string EmulatorImage = "mcr.microsoft.com/azure-messaging/servicebus-emulator:latest";
     private const int AmqpPort = 5672;
+    private const int ManagementPort = 5300;
 
     // SA password shared between SQL Server and the emulator's env vars.
     private const string SqlPassword = "Strong@Passw0rd!";
@@ -89,6 +90,7 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
             emulatorContainer = new ContainerBuilder(EmulatorImage)
                 .WithNetwork(network)
                 .WithPortBinding(AmqpPort, true)
+                .WithPortBinding(ManagementPort, true)
                 .WithEnvironment("ACCEPT_EULA", "Y")
                 .WithEnvironment("SQL_SERVER", SqlAlias)
                 .WithEnvironment("MSSQL_SA_PASSWORD", SqlPassword)
@@ -113,12 +115,28 @@ internal sealed class AzureServiceBusEmulatorContainer : IAsyncDisposable
         return new AzureServiceBusEmulatorContainer(network, sqlContainer, emulatorContainer, configPath);
     }
 
-    /// <summary>Gets the connection string pointing at the running emulator.</summary>
+    /// <summary>Gets the AMQP connection string pointing at the running emulator.</summary>
     public string ConnectionString
     {
         get
         {
             var port = _emulatorContainer.GetMappedPublicPort(AmqpPort);
+            return string.Format(ConnectionStringTemplate, port);
+        }
+    }
+
+    /// <summary>
+    /// Gets a connection string for <see cref="Azure.Messaging.ServiceBus.Administration.ServiceBusAdministrationClient"/>
+    /// that points at the emulator's HTTP management port (5300).
+    /// With <c>UseDevelopmentEmulator=true</c> the SDK derives the management endpoint from the
+    /// port in the connection string, so the admin client must use the management port — not the
+    /// AMQP port — otherwise HTTP requests land on the AMQP listener and fail.
+    /// </summary>
+    public string ManagementConnectionString
+    {
+        get
+        {
+            var port = _emulatorContainer.GetMappedPublicPort(ManagementPort);
             return string.Format(ConnectionStringTemplate, port);
         }
     }

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusFixture.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/TestSupport/AzureServiceBusFixture.cs
@@ -9,9 +9,12 @@ public sealed class AzureServiceBusFixture : IAsyncLifetime
 {
     private AzureServiceBusEmulatorContainer? _emulator;
 
-    /// <summary>Gets the connection string for the running Azure Service Bus emulator.</summary>
+    /// <summary>Gets the AMQP connection string for the running Azure Service Bus emulator.</summary>
     // InitializeAsync guarantees _emulator is set before any test accesses this property
     public string ConnectionString => _emulator!.ConnectionString;
+
+    /// <summary>Gets the management (HTTP port 5300) connection string for the running emulator.</summary>
+    public string ManagementConnectionString => _emulator!.ManagementConnectionString;
 
     /// <inheritdoc/>
     public async ValueTask InitializeAsync()


### PR DESCRIPTION
## Summary

- `ServiceBusAdministrationClient` with `UseDevelopmentEmulator=true` derives the HTTP management endpoint from the **port in the connection string** — it doesn't hardcode port 5300
- The container was only binding the AMQP port (5672), so the admin client sent HTTP requests to the AMQP listener → `HttpIOException: The response ended prematurely` in `TopologyInitializer` at host startup
- Fix: bind port 5300 (management HTTP) with a random host mapping alongside AMQP port 5672
- Pre-register `ServiceBusAdministrationClient` with `ManagementConnectionString` before `AddAzureServiceBusTransport` so the `TryAddSingleton` inside is skipped

## Test plan

- [ ] All three ASB integration tests pass on .NET 10 (CI): `Published_event_is_consumed_by_handler`, `Sent_command_is_consumed_by_single_handler`, `Dead_lettered_message_is_recorded_in_outbox`
- [ ] RabbitMQ tests unaffected