### PR TITLE
docs: conceptual guides and README update (issue #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,75 @@
 [![License: MIT](https://img.shields.io/github/license/SierraNL/OpinionatedEventing)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-8%20%7C%209%20%7C%2010-512BD4)](https://dotnet.microsoft.com)
 
-A set of libraries to make life easy for dotnet developers that need eventing.
+A suite of opinionated .NET libraries for event-driven and command-driven messaging, targeting Azure Service Bus and RabbitMQ. Designed for developers who want correctness and safe defaults over maximum flexibility.
+
+## What it does
+
+- **Outbox-first publishing** — events and commands are written atomically with your business data, then dispatched asynchronously. There is no direct broker publish path.
+- **Commands vs events, enforced** — `ICommand` routes point-to-point (one handler); `IEvent` fans out (many handlers). The compiler and DI container enforce this distinction.
+- **DDD aggregate roots** — raise domain events inside aggregate methods; the `DomainEventInterceptor` harvests and outboxes them automatically on `SaveChanges`.
+- **Sagas** — orchestration (`SagaOrchestrator<TSagaState>`) with state, timeouts, and compensation, plus lightweight choreography (`ISagaParticipant<TEvent>`).
+- **Transport-agnostic** — swap Azure Service Bus for RabbitMQ (or vice versa) by changing a single DI call. No handler code changes.
+- **Aspire-ready** — one-line AppHost extensions spin up RabbitMQ or the Azure Service Bus emulator locally.
+- **Observable** — structured logging via `ILogger<T>`, distributed tracing via `ActivitySource`, metrics via `System.Diagnostics.Metrics`.
+
+## Packages
+
+| Package | NuGet | Purpose |
+|---|---|---|
+| `OpinionatedEventing.Core` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Core.svg)](https://www.nuget.org/packages/OpinionatedEventing.Core) | Abstractions only — `IEvent`, `ICommand`, `IPublisher`, `AggregateRoot` |
+| `OpinionatedEventing.Outbox` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Outbox.svg)](https://www.nuget.org/packages/OpinionatedEventing.Outbox) | `OutboxDispatcherWorker`, `IOutboxStore` contract |
+| `OpinionatedEventing.EntityFramework` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.EntityFramework.svg)](https://www.nuget.org/packages/OpinionatedEventing.EntityFramework) | EF Core outbox store, `DomainEventInterceptor`, saga state |
+| `OpinionatedEventing.Sagas` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Sagas.svg)](https://www.nuget.org/packages/OpinionatedEventing.Sagas) | Orchestration and choreography engine |
+| `OpinionatedEventing.AzureServiceBus` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.AzureServiceBus.svg)](https://www.nuget.org/packages/OpinionatedEventing.AzureServiceBus) | Azure Service Bus transport |
+| `OpinionatedEventing.RabbitMQ` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.RabbitMQ.svg)](https://www.nuget.org/packages/OpinionatedEventing.RabbitMQ) | RabbitMQ transport |
+| `OpinionatedEventing.Aspire` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Aspire.svg)](https://www.nuget.org/packages/OpinionatedEventing.Aspire) | Aspire AppHost extensions and health checks |
+| `OpinionatedEventing.Testing` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Testing.svg)](https://www.nuget.org/packages/OpinionatedEventing.Testing) | In-memory stores and fakes for tests |
+
+## Quick start
+
+```csharp
+// Define messages
+public record OrderPlaced(Guid OrderId, decimal Total) : IEvent;
+public record ProcessPayment(Guid OrderId, decimal Amount) : ICommand;
+
+// Handle events
+public class NotificationHandler : IEventHandler<OrderPlaced>
+{
+    public Task HandleAsync(OrderPlaced @event, CancellationToken ct) => ...;
+}
+
+// Wire up (Program.cs)
+services
+    .AddOpinionatedEventing()
+    .AddHandlersFromAssemblies(Assembly.GetExecutingAssembly())
+    .AddOutbox();
+
+services.AddOpinionatedEventingEntityFramework<AppDbContext>();
+services.AddRabbitMQTransport(o => { o.ServiceName = "my-service"; });
+
+// Publish (within a SaveChanges transaction)
+await publisher.PublishEventAsync(new OrderPlaced(id, total), ct);
+await db.SaveChangesAsync(ct);
+```
+
+## Documentation
+
+| Guide | Description |
+|---|---|
+| [Getting Started](docs/getting-started.md) | Install, configure, and publish your first event |
+| [Commands vs Events](docs/commands-vs-events.md) | When to use each and why the separation matters |
+| [Outbox Pattern](docs/outbox-pattern.md) | How the outbox works internally, retry, and dead-letters |
+| [Saga Orchestration](docs/sagas-orchestration.md) | Stateful workflows with timeouts and compensation |
+| [Saga Choreography](docs/sagas-choreography.md) | Lightweight event-driven coordination with `ISagaParticipant` |
+| [DDD Aggregates](docs/ddd-aggregates.md) | Aggregate roots, domain events, and the interceptor |
+| [Local Development](docs/local-development.md) | Running locally with Aspire, RabbitMQ, and ASB emulator |
+| [Observability](docs/observability.md) | Logging, distributed tracing, and metrics |
+
+## Requirements
+
+.NET 8, 9, or 10. See [REQUIREMENTS.md](REQUIREMENTS.md) for the full specification.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/docs/commands-vs-events.md
+++ b/docs/commands-vs-events.md
@@ -1,0 +1,125 @@
+# Commands vs Events
+
+OpinionatedEventing makes a strict distinction between commands and events. Understanding the difference is the first step to designing a well-structured message-driven system.
+
+## The core difference
+
+| | Command | Event |
+|---|---|---|
+| **Marker interface** | `ICommand` | `IEvent` |
+| **Intent** | "Please do X" | "X happened" |
+| **Handlers** | Exactly one | Zero or more |
+| **Broker topology** | Point-to-point (queue) | Publish-subscribe (topic / exchange) |
+| **Direction** | Sender → specific service | Sender → any interested party |
+
+## Events
+
+An event records something that already happened. It is a fact — immutable and past tense.
+
+```csharp
+public record OrderPlaced(Guid OrderId, decimal Total) : IEvent;
+public record PaymentReceived(Guid OrderId, Guid PaymentId) : IEvent;
+public record StockReserved(Guid OrderId, string Sku, int Quantity) : IEvent;
+```
+
+Events are broadcast to a topic (Azure Service Bus) or exchange (RabbitMQ). Every service that has registered an `IEventHandler<T>` for that event type receives a copy. If no handler exists, the message is silently discarded — events have no required audience.
+
+```csharp
+// Multiple handlers can react to the same event.
+public class NotificationHandler : IEventHandler<OrderPlaced> { ... }
+public class AuditHandler : IEventHandler<OrderPlaced> { ... }
+public class OrderSaga : IEventHandler<OrderPlaced> { ... } // started by the saga engine
+```
+
+**Use an event when:**
+- Something happened in your domain that other parts of the system may care about
+- You want to decouple the producer from its consumers
+- Multiple downstream systems need to react independently
+- You cannot predict which services will be interested in the future
+
+## Commands
+
+A command is a request to perform a specific action. It has intent and a named target.
+
+```csharp
+public record ProcessPayment(Guid OrderId, decimal Amount) : ICommand;
+public record ReserveStock(Guid OrderId, string Sku, int Quantity) : ICommand;
+public record CancelPayment(Guid OrderId, string Reason) : ICommand;
+```
+
+Commands are routed to a single queue and consumed by exactly one handler. The framework enforces this at startup — registering two `ICommandHandler<ProcessPayment>` implementations throws an `InvalidOperationException`.
+
+```csharp
+// Only one handler allowed per command type.
+public class PaymentCommandHandler : ICommandHandler<ProcessPayment> { ... }
+```
+
+**Use a command when:**
+- You need a specific service to perform a specific action
+- You need clear ownership — one service is responsible for executing the operation
+- You are inside a saga and orchestrating a workflow
+
+## Why the strict separation matters
+
+### Topology maps to intent
+
+Events use publish-subscribe topology: one producer, many consumers. Commands use point-to-point topology: one sender, one receiver. Using the wrong abstraction for the wrong intent leads to subtle bugs:
+
+- Sending a "command" as an event means you cannot guarantee it is handled by exactly one consumer
+- Publishing a "state change" as a command means only one service ever learns about it
+
+The compiler enforces the distinction through `IEvent` and `ICommand` marker interfaces. The framework maps each to the correct broker topology automatically.
+
+### Decoupling
+
+Events give the producing service freedom — it does not need to know who cares. Consumers can be added or removed without touching the producer. Commands do the opposite: the sender explicitly names the recipient service via the queue name, which is intentional for directed operations.
+
+### Causation chain
+
+Both events and commands carry `CorrelationId` (the ID of the originating request) and `CausationId` (the ID of the message that caused this one to be sent). This lets you reconstruct the full chain of events and commands across services in traces and logs.
+
+## Naming conventions
+
+Use **past-tense verbs** for events, **imperative verbs** for commands:
+
+| Good event names | Good command names |
+|---|---|
+| `OrderPlaced` | `ProcessPayment` |
+| `PaymentReceived` | `ReserveStock` |
+| `StockReserved` | `SendConfirmationEmail` |
+| `OrderShipped` | `CancelOrder` |
+
+Avoid generic names like `OrderUpdated` or `DoSomething`. The name should communicate precisely what happened or what is being requested.
+
+## Naming the broker resources
+
+By convention the framework derives broker resource names from the message type name:
+
+| Type | Derived name |
+|---|---|
+| `OrderPlaced` (event) | topic/exchange: `order-placed` |
+| `ProcessPayment` (command) | queue: `process-payment` |
+
+Override the default with `[MessageTopic]` or `[MessageQueue]` attributes:
+
+```csharp
+[MessageTopic("payments.events.order-placed")]
+public record OrderPlaced(Guid OrderId, decimal Total) : IEvent;
+
+[MessageQueue("payments.commands.process-payment")]
+public record ProcessPayment(Guid OrderId, decimal Amount) : ICommand;
+```
+
+## Publishing
+
+Both events and commands are published through `IPublisher`. The interface is the same; the routing is different.
+
+```csharp
+// Fan-out to all IEventHandler<OrderPlaced> registrations.
+await publisher.PublishEventAsync(new OrderPlaced(order.Id, total), ct);
+
+// Point-to-point to the single ICommandHandler<ProcessPayment>.
+await publisher.SendCommandAsync(new ProcessPayment(order.Id, total), ct);
+```
+
+Both calls write to the outbox within the caller's transaction — the actual broker delivery happens asynchronously. See [Outbox Pattern](outbox-pattern.md) for details.

--- a/docs/ddd-aggregates.md
+++ b/docs/ddd-aggregates.md
@@ -1,0 +1,156 @@
+# DDD Aggregates
+
+OpinionatedEventing provides first-class support for the Domain-Driven Design (DDD) pattern of aggregate roots that raise domain events. Domain events are written to the outbox automatically, within the same EF Core `SaveChanges` transaction as the aggregate itself.
+
+## Defining an aggregate root
+
+Extend `AggregateRoot` and call `RaiseDomainEvent` inside your domain methods:
+
+```csharp
+using OpinionatedEventing;
+
+public class Order : AggregateRoot
+{
+    public Guid Id { get; private set; }
+    public decimal Total { get; private set; }
+    public OrderStatus Status { get; private set; }
+
+    private Order() { } // EF Core needs a parameterless constructor
+
+    public static Order Create(decimal total)
+    {
+        var order = new Order
+        {
+            Id = Guid.NewGuid(),
+            Total = total,
+            Status = OrderStatus.Pending
+        };
+        order.RaiseDomainEvent(new OrderPlaced(order.Id, total));
+        return order;
+    }
+
+    public void Cancel(string reason)
+    {
+        if (Status == OrderStatus.Shipped)
+            throw new InvalidOperationException("Cannot cancel a shipped order.");
+
+        Status = OrderStatus.Cancelled;
+        RaiseDomainEvent(new OrderCancelled(Id, reason));
+    }
+}
+```
+
+## Rules for aggregates
+
+**Do call `RaiseDomainEvent` when state changes.** Every meaningful state transition should produce an event that describes what happened.
+
+**Do not inject `IPublisher` into aggregates.** Aggregates must not know about infrastructure. `RaiseDomainEvent` queues the event in memory — the `DomainEventInterceptor` writes it to the outbox.
+
+**Do not call `SaveChanges` inside aggregate methods.** Persistence is the application layer's concern.
+
+**Do keep aggregates pure.** Aggregate methods should change state and raise events — nothing else. No database calls, no HTTP calls, no `async`.
+
+## How domain events reach the outbox
+
+When you call `db.SaveChangesAsync()`, the `DomainEventInterceptor` fires before EF writes to the database:
+
+1. It scans `DbContext.ChangeTracker` for tracked entities that implement `IAggregateRoot`
+2. For each aggregate with pending domain events, it creates an `OutboxMessage` per event
+3. It adds those `OutboxMessage` rows to the change tracker
+4. It calls `aggregate.ClearDomainEvents()` so events are not re-harvested on the next save
+5. EF writes both the aggregate rows and the outbox rows in a single transaction
+
+The entire process is invisible to application code. You write:
+
+```csharp
+var order = Order.Create(total);
+db.Orders.Add(order);
+await db.SaveChangesAsync(ct);
+// ↑ Order row + OutboxMessage(OrderPlaced) committed atomically
+```
+
+## Wiring up the interceptor
+
+Register the interceptor when configuring your `DbContext`:
+
+```csharp
+services.AddDbContext<AppDbContext>((sp, options) =>
+{
+    options.UseSqlServer(connectionString);
+    options.AddInterceptors(sp.GetRequiredService<DomainEventInterceptor>());
+});
+services.AddOpinionatedEventingEntityFramework<AppDbContext>();
+```
+
+The `DomainEventInterceptor` is registered as scoped by `AddOpinionatedEventingEntityFramework`.
+
+## Correlation propagation
+
+Every domain event written to the outbox carries:
+
+- `CorrelationId` — taken from `IMessagingContext.CorrelationId` in the current scope, which is the correlation ID of the inbound message being processed (or a new root ID if initiated from an HTTP request)
+- `CausationId` — taken from `IMessagingContext.CausationId`, linking this event to the message that triggered the current handler
+
+This means the full causal chain is captured in the outbox rows and propagated through the broker to consumers.
+
+## AggregateRoot API
+
+```csharp
+public abstract class AggregateRoot : IAggregateRoot
+{
+    // Queued domain events, cleared after each SaveChanges.
+    public IReadOnlyList<IEvent> DomainEvents { get; }
+
+    // Call inside domain methods to queue a domain event.
+    protected void RaiseDomainEvent(IEvent domainEvent);
+}
+```
+
+`ClearDomainEvents()` is internal — only the framework calls it. Application code should never clear the events list.
+
+## Using IAggregateRoot without the base class
+
+If your aggregate already extends another base class, implement `IAggregateRoot` directly:
+
+```csharp
+public interface IAggregateRoot
+{
+    IReadOnlyList<IEvent> DomainEvents { get; }
+    internal void ClearDomainEvents();
+}
+```
+
+Because `ClearDomainEvents` is `internal`, you will need to provide your own implementation of the domain events list. Consider using the `AggregateRoot` base class whenever possible.
+
+## Multiple aggregates in one transaction
+
+The interceptor scans **all** tracked aggregates. If a single `SaveChanges` modifies multiple aggregates, all their domain events are harvested and written to the outbox atomically:
+
+```csharp
+db.Orders.Add(order);   // raises OrderPlaced
+db.Invoices.Add(invoice); // raises InvoiceCreated
+await db.SaveChangesAsync(ct);
+// Both OutboxMessage rows committed with both entity rows.
+```
+
+## Testing aggregates
+
+Test aggregate logic without a database by inspecting `DomainEvents` directly:
+
+```csharp
+var order = Order.Create(100m);
+
+Assert.Single(order.DomainEvents);
+var evt = Assert.IsType<OrderPlaced>(order.DomainEvents[0]);
+Assert.Equal(100m, evt.Total);
+```
+
+For end-to-end tests that include outbox writes, use `InMemoryOutboxStore`:
+
+```csharp
+services.AddSingleton<IOutboxStore, InMemoryOutboxStore>();
+
+// After SaveChanges:
+var store = sp.GetRequiredService<InMemoryOutboxStore>();
+Assert.Single(store.PendingMessages);
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,195 @@
+# Getting Started
+
+This guide walks you through installing OpinionatedEventing, picking a transport, registering handlers, and publishing your first event end-to-end.
+
+## Prerequisites
+
+- .NET 8, 9, or 10
+- An Azure Service Bus namespace **or** a RabbitMQ broker (or run either locally via [Aspire](local-development.md))
+- Entity Framework Core (for outbox persistence and saga state)
+
+## 1. Install packages
+
+Install the packages you need via NuGet. At minimum you need the core package, the EF Core outbox store, and a transport.
+
+```
+dotnet add package OpinionatedEventing.Core
+dotnet add package OpinionatedEventing.Outbox
+dotnet add package OpinionatedEventing.EntityFramework
+
+# Pick one transport:
+dotnet add package OpinionatedEventing.AzureServiceBus
+dotnet add package OpinionatedEventing.RabbitMQ
+```
+
+For sagas add:
+
+```
+dotnet add package OpinionatedEventing.Sagas
+```
+
+For local development with .NET Aspire:
+
+```
+dotnet add package OpinionatedEventing.Aspire
+```
+
+## 2. Define your messages
+
+Messages are plain C# records. Implement `IEvent` for domain / integration events and `ICommand` for commands.
+
+```csharp
+using OpinionatedEventing;
+
+// An event is something that happened — broadcast to all interested parties.
+public record OrderPlaced(Guid OrderId, decimal Total) : IEvent;
+
+// A command is an instruction directed at one specific handler.
+public record ProcessPayment(Guid OrderId, decimal Amount) : ICommand;
+```
+
+See [Commands vs Events](commands-vs-events.md) for guidance on when to use each.
+
+## 3. Implement handlers
+
+```csharp
+using OpinionatedEventing;
+
+// Multiple handlers can subscribe to the same event.
+public class OrderNotificationHandler : IEventHandler<OrderPlaced>
+{
+    public Task HandleAsync(OrderPlaced @event, CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"Order {@event.OrderId} placed for {@event.Total:C}");
+        return Task.CompletedTask;
+    }
+}
+
+// Exactly one handler per command type — enforced at startup.
+public class PaymentCommandHandler : ICommandHandler<ProcessPayment>
+{
+    public Task HandleAsync(ProcessPayment command, CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"Processing payment of {command.Amount:C} for order {command.OrderId}");
+        return Task.CompletedTask;
+    }
+}
+```
+
+## 4. Configure your DbContext
+
+Add `OutboxMessage` to your `DbContext` and wire up the `DomainEventInterceptor`.
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using OpinionatedEventing.EntityFramework;
+
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyOutboxConfiguration();   // outbox_messages table
+        modelBuilder.ApplySagaStateConfiguration(); // saga_states table (if using sagas)
+    }
+}
+```
+
+Generate and apply an EF migration:
+
+```bash
+dotnet ef migrations add AddOutbox
+dotnet ef database update
+```
+
+## 5. Register services
+
+Wire everything up in `Program.cs` (or `Startup.cs`).
+
+```csharp
+using OpinionatedEventing;
+using OpinionatedEventing.EntityFramework;
+
+// --- Core ---
+var builder = services
+    .AddOpinionatedEventing()
+    .AddHandlersFromAssemblies(Assembly.GetExecutingAssembly())
+    .AddOutbox();
+
+// --- EF Core outbox store ---
+services.AddDbContext<AppDbContext>((sp, options) =>
+{
+    options.UseSqlServer(connectionString);
+    options.AddInterceptors(sp.GetRequiredService<DomainEventInterceptor>());
+});
+services.AddOpinionatedEventingEntityFramework<AppDbContext>();
+
+// --- Transport (choose one) ---
+
+// Azure Service Bus:
+services.AddAzureServiceBusTransport(options =>
+{
+    options.ConnectionString = builder.Configuration["AzureServiceBus:ConnectionString"];
+    options.ServiceName = "order-service"; // becomes the subscription name
+});
+
+// RabbitMQ:
+services.AddRabbitMQTransport(options =>
+{
+    options.ConnectionString = builder.Configuration["RabbitMQ:ConnectionString"];
+    options.ServiceName = "order-service";
+});
+```
+
+You only need one transport — swap them by changing DI registration. No handler code changes required.
+
+## 6. Publish your first event
+
+Inject `IPublisher` wherever you need to emit events or send commands.
+
+```csharp
+public class OrderService(IPublisher publisher, AppDbContext db)
+{
+    public async Task PlaceOrderAsync(decimal total, CancellationToken ct)
+    {
+        var order = new Order { Total = total };
+        db.Orders.Add(order);
+
+        // Write the event to the outbox within the same transaction.
+        await publisher.PublishEventAsync(new OrderPlaced(order.Id, total), ct);
+
+        // One SaveChanges call commits both the Order row and the outbox row atomically.
+        await db.SaveChangesAsync(ct);
+    }
+}
+```
+
+The `OutboxDispatcherWorker` background service picks up the pending message and forwards it to the broker. Your `OrderNotificationHandler` is called on the consumer side.
+
+> **Why not publish directly to the broker?** The outbox pattern guarantees that a message is never lost even if the broker is temporarily unavailable. See [Outbox Pattern](outbox-pattern.md) for details.
+
+## 7. (Optional) Configure the outbox dispatcher
+
+Tune polling and retry behaviour via `OpinionatedEventingOptions`:
+
+```csharp
+services.AddOpinionatedEventing(options =>
+{
+    options.Outbox.PollInterval = TimeSpan.FromSeconds(2);
+    options.Outbox.BatchSize = 100;
+    options.Outbox.MaxAttempts = 5;
+    options.Outbox.ConcurrentWorkers = 2;
+});
+```
+
+## Next steps
+
+| Topic | Guide |
+|---|---|
+| When to use events vs commands | [Commands vs Events](commands-vs-events.md) |
+| How the outbox works internally | [Outbox Pattern](outbox-pattern.md) |
+| Long-running workflows | [Saga Orchestration](sagas-orchestration.md) |
+| Lightweight event-driven choreography | [Saga Choreography](sagas-choreography.md) |
+| Aggregates and domain events | [DDD Aggregates](ddd-aggregates.md) |
+| Local dev with Aspire | [Local Development](local-development.md) |
+| Logging, tracing, and metrics | [Observability](observability.md) |

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -154,7 +154,7 @@ The Aspire dashboard polls `/health` and reflects the status in the resources vi
 
 | Health check | Tag | Condition |
 |---|---|---|
