### PR TITLE
test: improve coverage with Reqnroll specs and ASB integration tests (#59)

### DIFF
--- a/tests/OpinionatedEventing.AzureServiceBus.Specs/Features/AzureServiceBus.feature
+++ b/tests/OpinionatedEventing.AzureServiceBus.Specs/Features/AzureServiceBus.feature
@@ -27,3 +27,20 @@ Feature: AzureServiceBus Transport
     Given the Azure Service Bus transport is registered with ServiceName "order-service"
     When the service provider is built
     Then the ServiceName option is "order-service"
+
+  Scenario: Message naming convention respects explicit MessageQueue attribute
+    Given a command type with a MessageQueue attribute set to "my-custom-queue"
+    When I resolve the queue name
+    Then the queue name is "my-custom-queue"
+
+  Scenario: Default AzureServiceBusOptions has expected values
+    Given the Azure Service Bus transport is registered with a connection string
+    When the service provider is built
+    Then the default MaxDeliveryCount is 5
+    And the default MaxConcurrentCalls is 1
+    And sessions are disabled by default
+
+  Scenario: Transport registration with FullyQualifiedNamespace wires up ITransport
+    Given the Azure Service Bus transport is registered with FullyQualifiedNamespace "mybus.servicebus.windows.net"
+    When the service provider is built
+    Then ITransport is registered in the container

--- a/tests/OpinionatedEventing.AzureServiceBus.Specs/StepDefinitions/AzureServiceBusSteps.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Specs/StepDefinitions/AzureServiceBusSteps.cs
@@ -74,6 +74,26 @@ public sealed class AzureServiceBusSteps
         });
     }
 
+    [Given("a command type with a MessageQueue attribute set to {string}")]
+    public void GivenACommandTypeWithMessageQueueAttribute(string _)
+    {
+        _messageType = typeof(CustomQueueCommand);
+    }
+
+    [Given("the Azure Service Bus transport is registered with FullyQualifiedNamespace {string}")]
+    public void GivenTransportRegisteredWithFullyQualifiedNamespace(string fqns)
+    {
+        _services = new ServiceCollection();
+        _services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        _services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        _services.AddOpinionatedEventing();
+        _services.AddAzureServiceBusTransport(o =>
+        {
+            o.FullyQualifiedNamespace = fqns;
+            o.ServiceName = "test-service";
+        });
+    }
+
     // --- When ---
 
     [When("I resolve the topic name")]
@@ -121,6 +141,27 @@ public sealed class AzureServiceBusSteps
         Xunit.Assert.Equal(expected, opts.ServiceName);
     }
 
+    [Then("the default MaxDeliveryCount is {int}")]
+    public void ThenDefaultMaxDeliveryCountIs(int expected)
+    {
+        var opts = _serviceProvider!.GetRequiredService<IOptions<AzureServiceBusOptions>>().Value;
+        Xunit.Assert.Equal(expected, opts.MaxDeliveryCount);
+    }
+
+    [Then("the default MaxConcurrentCalls is {int}")]
+    public void ThenDefaultMaxConcurrentCallsIs(int expected)
+    {
+        var opts = _serviceProvider!.GetRequiredService<IOptions<AzureServiceBusOptions>>().Value;
+        Xunit.Assert.Equal(expected, opts.MaxConcurrentCalls);
+    }
+
+    [Then("sessions are disabled by default")]
+    public void ThenSessionsAreDisabledByDefault()
+    {
+        var opts = _serviceProvider!.GetRequiredService<IOptions<AzureServiceBusOptions>>().Value;
+        Xunit.Assert.False(opts.EnableSessions);
+    }
+
     // --- message types ---
 
     private sealed record OrderPlaced(string OrderId = "") : IEvent;
@@ -128,4 +169,7 @@ public sealed class AzureServiceBusSteps
 
     [MessageTopic("my-custom-topic")]
     private sealed record CustomTopicEvent : IEvent;
+
+    [MessageQueue("my-custom-queue")]
+    private sealed record CustomQueueCommand : ICommand;
 }

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
@@ -1,8 +1,10 @@
 #nullable enable
 
+using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpinionatedEventing.AzureServiceBus.Attributes;
 using OpinionatedEventing.AzureServiceBus.Tests.TestSupport;
 using OpinionatedEventing.Outbox;
 using OpinionatedEventing.Testing;
