### PR TITLE
fix(ci): handle exit code 8 from assemblies with no integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,14 @@ jobs:
       - name: Integration tests (Testcontainers — Docker required, .NET 10 only)
         if: github.event_name == 'push' && matrix.tfm == 'net10.0'
         timeout-minutes: 20
-        run: >
-          dotnet test --framework ${{ matrix.tfm }} ${{ matrix.mtp_sep }}
-          --filter-trait "Category=Integration"
-          --minimum-expected-tests 0
-          --report-trx --results-directory ./TestResults
-          --coverage --coverage-output-format cobertura
+        run: |
+          dotnet test --framework ${{ matrix.tfm }} \
+            --filter-trait "Category=Integration" \
+            --report-trx --results-directory ./TestResults \
+            --coverage --coverage-output-format cobertura
+          result=$?
+          # Exit code 8 = zero tests ran; expected for assemblies with no integration tests
+          [ $result -eq 0 ] || [ $result -eq 8 ] || exit $result
 
       - name: Find coverage reports
         if: matrix.tfm == 'net10.0'


### PR DESCRIPTION
## Summary

- Replaces the ineffective `--minimum-expected-tests 0` flag with a bash exit code check
- `--minimum-expected-tests 0` is recognised by MTP but does not suppress per-assembly exit code 8 from individual test hosts — the overall run still fails
- The new approach captures the exit code after `dotnet test` and treats exit code 8 (zero tests ran) as success; any other non-zero code (e.g. 2 = test failure) still fails the step

Fixes #54

## Test plan

- [ ] Integration test step passes without exit code 8 failures on non-integration assemblies
- [ ] `RabbitMQ.Tests` and `AzureServiceBus.Tests` still run and pass as before
- [ ] A real test failure (exit code 2) would still break the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)