-| Broker connectivity | `live`, `broker` | Unhealthy if broker is unreachable |
+| Broker connectivity | `ready`, `broker` | Unhealthy if broker is unreachable |
 | Outbox backlog | `ready`, `outbox` | Degraded above `OutboxBacklogThreshold` |
 | Saga timeout backlog | `ready`, `saga` | Degraded above `SagaTimeoutBacklogThreshold` |
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,169 @@
+# Local Development
+
+OpinionatedEventing is designed to run locally without any cloud accounts. The `OpinionatedEventing.Aspire` package provides Aspire AppHost extensions that spin up RabbitMQ or the Azure Service Bus emulator as Docker containers, with zero configuration required.
+
+## Prerequisites
+
+- [.NET Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling): `dotnet workload install aspire`
+- Docker Desktop (or compatible container runtime)
+
+## Project structure
+
+An Aspire solution typically has at least two projects:
+
+```
+YourSolution.AppHost/    ← Aspire host (orchestrates resources)
+YourSolution.ApiService/ ← Your application service(s)
+```
+
+Add the Aspire package to the AppHost:
+
+```
+dotnet add package OpinionatedEventing.Aspire
+```
+
+## RabbitMQ
+
+### AppHost setup
+
+```csharp
+// AppHost/Program.cs
+using Aspire.Hosting;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var rabbit = builder.AddRabbitMqMessaging("rabbitmq");
+
+var api = builder.AddProject<Projects.YourSolution_ApiService>("api")
+    .WithReference(rabbit);
+
+builder.Build().Run();
+```
+
+`AddRabbitMqMessaging` starts a RabbitMQ container with the management plugin enabled. It injects a `ConnectionStrings__rabbitmq` environment variable into any project that references it.
+
+### Service setup
+
+In your service project, use `AddRabbitMQTransport` and leave `ConnectionString` unset — the transport auto-discovers it from `IConfiguration["ConnectionStrings:rabbitmq"]`:
+
+```csharp
+services.AddRabbitMQTransport(options =>
+{
+    options.ServiceName = "order-service";
+    options.AutoDeclareTopology = true; // declare exchanges and queues at startup
+});
+```
+
+## Azure Service Bus emulator
+
+### AppHost setup
+
+```csharp
+// AppHost/Program.cs
+using Aspire.Hosting;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var asb = builder.AddAzureServiceBusEmulator("servicebus");
+
+var api = builder.AddProject<Projects.YourSolution_ApiService>("api")
+    .WithReference(asb);
+
+builder.Build().Run();
+```
+
+`AddAzureServiceBusEmulator` starts the Azure Service Bus emulator container and injects its connection string.
+
+### Service setup
+
+```csharp
+services.AddAzureServiceBusTransport(options =>
+{
+    options.ServiceName = "order-service";
+    options.AutoCreateResources = true; // create topics and queues at startup
+});
+```
+
+The transport reads the injected connection string automatically — no manual configuration needed.
+
+## Switching transports
+
+Switching between RabbitMQ and Azure Service Bus requires only a DI change. Handler, aggregate, and saga code is identical for both transports.
+
+A common pattern is to use `IConfiguration` or environment variables to select the transport:
+
+```csharp
+if (builder.Configuration["Transport"] == "AzureServiceBus")
+{
+    services.AddAzureServiceBusTransport(options =>
+    {
+        options.ServiceName = "order-service";
+        options.AutoCreateResources = true;
+    });
+}
+else
+{
+    services.AddRabbitMQTransport(options =>
+    {
+        options.ServiceName = "order-service";
+        options.AutoDeclareTopology = true;
+    });
+}
+```
+
+In `appsettings.Development.json`:
+
+```json
+{
+  "Transport": "RabbitMQ"
+}
+```
+
+## Running locally
+
+```bash
+cd src/YourSolution.AppHost
+dotnet run
+```
+
+The Aspire dashboard opens automatically at `http://localhost:15888`. It shows:
+
+- All running services and their health status
+- Console output per service
+- Distributed traces (if OTel is configured)
+- Resource connection strings
+
+## Health checks
+
+Both transport packages expose health checks via the `OpinionatedEventing.Aspire` extensions:
+
+```csharp
+services.AddHealthChecks()
+    .AddOpinionatedEventingHealthChecks(options =>
+    {
+        options.OutboxBacklogThreshold = 100;
+        options.SagaTimeoutBacklogThreshold = 10;
+    });
+
+app.MapHealthChecks("/health");
+```
+
+The Aspire dashboard polls `/health` and reflects the status in the resources view.
+
+| Health check | Tag | Condition |
+|---|---|---|
+| Broker connectivity | `live`, `broker` | Unhealthy if broker is unreachable |
+| Outbox backlog | `ready`, `outbox` | Degraded above `OutboxBacklogThreshold` |
+| Saga timeout backlog | `ready`, `saga` | Degraded above `SagaTimeoutBacklogThreshold` |
+
+## RabbitMQ management UI
+
+When using `AddRabbitMqMessaging`, the management plugin is enabled. Access the RabbitMQ management UI at:
+
+```
+http://localhost:15672
+```
+
+Default credentials: `guest` / `guest`
+
+Here you can inspect exchanges, queues, bindings, and message rates in real time.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -4,8 +4,10 @@ OpinionatedEventing is designed to run locally without any cloud accounts. The `
 
 ## Prerequisites
 
-- [.NET Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling): `dotnet workload install aspire`
-- Docker Desktop (or compatible container runtime)
+- **.NET 10 SDK** — required for the Aspire AppHost. Service projects can target .NET 8 or later.
+- **A container runtime** — Docker Desktop, Podman, or Rancher Desktop.
+
+> **Note:** From Aspire 9 onwards the separate `dotnet workload install aspire` step is no longer needed. Aspire is now a set of NuGet packages; there is no workload to install. See [aspire.dev](https://aspire.dev/get-started/prerequisites/) for the current prerequisites.
 
 ## Project structure
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -116,7 +116,7 @@ app.MapHealthChecks("/health/live",  new HealthCheckOptions { Predicate = c => c
 app.MapHealthChecks("/health/ready", new HealthCheckOptions { Predicate = c => c.Tags.Contains("ready") });
 ```
 