@@ -80,6 +82,133 @@ public sealed class AzureServiceBusIntegrationTests
     }
 
     [Fact]
+    public async Task Session_enabled_command_is_consumed_via_session_processor()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var received = new List<CheckoutOrder>();
+
+        using var host = BuildHost(
+            services =>
+            {
+                services.AddScoped<ICommandHandler<CheckoutOrder>>(_ =>
+                    new CapturingCommandHandler<CheckoutOrder>(received));
+            },
+            enableSessions: true);
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new CheckoutOrder("checkout-1"), "Command"), ct);
+
+        await WaitForConditionAsync(() => received.Count == 1, ct);
+
+        Assert.Single(received);
+        Assert.Equal("checkout-1", received[0].CheckoutId);
+
+        await host.StopAsync(ct);
+    }
+
+    [Fact]
+    public async Task Message_without_required_properties_is_dead_lettered_without_invoking_handler()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var received = new List<OrderPlaced>();
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ =>
+                new CapturingEventHandler<OrderPlaced>(received));
+        });
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        // Send a raw message with no OpinionatedEventing application properties.
+        var client = host.Services.GetRequiredService<ServiceBusClient>();
+        await using var sender = client.CreateSender("order-placed");
+        await sender.SendMessageAsync(new ServiceBusMessage("{\"OrderId\":\"raw\"}"), ct);
+
+        // Allow time for the message to be processed; handler must NOT be invoked.
+        await Task.Delay(2_000, ct);
+        Assert.Empty(received);
+
+        await host.StopAsync(ct);
+    }
+
+    [Fact]
+    public async Task Topology_initializer_is_idempotent_when_resources_already_exist()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // First host: creates topics, subscriptions, and queues.
+        using (var first = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ =>
+                new CapturingEventHandler<OrderPlaced>(new List<OrderPlaced>()));
+            services.AddScoped<ICommandHandler<ProcessPayment>>(_ =>
+                new CapturingCommandHandler<ProcessPayment>(new List<ProcessPayment>()));
+        }))
+        {
+            await first.StartAsync(ct);
+            await first.StopAsync(ct);
+        }
+
+        // Second host: same handlers — topology initializer must hit "already exists" branches
+        // on every resource without throwing.
+        using var second = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ =>
+                new CapturingEventHandler<OrderPlaced>(new List<OrderPlaced>()));
+            services.AddScoped<ICommandHandler<ProcessPayment>>(_ =>
+                new CapturingCommandHandler<ProcessPayment>(new List<ProcessPayment>()));
+        });
+
+        var ex = await Record.ExceptionAsync(() => second.StartAsync(ct));
+        Assert.Null(ex);
+        await second.StopAsync(ct);
+    }
+
+    [Fact]
+    public async Task Dead_lettered_message_with_causation_id_records_causation_id_in_outbox()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var outboxStore = new InMemoryOutboxStore();
+        var causationId = Guid.NewGuid();
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ => new ThrowingHandler<OrderPlaced>());
+            services.AddSingleton<IOutboxStore>(outboxStore);
+        }, maxDeliveryCount: 1);
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var payload = new OrderPlaced("causal-order");
+        var msg = new OutboxMessage
+        {
+            Id = Guid.NewGuid(),
+            MessageType = typeof(OrderPlaced).AssemblyQualifiedName!,
+            MessageKind = "Event",
+            Payload = System.Text.Json.JsonSerializer.Serialize(payload),
+            CorrelationId = Guid.NewGuid(),
+            CausationId = causationId,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(msg, ct);
+
+        await WaitForConditionAsync(() => outboxStore.Messages.Any(m => m.FailedAt.HasValue), ct);
+
+        var deadLetter = outboxStore.Messages.Single(m => m.FailedAt.HasValue);
+        Assert.Equal(causationId, deadLetter.CausationId);
+
+        await host.StopAsync(ct);
+    }
+
+    [Fact]
     public async Task Dead_lettered_message_is_recorded_in_outbox()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -107,7 +236,10 @@ public sealed class AzureServiceBusIntegrationTests
 
     // --- helpers ---
 
-    private IHost BuildHost(Action<IServiceCollection>? configureExtra = null, int maxDeliveryCount = 5)
+    private IHost BuildHost(
+        Action<IServiceCollection>? configureExtra = null,
+        int maxDeliveryCount = 5,
+        bool enableSessions = false)
         => Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
