### PR TITLE
fix(ci): allow zero tests in non-integration assemblies during integration step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         run: >
           dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
           --filter-trait "Category=Integration"
+          --minimum-expected-tests 0
           --report-trx --results-directory ./TestResults
           --coverage --coverage-output-format cobertura
 


### PR DESCRIPTION
## Summary

- Adds `--minimum-expected-tests 0` to the integration test step so assemblies with no `[Trait("Category", "Integration")]` tests don't fail with exit code 8 ("Zero tests ran")

Closes #54

## Test plan

- [ ] CI integration test step passes without exit code 8 failures on non-integration assemblies
- [ ] `RabbitMQ.Tests` and `AzureServiceBus.Tests` still run and pass as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)