-Liveness (`/health/live`) fails if the broker is unreachable. Readiness (`/health/ready`) degrades if the outbox or saga timeout backlog grows too large.
+All three built-in checks are tagged `ready`. Broker connectivity belongs on readiness, not liveness: a broker outage is a dependency failure that restarting the process cannot fix. Failing liveness would cause needless container restarts while the broker is down, delaying recovery once it comes back. Failing readiness removes the service from the load balancer until the broker is reachable again, which is the correct behaviour.
 
 ## Correlation and causation IDs
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,148 @@
+# Observability
+
+OpinionatedEventing emits structured logs, distributed traces, and metrics out of the box. All telemetry uses standard .NET abstractions — no Serilog, Seq, or OpenTelemetry package is required in the library itself.
+
+## Logging
+
+The library uses `Microsoft.Extensions.Logging.ILogger<T>`. As long as you configure a logging provider in your host, log output flows automatically.
+
+### What is logged
+
+| Component | Level | Events |
+|---|---|---|
+| `OutboxDispatcherWorker` | `Debug` | Poll cycle start/end, batch size |
+| `OutboxDispatcherWorker` | `Information` | Message dispatched successfully |
+| `OutboxDispatcherWorker` | `Warning` | Dispatch attempt failed (retrying) |
+| `OutboxDispatcherWorker` | `Error` | Message dead-lettered after MaxAttempts |
+| `SagaTimeoutWorker` | `Debug` | Timeout check cycle |
+| `SagaTimeoutWorker` | `Information` | Saga timed out, timeout handler invoked |
+| `SagaTimeoutWorker` | `Error` | Timeout handler threw exception |
+| Transport consumers | `Debug` | Message received |
+| Transport consumers | `Information` | Message handled successfully |
+| Transport consumers | `Error` | Handler threw unhandled exception |
+
+### Configuring log levels
+
+In `appsettings.json`:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "OpinionatedEventing": "Debug"
+    }
+  }
+}
+```
+
+## Distributed tracing
+
+The library uses `System.Diagnostics.ActivitySource`. All activity source names are under the `opinionatedeventing` prefix. Wire them up via the OpenTelemetry SDK:
+
+```csharp
+using OpinionatedEventing.OpenTelemetry;
+
+services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddOpinionatedEventingInstrumentation()
+        .AddOtlpExporter());
+```
+
+### Emitted spans
+
+| Span name | When | Key attributes |
+|---|---|---|
+| `outbox.publish` | `IPublisher` writes to the outbox store | `message.type`, `message.kind`, `correlation.id` |
+| `outbox.dispatch` | `OutboxDispatcherWorker` calls `ITransport.SendAsync` | `message.type`, `message.id`, `attempt.count` |
+| `message.consume` | Transport consumer hands off to handler(s) | `message.type`, `handler.type`, `correlation.id`, `causation.id` |
+| `saga.step` | A saga handler executes | `saga.type`, `saga.status`, `correlation.id` |
+
+Each span carries W3C trace context propagated through the message envelope so traces span service boundaries.
+
+### Viewing traces locally
+
+When using Aspire, the dashboard includes a built-in trace viewer. Traces from all services are aggregated automatically — no additional exporter configuration is needed for local development.
+
+## Metrics
+
+The library uses `System.Diagnostics.Metrics.Meter`. Wire up the metrics provider:
+
+```csharp
+using OpinionatedEventing.OpenTelemetry;
+
+services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddOpinionatedEventingInstrumentation()
+        .AddOtlpExporter());
+```
+
+### Available instruments
+
+| Instrument | Type | Description |
+|---|---|---|
+| `opinionatedeventing.outbox.pending` | Gauge | Current number of pending (unprocessed) outbox messages |
+| `opinionatedeventing.outbox.processed` | Counter | Total messages successfully dispatched to the broker |
+| `opinionatedeventing.outbox.failed` | Counter | Total messages dead-lettered after MaxAttempts |
+| `opinionatedeventing.publish.duration` | Histogram | Time (ms) to write a message to the outbox store |
+| `opinionatedeventing.dispatch.duration` | Histogram | Time (ms) to dispatch a message to the broker |
+| `opinionatedeventing.consume.duration` | Histogram | Time (ms) for the handler to process a message |
+| `opinionatedeventing.saga.active` | Gauge | Current number of active saga instances |
+| `opinionatedeventing.saga.timed_out` | Counter | Total sagas that have timed out |
+
+### Alerting recommendations
+
+| Metric | Alert condition | Meaning |
+|---|---|---|
+| `opinionatedeventing.outbox.pending` | > threshold for > 5 min | Dispatcher is stalled or the broker is unavailable |
+| `opinionatedeventing.outbox.failed` | Rate > 0 | Messages are dead-lettering — investigate errors |
+| `opinionatedeventing.consume.duration` | p99 > SLA | Handler is slow — risk of broker timeout and redelivery |
+| `opinionatedeventing.saga.active` | Growing without bound | Sagas are not completing — check timeouts |
+
+## Health checks
+
+Health checks are the quickest way to surface observability in an operations dashboard:
+
+```csharp
+services.AddHealthChecks()
+    .AddOpinionatedEventingHealthChecks(options =>
+    {
+        options.OutboxBacklogThreshold = 100;    // pending messages before Degraded
+        options.SagaTimeoutBacklogThreshold = 10; // expired sagas before Degraded
+    });
+
+app.MapHealthChecks("/health");
+app.MapHealthChecks("/health/live",  new HealthCheckOptions { Predicate = c => c.Tags.Contains("live") });
+app.MapHealthChecks("/health/ready", new HealthCheckOptions { Predicate = c => c.Tags.Contains("ready") });
+```
+
+Liveness (`/health/live`) fails if the broker is unreachable. Readiness (`/health/ready`) degrades if the outbox or saga timeout backlog grows too large.
+
+## Correlation and causation IDs
+
+Every message carries two identifiers that let you reconstruct the full causal chain across services:
+
+- **CorrelationId** — Set at the entry point (e.g., an HTTP request ID) and propagated through every event and command in the chain. All spans and log entries include this.
+- **CausationId** — The `Id` of the message that caused this one to be sent. Null for root messages. This is how you reconstruct the parent-child relationship between messages.
+
+These IDs are accessible in handlers via `IMessagingContext`:
+
+```csharp
+public class OrderNotificationHandler(IMessagingContext context) : IEventHandler<OrderPlaced>
+{
+    public Task HandleAsync(OrderPlaced @event, CancellationToken ct)
+    {
+        // context.CorrelationId — same across the entire order flow
+        // context.CausationId  — ID of the message that triggered this handler
+        return Task.CompletedTask;
+    }
+}
+```
+
+Log the correlation ID in every handler to make log aggregation trivial:
+
+```csharp
+_logger.LogInformation(
+    "Handling {EventType} for order {OrderId}, correlation={CorrelationId}",
+    nameof(OrderPlaced), @event.OrderId, context.CorrelationId);
+```

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -116,7 +116,11 @@ app.MapHealthChecks("/health/live",  new HealthCheckOptions { Predicate = c => c
 app.MapHealthChecks("/health/ready", new HealthCheckOptions { Predicate = c => c.Tags.Contains("ready") });
 ```
 
