### PR TITLE
fix(ci): use --ignore-exit-code 8 for integration test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       # Integration tests run on net10.0 only to avoid Docker container name conflicts
       # that occur when all three TFM legs run Testcontainers concurrently on the same runner.
       - name: Integration tests (Testcontainers — Docker required, .NET 10 only)
-        if: matrix.tfm == 'net10.0'
+        if: github.event_name == 'push' && matrix.tfm == 'net10.0'
         timeout-minutes: 20
         run: >
           dotnet test --framework ${{ matrix.tfm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,14 @@ jobs:
       # Integration tests run on net10.0 only to avoid Docker container name conflicts
       # that occur when all three TFM legs run Testcontainers concurrently on the same runner.
       - name: Integration tests (Testcontainers — Docker required, .NET 10 only)
-        if: github.event_name == 'push' && matrix.tfm == 'net10.0'
+        if: matrix.tfm == 'net10.0'
         timeout-minutes: 20
-        run: |
-          dotnet test --framework ${{ matrix.tfm }} \
-            --filter-trait "Category=Integration" \
-            --report-trx --results-directory ./TestResults \
-            --coverage --coverage-output-format cobertura
-          result=$?
-          # Exit code 8 = zero tests ran; expected for assemblies with no integration tests
-          [ $result -eq 0 ] || [ $result -eq 8 ] || exit $result
+        run: >
+          dotnet test --framework ${{ matrix.tfm }}
+          --filter-trait "Category=Integration"
+          --ignore-exit-code 8
+          --report-trx --results-directory ./TestResults
+          --coverage --coverage-output-format cobertura
 
       - name: Find coverage reports
         if: matrix.tfm == 'net10.0'


### PR DESCRIPTION
## Summary

- Uses `--ignore-exit-code 8` (MTP native flag) instead of bash workarounds to suppress "zero tests ran" from assemblies with no integration tests
- Integration tests are temporarily enabled on `pull_request` events so this fix can be verified before merging — will be restricted back to `push` (main only) once confirmed

Fixes #54

## Test plan

- [ ] Integration test step passes; `RabbitMQ.Tests` and `AzureServiceBus.Tests` still run and pass
- [ ] Assemblies with no integration tests no longer cause exit code 8 failures
- [ ] After merge: revert `if:` condition back to `push`-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)