@@ -124,6 +256,7 @@ public sealed class AzureServiceBusIntegrationTests
                     o.ServiceName = "test-service";
                     o.AutoCreateResources = true;
                     o.MaxDeliveryCount = maxDeliveryCount;
+                    o.EnableSessions = enableSessions;
                 });
                 configureExtra?.Invoke(services);
             })
@@ -153,6 +286,9 @@ public sealed class AzureServiceBusIntegrationTests
 
     private sealed record OrderPlaced(string OrderId) : IEvent;
     private sealed record ProcessPayment(string PaymentId, decimal Amount) : ICommand;
+
+    [SessionEnabled]
+    private sealed record CheckoutOrder(string CheckoutId) : ICommand;
 
     // --- handler implementations ---
 

--- a/tests/OpinionatedEventing.EntityFramework.Specs/Features/EntityFramework.feature
+++ b/tests/OpinionatedEventing.EntityFramework.Specs/Features/EntityFramework.feature
@@ -31,3 +31,31 @@ Feature: EntityFramework EF Core integration
     When the message is marked as failed
     And pending messages are queried
     Then no pending messages are returned
+
+  Scenario: New saga state is saved and can be found by saga type and correlation ID
+    Given a new saga state for type "SpecsOrderSaga" with correlation ID "order-123"
+    When the saga state is saved via EFCoreSagaStateStore
+    Then the saga state can be found by type "SpecsOrderSaga" and correlation ID "order-123"
+
+  Scenario: Saga state update is reflected when found again
+    Given a new saga state for type "SpecsOrderSaga" with correlation ID "order-456"
+    And the saga state is saved via EFCoreSagaStateStore
+    When the saga state status is updated to Completed
+    Then the found saga state has status Completed
+
+  Scenario: Unknown saga type and correlation ID returns null
+    When a saga state is looked up with type "UnknownSaga" and correlation ID "none"
+    Then the found saga state is null
+
+  Scenario: Expired active saga state is included in the expired batch
+    Given a new saga state for type "SpecsOrderSaga" with correlation ID "order-789"
+    And the saga state expires in the past
+    When the saga state is saved via EFCoreSagaStateStore
+    Then the expired saga query returns the saga state
+
+  Scenario: Completed saga state is excluded from the expired batch
+    Given a new saga state for type "SpecsOrderSaga" with correlation ID "order-completed"
+    And the saga state expires in the past
+    And the saga state status is Completed
+    When the saga state is saved via EFCoreSagaStateStore
+    Then the expired saga query returns no results

--- a/tests/OpinionatedEventing.EntityFramework.Specs/StepDefinitions/EntityFrameworkSteps.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Specs/StepDefinitions/EntityFrameworkSteps.cs
@@ -2,11 +2,13 @@
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpinionatedEventing;
 using OpinionatedEventing.EntityFramework;
 using OpinionatedEventing.Options;
 using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Sagas;
 using Reqnroll;
 
 namespace OpinionatedEventing.EntityFramework.Specs.StepDefinitions;
@@ -22,6 +24,14 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
     private Guid _correlationId;
     private SpecsTestOrder? _order;
 
+    // --- saga state store fields ---
+    private ServiceProvider? _sagaServiceProvider;
+    private IServiceScope? _sagaScope;
+    private ISagaStateStore? _sagaStore;
+    private SagaState? _sagaState;
+    private SagaState? _foundSagaState;
+    private IReadOnlyList<SagaState>? _expiredSagaStates;
+
     // --- Given ---
 
     [Given("an order aggregate with a pending domain event")]
@@ -34,6 +44,40 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
     public void GivenKnownCorrelationId()
     {
         _correlationId = Guid.NewGuid();
+    }
+
+    [Given("a new saga state for type {string} with correlation ID {string}")]
+    public void GivenNewSagaState(string sagaType, string correlationId)
+    {
+        _sagaState = new SagaState
+        {
+            Id = Guid.NewGuid(),
+            SagaType = sagaType,
+            CorrelationId = correlationId,
+            State = "{}",
+            Status = SagaStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        _sagaStore ??= GetOrCreateSagaStore();
+    }
+
+    [Given("the saga state expires in the past")]
+    public void GivenSagaStateExpiresInThePast()
+    {
+        _sagaState!.ExpiresAt = DateTimeOffset.UtcNow.AddDays(-1);
+    }
+
+    [Given("the saga state status is Completed")]
+    public void GivenSagaStateStatusIsCompleted()
+    {
+        _sagaState!.Status = SagaStatus.Completed;
+    }
+
+    [Given("the saga state is saved via EFCoreSagaStateStore")]
+    public async Task GivenSagaStateSaved()
+    {
+        await _sagaStore!.SaveAsync(_sagaState!);
     }
 
     [Given("a message is staged and committed via EFCoreOutboxStore")]
@@ -85,6 +129,26 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
         await _store!.MarkFailedAsync(_savedMessage!.Id, "test error");
     }
 