-All three built-in checks are tagged `ready`. Broker connectivity belongs on readiness, not liveness: a broker outage is a dependency failure that restarting the process cannot fix. Failing liveness would cause needless container restarts while the broker is down, delaying recovery once it comes back. Failing readiness removes the service from the load balancer until the broker is reachable again, which is the correct behaviour.
+All three built-in checks are tagged `ready`. Broker connectivity belongs on readiness, not liveness: a broker outage is a dependency failure that restarting the process cannot fix — failing liveness would just cause needless container restarts.
+
+**Important limitation for event-driven services:** readiness probes only control the Kubernetes `Service` endpoint, which governs *HTTP* traffic. The broker consumer workers (`RabbitMQConsumerWorker`, `AzureServiceBusConsumerWorker`) are `BackgroundService` instances that pull messages directly from the broker, independent of any load balancer. Failing readiness does **not** pause event consumption.
+
+This means the health checks here are best treated as **observability signals** — surfacing problems in dashboards and triggering alerts — rather than as back-pressure mechanisms. If you need to actually stop a service from consuming events (for example, during an overload situation), you need an explicit mechanism such as scaling down the deployment or pausing the consumer workers in application code.
 
 ## Correlation and causation IDs
 

--- a/docs/outbox-pattern.md
+++ b/docs/outbox-pattern.md
@@ -1,0 +1,161 @@
+# Outbox Pattern
+
+The outbox pattern guarantees that every message your application writes is eventually delivered to the broker — even if the broker is temporarily unavailable when your code runs.
+
+## The problem it solves
+
+Without the outbox, a typical event-publishing flow looks like this:
+
+```
+1. Insert Order row into database
+2. Publish OrderPlaced event to broker
+3. Commit database transaction
+```
+
+This has a critical flaw: steps 1–3 are not atomic. If the broker call in step 2 fails, the Order is saved but no event is published. If the process crashes after step 2 but before step 3, the event is published but the Order is not saved. Either way your data and your messages are out of sync.
+
+## How the outbox solves it
+
+The outbox replaces the direct broker call with a write to an `outbox_messages` table in the same database transaction as your business data:
+
+```
+1. Insert Order row into database
+2. Insert OutboxMessage row into outbox_messages
+3. Commit database transaction  ← both rows commit or neither does
+```
+
+A background `OutboxDispatcherWorker` then reads the pending rows and forwards them to the broker:
+
+```
+4. Worker reads pending OutboxMessage rows
+5. Calls ITransport.SendAsync() for each message
+6. On success: marks message ProcessedAt (delivered)
+7. On failure: increments AttemptCount, retries up to MaxAttempts
+8. After MaxAttempts: marks message FailedAt (dead-letter)
+```
+
+Steps 4–8 can be retried indefinitely. The broker call is idempotent from the outbox's perspective — if the process crashes between step 5 and 6, the worker simply picks up the same row again on the next poll.
+
+## There is no direct publish path
+
+`IPublisher` writes **only** to the outbox. There is intentionally no method to publish directly to the broker. This design choice means:
+
+- You never accidentally bypass the transactional guarantee
+- The outbox is always the source of truth for what needs to be sent
+- The broker being slow, unavailable, or restarted does not affect your write path
+
+## Atomic writes with EF Core
+
+When you use `OpinionatedEventing.EntityFramework`, the outbox write is fully automatic for domain events raised on aggregate roots. The `DomainEventInterceptor` hooks `DbContext.SaveChangesAsync()` and harvests any `IEvent` instances queued on your aggregates:
+
+```csharp
+// Inside your aggregate:
+public void Place(decimal total)
+{
+    Total = total;
+    Status = OrderStatus.Placed;
+    RaiseDomainEvent(new OrderPlaced(Id, total)); // queued, not written yet
+}
+
+// In your application code:
+db.Orders.Add(order);
+order.Place(total);
+await db.SaveChangesAsync(ct);
+// ↑ DomainEventInterceptor fires here, harvests OrderPlaced,
+//   creates OutboxMessage, writes both rows in one transaction.
+```
+
+If you need to publish an event from application code (not from an aggregate), inject `IPublisher`:
+
+```csharp
+await publisher.PublishEventAsync(new OrderPlaced(orderId, total), ct);
+await db.SaveChangesAsync(ct); // commits both the business row and the outbox row
+```
+
+## OutboxMessage structure
+
+Each row in `outbox_messages` contains:
+
+| Column | Purpose |
+|---|---|
+| `Id` | Unique message identifier (Guid) |
+| `MessageType` | Assembly-qualified CLR type name for deserialization |
+| `Payload` | JSON-serialized message body |
+| `MessageKind` | `"Event"` or `"Command"` |
+| `CorrelationId` | Chain identifier propagated from the originating request |
+| `CausationId` | ID of the message that caused this one to be published |
+| `CreatedAt` | When the row was written |
+| `ProcessedAt` | Set when successfully dispatched to the broker |
+| `FailedAt` | Set when MaxAttempts is exhausted (dead-lettered) |
+| `AttemptCount` | Number of dispatch attempts made |
+| `Error` | Last dispatch error message |
+
+## Retry behaviour
+
+The `OutboxDispatcherWorker` retries failed dispatches up to `OutboxOptions.MaxAttempts` (default: 5). Between attempts the worker continues processing other messages — there is no exponential back-off by default, but the `PollInterval` (default: 1 second) acts as a natural delay.
+
+After `MaxAttempts` failures the row is marked as dead-lettered (`FailedAt` is set). Dead-lettered rows are never retried automatically. Use `IOutboxMonitor.GetDeadLetterCountAsync()` to detect accumulation and alert on it.
+
+## Configuring the dispatcher
+
+```csharp
+services.AddOpinionatedEventing(options =>
+{
+    options.Outbox.PollInterval = TimeSpan.FromSeconds(1);   // how often to poll
+    options.Outbox.BatchSize = 50;                           // messages per poll cycle
+    options.Outbox.MaxAttempts = 5;                          // before dead-lettering
+    options.Outbox.ConcurrentWorkers = 1;                    // parallel dispatch workers
+});
+```
+
+Increase `ConcurrentWorkers` to raise throughput. Each worker polls and dispatches independently. The `IOutboxStore` implementation is responsible for ensuring that concurrent workers do not pick up the same message (the EF Core store handles this with row-level locking).
+
+## IOutboxStore
+
+`IOutboxStore` is an abstraction — implementations live in separate packages. The framework ships two:
+
+| Implementation | Package | Purpose |
+|---|---|---|
+| `EFCoreOutboxStore<TDbContext>` | `OpinionatedEventing.EntityFramework` | Production use |
+| `InMemoryOutboxStore` | `OpinionatedEventing.Testing` | Unit and integration tests |
+
+You can implement `IOutboxStore` yourself to support other persistence backends.
+
+## Health monitoring
+
+Use `IOutboxMonitor` to observe the backlog:
+
+```csharp
+public class OutboxHealthEndpoint(IOutboxMonitor monitor)
+{
+    public async Task<int> GetPendingCountAsync(CancellationToken ct)
+        => await monitor.GetPendingCountAsync(ct);
+
+    public async Task<int> GetDeadLetterCountAsync(CancellationToken ct)
+        => await monitor.GetDeadLetterCountAsync(ct);
+}
+```
+
+Or use the built-in health check extension (from `OpinionatedEventing.Aspire`):
+
+```csharp
+services.AddHealthChecks()
+    .AddOpinionatedEventingHealthChecks(options =>
+    {
+        options.OutboxBacklogThreshold = 100; // Degraded above this
+    });
+```
+
+## EF Core migration helpers
+
+Rather than writing migration SQL by hand, use the provided extension methods:
+
+```csharp
+// In your migration's Up() method:
+migrationBuilder.CreateOutboxTable();
+migrationBuilder.CreateSagaStateTable(); // if using sagas
+
+// In your migration's Down() method:
+migrationBuilder.DropOutboxTable();
+migrationBuilder.DropSagaStateTable();
+```

