### PR TITLE
fix: resolve MSB3030 apphost.exe error when SDK 10 builds net9.0 test projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,6 @@ dotnet test -- --filter-trait "Category=Integration"    # requires Docker (Testc
 
 - **`dotnet test` requires `--project`**, not a bare path: `dotnet test --project tests/Foo/Foo.csproj`
 - **`dotnet build`/`test` with a path** does not need `--project`: `dotnet build tests/Foo/Foo.csproj`
-- **`MSB3030 apphost.exe` on net9.0 in Specs projects** is a pre-existing environment issue — not caused by code changes, safe to ignore
 - **`cref` attributes in XML docs** must use the fully qualified type name if the type lives in a different namespace within the same project (e.g. `<see cref="OpinionatedEventing.Outbox.IOutboxStore"/>` from within `OpinionatedEventing.Options`)
 
 ## Before committing

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,24 @@
+<Project>
+
+  <!-- Workaround for MSB3030 "apphost.exe not found" when SDK 10 cross-compiles
+       net9.0 test projects. SDK 10 ships KnownAppHostPack entries pointing to a
+       specific net9.0 patch version (e.g. 9.0.15) that may not be installed locally
+       (e.g. only 9.0.2 present). When exactly one 9.0.x apphost pack is on disk and
+       the SDK-expected version is absent, redirect KnownAppHostPack to use the
+       installed version. See: https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1145
+       This block runs during project evaluation, after BundledVersions.props has
+       populated KnownAppHostPack, so the Update operation takes effect. -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <_Net9AppHostPackDir>$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::Combine('$(NetCoreTargetingPackRoot)', 'Microsoft.NETCore.App.Host.$(NETCoreSdkRuntimeIdentifier)'))))</_Net9AppHostPackDir>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' and Exists('$(_Net9AppHostPackDir)')">
+    <_InstalledNet9AppHostPackDirs Include="$([System.IO.Directory]::GetDirectories('$(_Net9AppHostPackDir)', '9.0.*'))" />
+  </ItemGroup>
+  <ItemGroup Condition="'@(_InstalledNet9AppHostPackDirs->Count())' == '1'">
+    <KnownAppHostPack Update="@(KnownAppHostPack)">
+      <AppHostPackVersion Condition="'%(TargetFramework)' == 'net9.0' and
+                                     !Exists('$(_Net9AppHostPackDir)%(AppHostPackVersion)')">@(_InstalledNet9AppHostPackDirs->'%(Filename)%(Extension)')</AppHostPackVersion>
+    </KnownAppHostPack>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Adds `Directory.Build.targets` with a `KnownAppHostPack` version redirect for net9.0 test projects
- When SDK 10 expects apphost pack `9.0.15` but only `9.0.2` (or another 9.0.x) is installed, the override redirects `KnownAppHostPack` to the installed version so `apphost.exe` is created correctly
- Removes the stale `CLAUDE.md` note that told contributors to ignore MSB3030 as a pre-existing environment issue

## Root cause

SDK 10.0.x ships `BundledVersions.props` with `KnownAppHostPack` entries that expect a specific net9.0 apphost pack version (e.g. `9.0.15`). If only a different 9.0.x patch (e.g. `9.0.2`) is installed locally, `ResolveAppHosts` finds no matching pack → `AppHostSourcePath` is empty → `_CreateAppHost` is skipped → `apphost.exe` is never written to `obj/` → `MSB3030` fires when the SDK tries to copy it to `bin/`.

## Fix

`Directory.Build.targets` (imported after `BundledVersions.props`, so `KnownAppHostPack` items already exist) updates the `AppHostPackVersion` metadata for the `net9.0` entry to point at the installed 9.0.x directory. Guards:

- Only runs for test projects (`IsTestProject == true`) — xunit.v3 MTP requires `OutputType=Exe` and therefore an apphost; src libraries are unaffected
- Only runs when exactly one 9.0.x pack directory is present (avoids ambiguity)
- Only overrides when the SDK-expected version directory is absent (no-op on CI where the correct version is installed)

Closes #67

## Test plan

- [x] `dotnet build` — succeeds across all TFMs (net8.0, net9.0, net10.0), 0 warnings, 0 errors
- [x] `dotnet test --project tests/OpinionatedEventing.Core.Specs … -f net9.0` — 5 specs pass (previously failed with MSB3030)
- [x] `dotnet test --project tests/OpinionatedEventing.Core.Tests … -f net9.0` — 33 tests pass
- [x] `dotnet test --project tests/OpinionatedEventing.Outbox.Tests … -f net9.0` — 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)