+    [When("the saga state is saved via EFCoreSagaStateStore")]
+    public async Task WhenSagaStateSaved()
+    {
+        await _sagaStore!.SaveAsync(_sagaState!);
+    }
+
+    [When("the saga state status is updated to Completed")]
+    public async Task WhenSagaStateStatusUpdatedToCompleted()
+    {
+        _sagaState!.Status = SagaStatus.Completed;
+        await _sagaStore!.UpdateAsync(_sagaState);
+    }
+
+    [When("a saga state is looked up with type {string} and correlation ID {string}")]
+    public async Task WhenSagaStateLookedUp(string sagaType, string correlationId)
+    {
+        _sagaStore ??= GetOrCreateSagaStore();
+        _foundSagaState = await _sagaStore.FindAsync(sagaType, correlationId);
+    }
+
     // --- Then ---
 
     [Then("one outbox message with kind {string} is written to the database")]
@@ -122,14 +186,63 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
         Xunit.Assert.Empty(_pendingMessages!);
     }
 
+    [Then("the saga state can be found by type {string} and correlation ID {string}")]
+    public async Task ThenSagaStateCanBeFound(string sagaType, string correlationId)
+    {
+        _foundSagaState = await _sagaStore!.FindAsync(sagaType, correlationId);
+        Xunit.Assert.NotNull(_foundSagaState);
+        Xunit.Assert.Equal(sagaType, _foundSagaState.SagaType);
+        Xunit.Assert.Equal(correlationId, _foundSagaState.CorrelationId);
+    }
+
+    [Then("the found saga state has status Completed")]
+    public async Task ThenFoundSagaStateHasStatusCompleted()
+    {
+        var found = await _sagaStore!.FindAsync(_sagaState!.SagaType, _sagaState.CorrelationId);
+        Xunit.Assert.Equal(SagaStatus.Completed, found!.Status);
+    }
+
+    [Then("the found saga state is null")]
+    public void ThenFoundSagaStateIsNull()
+    {
+        Xunit.Assert.Null(_foundSagaState);
+    }
+
+    [Then("the expired saga query returns the saga state")]
+    public async Task ThenExpiredSagaQueryReturnsState()
+    {
+        _expiredSagaStates = await _sagaStore!.GetExpiredAsync(DateTimeOffset.UtcNow);
+        Xunit.Assert.Contains(_expiredSagaStates, s => s.CorrelationId == _sagaState!.CorrelationId);
+    }
+
+    [Then("the expired saga query returns no results")]
+    public async Task ThenExpiredSagaQueryReturnsNoResults()
+    {
+        _expiredSagaStates = await _sagaStore!.GetExpiredAsync(DateTimeOffset.UtcNow);
+        Xunit.Assert.Empty(_expiredSagaStates);
+    }
+
     // --- IAsyncDisposable ---
 
     public async ValueTask DisposeAsync()
     {
         if (_context is not null) await _context.DisposeAsync();
+        _sagaScope?.Dispose();
+        if (_sagaServiceProvider is not null) await _sagaServiceProvider.DisposeAsync();
     }
 
     // --- private helpers ---
+
+    private ISagaStateStore GetOrCreateSagaStore()
+    {
+        var sagaDbName = _databaseName + "-saga";
+        var services = new ServiceCollection();
+        services.AddDbContext<SpecsSagaDbContext>(opts => opts.UseInMemoryDatabase(sagaDbName));
+        services.AddOpinionatedEventingEntityFramework<SpecsSagaDbContext>();
+        _sagaServiceProvider = services.BuildServiceProvider(validateScopes: true);
+        _sagaScope = _sagaServiceProvider.CreateScope();
+        return _sagaScope.ServiceProvider.GetRequiredService<ISagaStateStore>();
+    }
 
     private SpecsDbContext GetOrCreateContext()
     {
@@ -189,6 +302,17 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
                 b.HasKey(o => o.Id);
                 b.Ignore(o => o.DomainEvents);
             });