--- a/docs/sagas-choreography.md
+++ b/docs/sagas-choreography.md
@@ -1,0 +1,154 @@
+# Saga Choreography
+
+Choreography is the lighter-weight alternative to orchestration. Instead of a central coordinator that sends commands and waits for responses, each service independently reacts to the events it cares about — no central workflow class, no shared state machine.
+
+`ISagaParticipant<TEvent>` is the building block for choreography in OpinionatedEventing.
+
+## When to use choreography
+
+Use choreography when:
+
+- Each step is genuinely independent — the services do not need to share state
+- You want maximum decoupling: adding a new service is a matter of subscribing to an existing event
+- The workflow has no meaningful timeout or compensation requirements
+- The flow is simple enough to reason about without a central view
+
+Use [orchestration](sagas-orchestration.md) when you need state, timeouts, compensation, or a single place to read the full workflow.
+
+## ISagaParticipant vs IEventHandler
+
+Both `ISagaParticipant<TEvent>` and `IEventHandler<TEvent>` react to events. The difference is context:
+
+| | `IEventHandler<T>` | `ISagaParticipant<T>` |
+|---|---|---|
+| Access to `ISagaContext` | No | Yes |
+| Can send commands via outbox | Via `IPublisher` injection | Via `ctx.SendCommandAsync()` |
+| Can publish events via outbox | Via `IPublisher` injection | Via `ctx.PublishEventAsync()` |
+| Has CorrelationId from chain | Via `IMessagingContext` | Via `ctx.CorrelationId` |
+
+Use `ISagaParticipant<TEvent>` when you need to send commands or publish events as part of a choreographed flow. Use `IEventHandler<TEvent>` for side-effects that don't produce outbound messages.
+
+## Implementing a participant
+
+```csharp
+public class FulfillmentParticipant : ISagaParticipant<PaymentReceived>
+{
+    private readonly IInventoryService _inventory;
+
+    public FulfillmentParticipant(IInventoryService inventory)
+    {
+        _inventory = inventory;
+    }
+
+    public async Task HandleAsync(
+        PaymentReceived @event,
+        ISagaContext ctx,
+        CancellationToken cancellationToken)
+    {
+        // Reserve stock in response to a payment being received.
+        var result = await _inventory.TryReserveAsync(@event.Sku, @event.Quantity, cancellationToken);
+
+        if (result.Success)
+        {
+            await ctx.PublishEventAsync(
+                new StockReserved(ctx.CorrelationId, @event.Sku, result.ReservedQuantity),
+                cancellationToken);
+        }
+        else
+        {
+            await ctx.PublishEventAsync(
+                new StockReservationFailed(ctx.CorrelationId, @event.Sku, result.Reason),
+                cancellationToken);
+        }
+    }
+}
+```
+
+## Registering a participant
+
+```csharp
+services.AddOpinionatedEventingSagas();
+services.AddSagaParticipant<FulfillmentParticipant>();
+```
+
+`AddSagaParticipant<T>` scans the `ISagaParticipant<TEvent>` interface, extracts the event type, and registers the correct subscription internally. The participant is resolved from DI per message — constructor injection works normally.
+
+## ISagaContext in choreography
+
+The `ISagaContext` available in `HandleAsync` provides:
+
+```csharp
+public interface ISagaContext
+{
+    Guid CorrelationId { get; }      // propagated from the incoming event
+
+    Task SendCommandAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : ICommand;
+
+    Task PublishEventAsync<TEvent>(TEvent @event, CancellationToken ct = default)
+        where TEvent : IEvent;
+
+    void Complete(); // no-op in a stateless participant, but available
+}
+```
+
+All messages sent through `ISagaContext` go through the outbox. If the handler throws, none of them are dispatched.
+
+## Choreography vs orchestration: a comparison
+
+Consider the e-commerce flow:
+
+```
+OrderPlaced
+  └── FulfillmentParticipant reacts → sends ReserveStock command
+        └── ReserveStock handled → raises StockReserved
+              └── NotificationHandler reacts → sends email
+```
+
+With orchestration an `OrderSaga` drives every step and persists state between them. With choreography each service reacts in isolation — there is no saga state table and no coordinator.
+
+The choreography version is simpler to write and deploy, but harder to debug across services because there is no single place that holds the full picture of "where is this order in the flow?"
+
+**Rule of thumb:** start with choreography. Introduce orchestration when you need compensation, timeout, or a single audit trail.
+
+## Testing participants
+
+`ISagaParticipant<TEvent>.HandleAsync` receives an `ISagaContext` — a different interface from `IMessagingContext`. The `OpinionatedEventing.Testing` package does not ship a `FakeSagaContext`, so write a minimal one inline for your tests:
+
+```csharp
+using OpinionatedEventing.Sagas;
+
+sealed class TestSagaContext(Guid correlationId) : ISagaContext
+{
+    public Guid CorrelationId { get; } = correlationId;
+    public List<object> SentCommands { get; } = [];
+    public List<object> PublishedEvents { get; } = [];
+
+    public Task SendCommandAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : ICommand
+    {
+        SentCommands.Add(command!);
+        return Task.CompletedTask;
+    }
+
+    public Task PublishEventAsync<TEvent>(TEvent @event, CancellationToken ct = default)
+        where TEvent : IEvent
+    {
+        PublishedEvents.Add(@event!);
+        return Task.CompletedTask;
+    }
+
+    public void Complete() { }
+}
+
+// In your test:
+var ctx = new TestSagaContext(Guid.NewGuid());
+var participant = new FulfillmentParticipant(new FakeInventoryService());
+
+await participant.HandleAsync(
+    new PaymentReceived(orderId, paymentId, "SKU-123", 2),
+    ctx,
+    CancellationToken.None);
+
+Assert.Single(ctx.PublishedEvents.OfType<StockReserved>());
+```

