### PR TITLE
feat(core): auto-populate logging scope with CorrelationId, CausationId, and MessageType

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.6" />

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -143,10 +143,16 @@ public class OrderNotificationHandler(IMessagingContext context) : IEventHandler
 }
 ```
 
-Log the correlation ID in every handler to make log aggregation trivial:
+### Automatic logging scope
 
-```csharp
-_logger.LogInformation(
-    "Handling {EventType} for order {OrderId}, correlation={CorrelationId}",
-    nameof(OrderPlaced), @event.OrderId, context.CorrelationId);
+`MessageHandlerRunner` calls `ILogger.BeginScope` before invoking handlers, pushing `CorrelationId`, `CausationId`, and `MessageType` as structured properties into the ambient logging scope:
+
+```json
+{
+  "CorrelationId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "CausationId":   "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "MessageType":   "MyApp.Orders.OrderPlaced, MyApp"
+}
 ```
+
+Any `ILogger<T>` used inside a handler automatically inherits these properties — no manual logging required. Logging providers that support structured scopes (OpenTelemetry, Serilog, Application Insights) pick them up and include them on every log entry emitted during handler execution.

--- a/src/OpinionatedEventing.Core/MessageHandlerRunner.cs
+++ b/src/OpinionatedEventing.Core/MessageHandlerRunner.cs
@@ -57,6 +57,13 @@ public sealed class MessageHandlerRunner : IMessageHandlerRunner
             var message = JsonSerializer.Deserialize(payload, type, _options.Value.SerializerOptions)
                 ?? throw new InvalidOperationException($"Deserialised null for type '{messageType}'.");
 
+            using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["CorrelationId"] = correlationId,
+                ["CausationId"] = causationId,
+                ["MessageType"] = messageType,
+            });
+
             switch (messageKind)
             {
                 case "Event":

--- a/tests/OpinionatedEventing.Core.Tests/MessageHandlerRunnerTests.cs
+++ b/tests/OpinionatedEventing.Core.Tests/MessageHandlerRunnerTests.cs
@@ -8,6 +8,50 @@ namespace OpinionatedEventing.Tests;
 
 public sealed class MessageHandlerRunnerTests
 {
+    private sealed class CapturingLoggerProvider : ILoggerProvider, ISupportExternalScope
+    {
+        private IExternalScopeProvider? _scopeProvider;
+        public List<CapturedLogEntry> Entries { get; } = [];
+
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider) => _scopeProvider = scopeProvider;
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, Entries, () => _scopeProvider);
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(
+        string category,
+        List<CapturedLogEntry> entries,
+        Func<IExternalScopeProvider?> getScopeProvider) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            => getScopeProvider()?.Push(state);
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var scopes = new Dictionary<string, object?>();
+            getScopeProvider()?.ForEachScope((scope, acc) =>
+            {
+                if (scope is IEnumerable<KeyValuePair<string, object?>> kvps)
+                    foreach (var kvp in kvps) acc[kvp.Key] = kvp.Value;
+            }, scopes);
+            entries.Add(new CapturedLogEntry(category, scopes));
+        }
+    }
+
+    private sealed record CapturedLogEntry(string Category, Dictionary<string, object?> Scopes);
+
+    private sealed class LoggingEventHandler(ILogger<LoggingEventHandler> logger) : IEventHandler<RunnerEvent>
+    {
+        public Task HandleAsync(RunnerEvent @event, CancellationToken ct)
+        {
+            logger.LogInformation("Handling event {EventId}", @event.Id);
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed record RunnerEvent(Guid Id) : IEvent;
     private sealed record RunnerCommand(Guid Id) : ICommand;
 
@@ -52,11 +96,21 @@ public sealed class MessageHandlerRunnerTests
         }
     }
 
-    private static ServiceProvider BuildProvider(Action<IServiceCollection>? configure = null)
+    private static ServiceProvider BuildProvider(
+        Action<IServiceCollection>? configure = null,
+        ILoggerFactory? loggerFactory = null)
     {
         var services = new ServiceCollection();
-        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
-        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        if (loggerFactory is not null)
+        {
+            services.AddSingleton(loggerFactory);
+            services.AddSingleton(typeof(ILogger<>), typeof(Logger<>));
+        }
+        else
+        {
+            services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        }
         services.AddOpinionatedEventing();
         configure?.Invoke(services);
         return services.BuildServiceProvider();
@@ -240,6 +294,36 @@ public sealed class MessageHandlerRunnerTests
                 Guid.NewGuid(),
                 null,
                 ct));
+    }
+
+    [Fact]
+    public async Task RunAsync_exposes_correlation_causation_and_message_type_in_logging_scope()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var capturingProvider = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(b => b.AddProvider(capturingProvider));
+
+        await using var provider = BuildProvider(
+            s => s.AddScoped<IEventHandler<RunnerEvent>>(
+                sp => new LoggingEventHandler(sp.GetRequiredService<ILogger<LoggingEventHandler>>())),
+            loggerFactory);
+
+        var runner = provider.GetRequiredService<IMessageHandlerRunner>();
+        var correlationId = Guid.NewGuid();
+        var causationId = Guid.NewGuid();
+        var messageType = typeof(RunnerEvent).AssemblyQualifiedName!;
+
+        await runner.RunAsync(
+            messageType, "Event",
+            JsonSerializer.Serialize(new RunnerEvent(Guid.NewGuid())),
+            correlationId, causationId, ct);
+
+        var handlerEntry = capturingProvider.Entries
+            .Single(e => e.Category.Contains(nameof(LoggingEventHandler)));
+
+        Assert.Equal(correlationId, handlerEntry.Scopes["CorrelationId"]);
+        Assert.Equal(causationId, handlerEntry.Scopes["CausationId"]);
+        Assert.Equal(messageType, handlerEntry.Scopes["MessageType"]);
     }
 
     [Fact]

--- a/tests/OpinionatedEventing.Core.Tests/OpinionatedEventing.Core.Tests.csproj
+++ b/tests/OpinionatedEventing.Core.Tests/OpinionatedEventing.Core.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
## Summary

- `MessageHandlerRunner.RunAsync` now calls `ILogger.BeginScope` before dispatching handlers, pushing `CorrelationId`, `CausationId`, and `MessageType` as structured properties into the ambient logging scope
- Any `ILogger<T>` used inside a handler automatically inherits these properties — no manual correlation ID logging required
- `docs/observability.md` updated to remove the manual-logging boilerplate advice and document the automatic scope behaviour
- Unit test added (`RunAsync_exposes_correlation_causation_and_message_type_in_logging_scope`) using a hand-written `CapturingLoggerProvider`/`CapturingLogger` that implements `ISupportExternalScope` to verify scope properties are present on log entries emitted from within a handler

## Test plan

- [x] `dotnet test --project tests/OpinionatedEventing.Core.Tests/OpinionatedEventing.Core.Tests.csproj -f net8.0` — 30/30 pass
- [x] `dotnet test --project tests/OpinionatedEventing.Core.Tests/OpinionatedEventing.Core.Tests.csproj -f net10.0` — 30/30 pass
- [x] New test verifies `CorrelationId`, `CausationId`, and `MessageType` appear in the scope on handler log entries

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)