+        }
+    }
+
+    private sealed class SpecsSagaDbContext : DbContext
+    {
+        public SpecsSagaDbContext(DbContextOptions<SpecsSagaDbContext> options) : base(options) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyOutboxConfiguration();
+            modelBuilder.ApplySagaStateConfiguration();
         }
     }
 }

--- a/tests/OpinionatedEventing.Sagas.Specs/Features/Sagas.feature
+++ b/tests/OpinionatedEventing.Sagas.Specs/Features/Sagas.feature
@@ -22,3 +22,20 @@ Feature: Saga Orchestration
     When a PaymentFailed event is dispatched
     Then the saga status is Completed
     And the saga instance state shows payment was not processed
+
+  Scenario: Choreography participant reacts to an event and sends a command
+    Given the notification participant is registered
+    When an OrderShipped event is dispatched
+    Then the notification participant command was published
+
+  Scenario: Saga with a timeout handler fires when an expired saga is processed
+    Given the order saga with timeout is registered
+    When an OrderPlaced event is dispatched
+    And the saga timeout worker processes expired sagas
+    Then the saga timeout handler was invoked
+
+  Scenario: Saga with custom correlation routes events by the custom key
+    Given the order saga with custom correlation is registered
+    When an OrderPlaced event is dispatched with custom correlation key "custom-key-1"
+    And a PaymentReceived event is dispatched with custom correlation key "custom-key-1"
+    Then the saga instance state shows payment was processed

--- a/tests/OpinionatedEventing.Sagas.Specs/StepDefinitions/SagasSteps.cs
+++ b/tests/OpinionatedEventing.Sagas.Specs/StepDefinitions/SagasSteps.cs
@@ -2,9 +2,11 @@
 
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpinionatedEventing.Sagas;
+using OpinionatedEventing.Sagas.Options;
 using OpinionatedEventing.Testing;
 using Reqnroll;
 
@@ -16,8 +18,10 @@ public sealed class SagasSteps : IAsyncDisposable
     private Guid _correlationId;
     private ISagaDispatcher? _dispatcher;
     private InMemorySagaStateStore? _store;
+    private FakePublisher? _publisher;
     private ServiceProvider? _root;
     private IServiceScope? _scope;
+    private SpecsTimeoutSignal? _timeoutSignal;
 
     // --- Given ---
 
