### PR TITLE
fix(deps): bump OpenTelemetry to 1.15.3 (GHSA-g94r-2vxg-569j)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
 
   <!-- OpenTelemetry -->
   <ItemGroup>
-    <PackageVersion Include="OpenTelemetry" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
   </ItemGroup>
 
   <!-- Aspire -->


### PR DESCRIPTION
## Summary

- Bumps `OpenTelemetry` from `1.15.2` → `1.15.3` in `Directory.Packages.props`
- Resolves moderate severity vulnerability **GHSA-g94r-2vxg-569j** (CVE-2026-40894) in `OpenTelemetry.Api` and `OpenTelemetry.Extensions.Propagators`
- Advisory: https://github.com/advisories/GHSA-g94r-2vxg-569j

## Test plan

- [ ] `dotnet restore` completes without NU1902 warning-as-error
- [ ] All unit tests pass (no behaviour change — this is a patch-level bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)