--- a/docs/sagas-orchestration.md
+++ b/docs/sagas-orchestration.md
@@ -1,0 +1,219 @@
+# Saga Orchestration
+
+A saga manages a long-running business process that spans multiple services and messages. The orchestration style uses a central `SagaOrchestrator<TSagaState>` that explicitly coordinates each step — sending commands, reacting to events, handling timeouts, and compensating on failure.
+
+## When to use orchestration
+
+Use orchestration when:
+
+- The workflow has a clear sequence of steps with explicit dependencies
+- You need timeout and compensation logic (rollback on failure)
+- You want a single class that makes the full flow readable
+- The number of participating services is known upfront
+
+For looser coupling where each service reacts to events independently, see [Saga Choreography](sagas-choreography.md).
+
+## Defining a saga
+
+Create a POCO state class and an orchestrator:
+
+```csharp
+// The state is serialized to JSON and persisted between steps.
+public class OrderSagaState
+{
+    public Guid OrderId { get; set; }
+    public Guid? PaymentId { get; set; }
+    public bool PaymentConfirmed { get; set; }
+    public bool StockReserved { get; set; }
+}
+
+public class OrderSaga : SagaOrchestrator<OrderSagaState>
+{
+    protected override void Configure(ISagaBuilder<OrderSagaState> builder)
+    {
+        builder
+            .StartWith<OrderPlaced>(async (evt, state, ctx) =>
+            {
+                state.OrderId = evt.OrderId;
+                await ctx.SendCommandAsync(new ProcessPayment(evt.OrderId, evt.Total));
+            })
+            .Then<PaymentReceived>(async (evt, state, ctx) =>
+            {
+                state.PaymentId = evt.PaymentId;
+                state.PaymentConfirmed = true;
+                await ctx.SendCommandAsync(new ReserveStock(state.OrderId, evt.Sku, evt.Quantity));
+            })
+            .Then<StockReserved>((evt, state, ctx) =>
+            {
+                state.StockReserved = true;
+                ctx.Complete(); // saga is done
+                return Task.CompletedTask;
+            })
+            .CompensateWith<PaymentFailed>(async (evt, state, ctx) =>
+            {
+                // Undo previous steps — run in reverse registration order.
+                await ctx.SendCommandAsync(new CancelPayment(state.OrderId, evt.Reason));
+            })
+            .ExpireAfter(TimeSpan.FromMinutes(30))
+            .OnTimeout(async (state, ctx) =>
+            {
+                await ctx.SendCommandAsync(new CancelPayment(state.OrderId, "Timed out"));
+            });
+    }
+}
+```
+
+## Registering the saga
+
+```csharp
+services.AddOpinionatedEventingSagas();
+services.AddSaga<OrderSaga>();
+```
+
+## How it works
+
+### Starting a saga
+
+When the framework receives an event registered with `StartWith<TEvent>`, it:
+
+1. Creates a new `OrderSagaState` instance
+2. Persists a `SagaState` row with `Status = Active`
+3. Invokes the `StartWith` handler
+4. Saves the updated state
+
+The saga's `CorrelationId` is taken from the incoming event's `CorrelationId`. All subsequent commands and events in the chain carry the same `CorrelationId`, which is how the framework correlates them back to the right saga instance.
+
+### Continuing a saga
+
+When subsequent events arrive (registered with `Then<TEvent>`), the framework:
+
+1. Looks up the existing `SagaState` by `CorrelationId`
+2. Deserializes the persisted `State` JSON back into `TSagaState`
+3. Invokes the handler
+4. Serializes the updated state and persists it
+
+### Completing a saga
+
+Call `ctx.Complete()` inside any handler to mark the saga as `Completed`. No further events will be processed for this instance.
+
+### ISagaContext
+
+The `ISagaContext` passed to every handler provides:
+
+```csharp
+public interface ISagaContext
+{
+    Guid CorrelationId { get; }
+
+    Task SendCommandAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : ICommand;
+
+    Task PublishEventAsync<TEvent>(TEvent @event, CancellationToken ct = default)
+        where TEvent : IEvent;
+
+    void Complete();
+}
+```
+
+All messages sent through `ISagaContext` go through the outbox — they are written atomically with the saga state update.
+
+## Timeout and compensation
+
+### Setting a timeout
+
+```csharp
+builder.ExpireAfter(TimeSpan.FromMinutes(30));
+// or — inject TimeProvider so the clock is controllable in tests
+builder.ExpireAt(timeProvider.GetUtcNow().AddDays(1));
+```
+
+The `SagaTimeoutWorker` background service polls at `SagaOptions.TimeoutCheckInterval` (default: 30 seconds) for sagas whose `ExpiresAt` is in the past and `Status` is still `Active`. It then invokes the `OnTimeout` handler.
+
+### Compensation
+
+Register compensation handlers with `CompensateWith<TEvent>`:
+
+```csharp
+builder.CompensateWith<PaymentFailed>(async (evt, state, ctx) =>
+{
+    await ctx.SendCommandAsync(new CancelPayment(state.OrderId, evt.Reason));
+});
+```
+
+When a compensation event arrives, the framework transitions the saga to `Compensating` and runs the handler. Compensation handlers run in **reverse registration order** — last registered, first executed — so you can undo steps in the correct sequence.
+
+After compensation completes successfully, the saga transitions to `Completed`. On failure during compensation, it transitions to `Failed`.
+
+## Saga status lifecycle
+
+```
+Active
+  ├── ctx.Complete() ──────────────────────→ Completed
+  ├── CompensateWith<T> handler invoked ──→ Compensating
+  │     ├── success ───────────────────────→ Completed
+  │     └── failure ───────────────────────→ Failed
+  └── ExpiresAt reached ───────────────────→ TimedOut
+        └── OnTimeout handler runs
+              └── compensation if needed ──→ Completed / Failed
+```
+
+## Custom correlation
+
+By default the framework correlates events to sagas via the `CorrelationId` in the message envelope. If you need to correlate by a property in the event payload, use `CorrelateBy`:
+
+```csharp
+builder.CorrelateBy<PaymentReceived>(evt => evt.OrderId.ToString());
+```
+
+## Persisting state: EF Core
+
+Saga state is stored in the `saga_states` table. Configure it in your `DbContext`:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.ApplySagaStateConfiguration();
+}
+```
+
+And register the EF Core store:
+
+```csharp
+services.AddOpinionatedEventingEntityFramework<AppDbContext>();
+```
+
+## Full registration example
+
+```csharp
+// Add the saga engine
+services.AddOpinionatedEventingSagas(options =>
+{
+    options.TimeoutCheckInterval = TimeSpan.FromSeconds(30);
+});
+
+// Register each orchestrator
+services.AddSaga<OrderSaga>();
+
+// Register any choreography participants (see sagas-choreography.md)
+services.AddSagaParticipant<FulfillmentParticipant>();
+```
+
+## Testing sagas
+
+Use `InMemorySagaStateStore` from `OpinionatedEventing.Testing` to test saga logic without a database:
+
+```csharp
+var store = new InMemorySagaStateStore();
+services.AddSingleton<ISagaStateStore>(store);
+
+// Publish the starting event and assert on store.States
+```
+
+Use `FakeTimeProvider` to control the clock when testing timeout behaviour:
+
+```csharp
+var clock = new FakeTimeProvider();
+services.AddSingleton<TimeProvider>(clock);
+
+clock.Advance(TimeSpan.FromMinutes(31)); // trigger timeout
+```


### PR DESCRIPTION
## Summary

- Adds `docs/` folder with 8 conceptual guides covering the full library surface
- Updates `README.md` with a library summary, package table, quick-start snippet, and links to the new guides
- XML doc generation (`GenerateDocumentationFile=true`) was already enabled globally; all public/protected members in `src/` have `<summary>` comments

## Guides added

| File | Covers |
|---|---|
| `docs/getting-started.md` | Install, configure, first event end-to-end |
| `docs/commands-vs-events.md` | When to use each, routing rules, naming |
| `docs/outbox-pattern.md` | Write path, dispatch, retry, dead-letter |
| `docs/sagas-orchestration.md` | State, steps, timeouts, compensation, lifecycle |
| `docs/sagas-choreography.md` | `ISagaParticipant`, comparison with orchestration |
| `docs/ddd-aggregates.md` | `AggregateRoot`, `DomainEventInterceptor`, correlation |
| `docs/local-development.md` | Aspire, RabbitMQ container, ASB emulator, health checks |
| `docs/observability.md` | Logging, tracing spans, metrics instruments, alerting |

## Test plan

- [ ] All code snippets in the guides were verified against actual source signatures (`ISagaBuilder<T>`, `ISagaContext`, `ISagaParticipant<T>`, `IPublisher`, `AggregateRoot`)
- [ ] `src/` projects build cleanly: `dotnet build src/<each>` — all 9 succeed
- [ ] No new packages or source changes — docs-only PR

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)