@@ -25,8 +29,38 @@ public sealed class SagasSteps : IAsyncDisposable
     public void GivenOrderSagaIsRegistered()
     {
         _correlationId = Guid.NewGuid();
-        (_dispatcher, _store, _root, _scope) = BuildHarness(svc =>
+        (_dispatcher, _store, _publisher, _root, _scope) = BuildHarness(svc =>
             svc.AddSaga<SpecsOrderSaga>());
+    }
+
+    [Given("the notification participant is registered")]
+    public void GivenNotificationParticipantIsRegistered()
+    {
+        _correlationId = Guid.NewGuid();
+        (_dispatcher, _store, _publisher, _root, _scope) = BuildHarness(svc =>
+            svc.AddSagaParticipant<SpecsNotificationParticipant>());
+    }
+
+    [Given("the order saga with timeout is registered")]
+    public void GivenOrderSagaWithTimeoutIsRegistered()
+    {
+        _correlationId = Guid.NewGuid();
+        _timeoutSignal = new SpecsTimeoutSignal();
+        (_dispatcher, _store, _publisher, _root, _scope) = BuildHarness(
+            svc =>
+            {
+                svc.AddSingleton(_timeoutSignal);
+                svc.AddSaga<SpecsTimeoutOrderSaga>();
+            },
+            timeoutInterval: TimeSpan.FromMilliseconds(10));
+    }
+
+    [Given("the order saga with custom correlation is registered")]
+    public void GivenOrderSagaWithCustomCorrelationIsRegistered()
+    {
+        _correlationId = Guid.NewGuid();
+        (_dispatcher, _store, _publisher, _root, _scope) = BuildHarness(svc =>
+            svc.AddSaga<SpecsCustomCorrelationSaga>());
     }
 
     [Given("an OrderPlaced event has been dispatched")]
@@ -57,6 +91,47 @@ public sealed class SagasSteps : IAsyncDisposable
     {
         await _dispatcher!.DispatchAsync(
             new SpecsPaymentFailed { CorrelationId = _correlationId });
+    }
+
+    [When("an OrderShipped event is dispatched")]
+    public async Task WhenOrderShippedEventDispatched()
+    {
+        await _dispatcher!.DispatchAsync(
+            new SpecsOrderShipped { CorrelationId = _correlationId });
+    }
+
+    [When("the saga timeout worker processes expired sagas")]
+    public async Task WhenSagaTimeoutWorkerProcessesExpiredSagas()
+    {
+        // Force the saga state to appear expired so the worker picks it up immediately.
+        var existingState = _store!.States.FirstOrDefault();
+        if (existingState is not null)
+        {
+            existingState.ExpiresAt = DateTimeOffset.UtcNow.AddDays(-1);
+            await _store.UpdateAsync(existingState);
+        }
+
+        var worker = _root!.GetServices<IHostedService>().OfType<SagaTimeoutWorker>().First();
+        await worker.StartAsync(CancellationToken.None);
+
+        // Poll until the timeout handler fires or 5 s elapses.
+        for (var i = 0; i < 500 && _timeoutSignal?.Fired != true; i++)
+            await Task.Delay(10);
+
+        // StopAsync cancels the internal _stoppingCts that ExecuteAsync uses.
+        await worker.StopAsync(CancellationToken.None);
+    }
+
+    [When("an OrderPlaced event is dispatched with custom correlation key {string}")]
+    public async Task WhenOrderPlacedWithCustomCorrelation(string key)
+    {
+        await _dispatcher!.DispatchAsync(new SpecsCustomOrderPlaced { CustomKey = key });
+    }
+
+    [When("a PaymentReceived event is dispatched with custom correlation key {string}")]
+    public async Task WhenPaymentReceivedWithCustomCorrelation(string key)
+    {
+        await _dispatcher!.DispatchAsync(new SpecsCustomPaymentReceived { CustomKey = key });
     }
 
     // --- Then ---
@@ -94,6 +169,19 @@ public sealed class SagasSteps : IAsyncDisposable
         Xunit.Assert.False(state!.PaymentProcessed);
     }
 
+    [Then("the notification participant command was published")]
+    public void ThenNotificationParticipantCommandWasPublished()
+    {
+        Xunit.Assert.Single(_publisher!.SentCommands);
+        Xunit.Assert.IsType<SpecsSendNotification>(_publisher.SentCommands[0]);
+    }
+
+    [Then("the saga timeout handler was invoked")]
+    public void ThenSagaTimeoutHandlerWasInvoked()
+    {
+        Xunit.Assert.True(_timeoutSignal?.Fired);
+    }
+
     // --- IAsyncDisposable ---
 
     public async ValueTask DisposeAsync()
@@ -104,8 +192,9 @@ public sealed class SagasSteps : IAsyncDisposable
 
     // --- private helpers ---
 
-    private static (ISagaDispatcher, InMemorySagaStateStore, ServiceProvider, IServiceScope) BuildHarness(
-        Action<IServiceCollection> configure)
+    private (ISagaDispatcher, InMemorySagaStateStore, FakePublisher, ServiceProvider, IServiceScope) BuildHarness(
+        Action<IServiceCollection> configure,
+        TimeSpan? timeoutInterval = null)
     {
         var store = new InMemorySagaStateStore();
         var publisher = new FakePublisher();
@@ -117,14 +206,18 @@ public sealed class SagasSteps : IAsyncDisposable
         services.AddSingleton(
             typeof(ILogger<SagaTimeoutWorker>),
             NullLogger<SagaTimeoutWorker>.Instance);
-        services.AddOpinionatedEventingSagas();
+        services.AddOpinionatedEventingSagas(opts =>
+        {
+            if (timeoutInterval.HasValue)
+                opts.TimeoutCheckInterval = timeoutInterval.Value;
+        });
         configure(services);
 
         var root = services.BuildServiceProvider(validateScopes: true);
         var scope = root.CreateScope();
         var dispatcher = scope.ServiceProvider.GetRequiredService<ISagaDispatcher>();
 
-        return (dispatcher, store, root, scope);
+        return (dispatcher, store, publisher, root, scope);
     }
 
     // --- inner saga types ---
@@ -186,6 +279,91 @@ public sealed class SagasSteps : IAsyncDisposable
         {
             ctx.Complete();
             return Task.CompletedTask;
+        }
+    }
+
+    // --- choreography participant types ---
+
+    private sealed record SpecsOrderShipped : IEvent
+    {
+        public Guid CorrelationId { get; init; }
+    }
+
+    private sealed record SpecsSendNotification : ICommand
+    {
+        public Guid OrderId { get; init; }
+    }
+
+    private sealed class SpecsNotificationParticipant : ISagaParticipant<SpecsOrderShipped>
+    {
+        public Task HandleAsync(SpecsOrderShipped @event, ISagaContext ctx, CancellationToken cancellationToken)
+            => ctx.SendCommandAsync(new SpecsSendNotification { OrderId = @event.CorrelationId }, cancellationToken);
+    }
+
+    // --- timeout saga types ---
+
+    private sealed class SpecsTimeoutSignal
+    {
+        public bool Fired { get; set; }
+    }
+
+    private sealed class SpecsTimeoutOrderSagaState
+    {
+        public bool TimedOut { get; set; }
+    }
+
+    private sealed class SpecsTimeoutOrderSaga : SagaOrchestrator<SpecsTimeoutOrderSagaState>
+    {
+        private readonly SpecsTimeoutSignal _signal;
+
+        public SpecsTimeoutOrderSaga(SpecsTimeoutSignal signal) => _signal = signal;
+
+        protected override void Configure(ISagaBuilder<SpecsTimeoutOrderSagaState> builder)
+        {
+            builder
+                .StartWith<SpecsOrderPlaced>((_, _, _) => Task.CompletedTask)
+                .ExpireAfter(TimeSpan.FromMilliseconds(1))
+                .OnTimeout((state, ctx) =>
+                {
+                    state.TimedOut = true;
+                    _signal.Fired = true;
+                    ctx.Complete();
+                    return Task.CompletedTask;
+                });
+        }
+    }
+
+    // --- custom correlation saga types ---
+
+    private sealed record SpecsCustomOrderPlaced : IEvent
+    {
+        public string CustomKey { get; init; } = string.Empty;
+    }
+
+    private sealed record SpecsCustomPaymentReceived : IEvent
+    {
+        public string CustomKey { get; init; } = string.Empty;
+    }
+
+    private sealed class SpecsCustomCorrelationSagaState
+    {
+        public bool PaymentProcessed { get; set; }
+    }
+
+    private sealed class SpecsCustomCorrelationSaga : SagaOrchestrator<SpecsCustomCorrelationSagaState>
+    {
+        protected override void Configure(ISagaBuilder<SpecsCustomCorrelationSagaState> builder)
+        {
+            builder
+                .StartWith<SpecsCustomOrderPlaced>((_, _, _) => Task.CompletedTask)
+                .Then<SpecsCustomPaymentReceived>((_, state, ctx) =>
+                {
+                    state.PaymentProcessed = true;
+                    ctx.Complete();
+                    return Task.CompletedTask;
+                })
+                .CorrelateBy<SpecsCustomOrderPlaced>(e => e.CustomKey)
+                .CorrelateBy<SpecsCustomPaymentReceived>(e => e.CustomKey);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **EntityFramework.Specs** — 5 new Reqnroll scenarios covering `EFCoreSagaStateStore`: save/find, update, null lookup, expired-active batch, completed-excluded batch
- **Sagas.Specs** — 3 new scenarios: choreography participant (`ISagaParticipant`), saga timeout worker firing, custom `CorrelateBy` expression
- **AzureServiceBus.Specs** — 3 new scenarios: `MessageQueueAttribute` override, `AzureServiceBusOptions` defaults, `FullyQualifiedNamespace` registration
- **AzureServiceBus.Tests** — 4 new `[Category=Integration]` tests: session-enabled command via session processor, missing-properties dead-letter, topology idempotency (all "already exists" branches), `CausationId` round-trip through transport and outbox

## Test plan

- [ ] `dotnet test` (non-integration) — all 24 new specs pass across net8/net10
- [ ] `dotnet test -- --filter-trait "Category=Integration"` — all 7 ASB integration tests pass (requires Docker)
- [ ] No new warnings with `TreatWarningsAsErrors=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)