### PR TITLE
feat(ef): SQLite support via UTC-ticks value converters for DateTimeOffset columns

### DIFF
--- a/src/OpinionatedEventing.EntityFramework/Configuration/OutboxMessageEntityTypeConfiguration.cs
+++ b/src/OpinionatedEventing.EntityFramework/Configuration/OutboxMessageEntityTypeConfiguration.cs
@@ -9,8 +9,17 @@ namespace OpinionatedEventing.EntityFramework.Configuration;
 /// Maps the outbox table to <c>outbox_messages</c> with an index optimised for pending-message queries.
 /// </summary>
 /// <remarks>
-/// Apply via <c>modelBuilder.ApplyOutboxConfiguration()</c> inside <c>OnModelCreating</c>,
-/// or let EF Core discover it automatically via <c>modelBuilder.ApplyConfigurationsFromAssembly</c>.
+/// <para>
+/// Apply via <c>modelBuilder.ApplyOutboxConfiguration(Database.ProviderName)</c> inside
+/// <c>OnModelCreating</c>. Passing <c>Database.ProviderName</c> enables the automatic
+/// SQLite value-converter that stores <see cref="DateTimeOffset"/> columns as UTC ticks,
+/// preserving sort order on the pending-message index.
+/// </para>
+/// <para>
+/// When using <c>modelBuilder.ApplyConfigurationsFromAssembly</c>, this configuration is
+/// discovered automatically but the SQLite converters are <b>not</b> applied — call
+/// <c>modelBuilder.ApplyOutboxConfiguration(Database.ProviderName)</c> explicitly instead.
+/// </para>
 /// </remarks>
 public sealed class OutboxMessageEntityTypeConfiguration : IEntityTypeConfiguration<OutboxMessage>
 {

--- a/src/OpinionatedEventing.EntityFramework/Configuration/SagaStateEntityTypeConfiguration.cs
+++ b/src/OpinionatedEventing.EntityFramework/Configuration/SagaStateEntityTypeConfiguration.cs
@@ -9,8 +9,17 @@ namespace OpinionatedEventing.EntityFramework.Configuration;
 /// Maps the saga state table to <c>saga_states</c> with an index optimised for timeout polling.
 /// </summary>
 /// <remarks>
-/// Apply via <c>modelBuilder.ApplySagaStateConfiguration()</c> inside <c>OnModelCreating</c>,
-/// or let EF Core discover it automatically via <c>modelBuilder.ApplyConfigurationsFromAssembly</c>.
+/// <para>
+/// Apply via <c>modelBuilder.ApplySagaStateConfiguration(Database.ProviderName)</c> inside
+/// <c>OnModelCreating</c>. Passing <c>Database.ProviderName</c> enables the automatic
+/// SQLite value-converter that stores <see cref="DateTimeOffset"/> columns as UTC ticks,
+/// preserving sort order on the saga-timeout index.
+/// </para>
+/// <para>
+/// When using <c>modelBuilder.ApplyConfigurationsFromAssembly</c>, this configuration is
+/// discovered automatically but the SQLite converters are <b>not</b> applied — call
+/// <c>modelBuilder.ApplySagaStateConfiguration(Database.ProviderName)</c> explicitly instead.
+/// </para>
 /// </remarks>
 public sealed class SagaStateEntityTypeConfiguration : IEntityTypeConfiguration<SagaState>
 {

--- a/src/OpinionatedEventing.EntityFramework/Extensions/MigrationBuilderExtensions.cs
+++ b/src/OpinionatedEventing.EntityFramework/Extensions/MigrationBuilderExtensions.cs
@@ -10,11 +10,24 @@ namespace Microsoft.EntityFrameworkCore.Migrations;
 /// </summary>
 public static class OpinionatedEventingMigrationBuilderExtensions
 {
-    /// <summary>Creates the <c>outbox_messages</c> table.</summary>
+    /// <summary>
+    /// Creates the <c>outbox_messages</c> table.
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="MigrationBuilder.ActiveProvider"/> contains <c>"Sqlite"</c> (case-insensitive),
+    /// <see cref="DateTimeOffset"/> columns (<c>CreatedAt</c>, <c>ProcessedAt</c>, <c>FailedAt</c>) are
+    /// emitted as <c>long</c> (<c>INTEGER</c>) to store UTC ticks, matching the
+    /// <see cref="Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter{TModel,TProvider}"/>
+    /// applied by <c>modelBuilder.ApplyOutboxConfiguration(Database.ProviderName)</c>.
+    /// </remarks>
     /// <param name="migrationBuilder">The migration builder.</param>
     /// <returns>The same <paramref name="migrationBuilder"/> for chaining.</returns>
     public static MigrationBuilder CreateOutboxTable(this MigrationBuilder migrationBuilder)
     {
+        // null-safe: ActiveProvider is non-nullable in EF Core 8–10, but defensive here;
+        // a missing/null provider is treated as non-SQLite (correct default).
+        var sqlite = migrationBuilder.ActiveProvider?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) == true;
+
         migrationBuilder.CreateTable(
             name: "outbox_messages",
             columns: table => new
@@ -25,9 +38,9 @@ public static class OpinionatedEventingMigrationBuilderExtensions
                 MessageKind = table.Column<string>(maxLength: 16, nullable: false),
                 CorrelationId = table.Column<Guid>(nullable: false),
                 CausationId = table.Column<Guid>(nullable: true),
-                CreatedAt = table.Column<DateTimeOffset>(nullable: false),
-                ProcessedAt = table.Column<DateTimeOffset>(nullable: true),
-                FailedAt = table.Column<DateTimeOffset>(nullable: true),
+                CreatedAt = sqlite ? table.Column<long>(nullable: false) : table.Column<DateTimeOffset>(nullable: false),
+                ProcessedAt = sqlite ? table.Column<long>(nullable: true) : table.Column<DateTimeOffset>(nullable: true),
+                FailedAt = sqlite ? table.Column<long>(nullable: true) : table.Column<DateTimeOffset>(nullable: true),
                 AttemptCount = table.Column<int>(nullable: false, defaultValue: 0),
                 Error = table.Column<string>(nullable: true),
             },
@@ -51,11 +64,24 @@ public static class OpinionatedEventingMigrationBuilderExtensions
         return migrationBuilder;
     }
 
-    /// <summary>Creates the <c>saga_states</c> table.</summary>
+    /// <summary>
+    /// Creates the <c>saga_states</c> table.
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="MigrationBuilder.ActiveProvider"/> contains <c>"Sqlite"</c> (case-insensitive),
+    /// <see cref="DateTimeOffset"/> columns (<c>CreatedAt</c>, <c>UpdatedAt</c>, <c>ExpiresAt</c>) are
+    /// emitted as <c>long</c> (<c>INTEGER</c>) to store UTC ticks, matching the
+    /// <see cref="Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter{TModel,TProvider}"/>
+    /// applied by <c>modelBuilder.ApplySagaStateConfiguration(Database.ProviderName)</c>.
+    /// </remarks>
     /// <param name="migrationBuilder">The migration builder.</param>
     /// <returns>The same <paramref name="migrationBuilder"/> for chaining.</returns>
     public static MigrationBuilder CreateSagaStateTable(this MigrationBuilder migrationBuilder)
     {
+        // null-safe: ActiveProvider is non-nullable in EF Core 8–10, but defensive here;
+        // a missing/null provider is treated as non-SQLite (correct default).
+        var sqlite = migrationBuilder.ActiveProvider?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) == true;
+
         migrationBuilder.CreateTable(
             name: "saga_states",
             columns: table => new
@@ -65,9 +91,9 @@ public static class OpinionatedEventingMigrationBuilderExtensions
                 CorrelationId = table.Column<string>(maxLength: 256, nullable: false),
                 State = table.Column<string>(nullable: false),
                 Status = table.Column<int>(nullable: false),
-                CreatedAt = table.Column<DateTimeOffset>(nullable: false),
-                UpdatedAt = table.Column<DateTimeOffset>(nullable: false),
-                ExpiresAt = table.Column<DateTimeOffset>(nullable: true),
+                CreatedAt = sqlite ? table.Column<long>(nullable: false) : table.Column<DateTimeOffset>(nullable: false),
+                UpdatedAt = sqlite ? table.Column<long>(nullable: false) : table.Column<DateTimeOffset>(nullable: false),
+                ExpiresAt = sqlite ? table.Column<long>(nullable: true) : table.Column<DateTimeOffset>(nullable: true),
             },
             constraints: table =>
                 table.PrimaryKey("PK_saga_states", x => x.Id));

--- a/src/OpinionatedEventing.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/src/OpinionatedEventing.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -1,5 +1,8 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OpinionatedEventing.EntityFramework.Configuration;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Sagas;
 
 // Placing in this namespace so the extension is available without an extra using directive.
 namespace Microsoft.EntityFrameworkCore;
@@ -14,10 +17,21 @@ public static class OpinionatedEventingModelBuilderExtensions
     /// Call this inside <c>OnModelCreating</c> to include the outbox table in your schema.
     /// </summary>
     /// <param name="modelBuilder">The model builder to configure.</param>
+    /// <param name="providerName">
+    /// The active database provider name (e.g. <c>Database.ProviderName</c>).
+    /// When the value contains <c>"Sqlite"</c> (case-insensitive), a
+    /// <see cref="ValueConverter{TModel,TProvider}"/> that stores <see cref="DateTimeOffset"/>
+    /// as UTC ticks (<c>long</c> / <c>INTEGER</c>) is applied to all <see cref="DateTimeOffset"/>
+    /// columns, preserving sort order on SQLite.
+    /// </param>
     /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
-    public static ModelBuilder ApplyOutboxConfiguration(this ModelBuilder modelBuilder)
+    public static ModelBuilder ApplyOutboxConfiguration(this ModelBuilder modelBuilder, string? providerName = null)
     {
         modelBuilder.ApplyConfiguration(new OutboxMessageEntityTypeConfiguration());
+
+        if (IsSqlite(providerName))
+            ApplyOutboxSqliteConverters(modelBuilder);
+
         return modelBuilder;
     }
 
@@ -26,10 +40,52 @@ public static class OpinionatedEventingModelBuilderExtensions
     /// Call this inside <c>OnModelCreating</c> to include the saga state table in your schema.
     /// </summary>
     /// <param name="modelBuilder">The model builder to configure.</param>
+    /// <param name="providerName">
+    /// The active database provider name (e.g. <c>Database.ProviderName</c>).
+    /// When the value contains <c>"Sqlite"</c> (case-insensitive), a
+    /// <see cref="ValueConverter{TModel,TProvider}"/> that stores <see cref="DateTimeOffset"/>
+    /// as UTC ticks (<c>long</c> / <c>INTEGER</c>) is applied to all <see cref="DateTimeOffset"/>
+    /// columns, preserving sort order on SQLite.
+    /// </param>
     /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
-    public static ModelBuilder ApplySagaStateConfiguration(this ModelBuilder modelBuilder)
+    public static ModelBuilder ApplySagaStateConfiguration(this ModelBuilder modelBuilder, string? providerName = null)
     {
         modelBuilder.ApplyConfiguration(new SagaStateEntityTypeConfiguration());
+
+        if (IsSqlite(providerName))
+            ApplySagaStateSqliteConverters(modelBuilder);
+
         return modelBuilder;
+    }
+
+    private static bool IsSqlite(string? providerName)
+        => providerName?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) == true;
+
+    // Stores DateTimeOffset as UTC ticks (long/INTEGER) on SQLite.
+    // SQLite has no native DateTimeOffset type; without this, EF stores it as TEXT, breaking
+    // ORDER BY correctness on the pending-message and saga-timeout indexes.
+    // The converter is stateless (pure functions, no captured state) — safe to share across
+    // multiple HasConversion calls and across context instances.
+    private static readonly ValueConverter<DateTimeOffset, long> DateTimeOffsetToTicks =
+        new(dto => dto.UtcTicks, ticks => new DateTimeOffset(ticks, TimeSpan.Zero));
+
+    private static void ApplyOutboxSqliteConverters(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<OutboxMessage>(b =>
+        {
+            b.Property(m => m.CreatedAt).HasConversion(DateTimeOffsetToTicks);
+            b.Property(m => m.ProcessedAt).HasConversion(DateTimeOffsetToTicks);
+            b.Property(m => m.FailedAt).HasConversion(DateTimeOffsetToTicks);
+        });
+    }
+
+    private static void ApplySagaStateSqliteConverters(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<SagaState>(b =>
+        {
+            b.Property(s => s.CreatedAt).HasConversion(DateTimeOffsetToTicks);
+            b.Property(s => s.UpdatedAt).HasConversion(DateTimeOffsetToTicks);
+            b.Property(s => s.ExpiresAt).HasConversion(DateTimeOffsetToTicks);
+        });
     }
 }

--- a/src/OpinionatedEventing.EntityFramework/README.md
+++ b/src/OpinionatedEventing.EntityFramework/README.md
@@ -28,11 +28,19 @@ public class AppDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.ApplyOutboxConfiguration();
-        modelBuilder.ApplySagaStateConfiguration();
+        modelBuilder.ApplyOutboxConfiguration(Database.ProviderName);
+        modelBuilder.ApplySagaStateConfiguration(Database.ProviderName);
     }
 }
 ```
+
+### Supported databases
+
+| Provider | Notes |
+|----------|-------|
+| **SQL Server** | Fully supported. `DateTimeOffset` columns stored natively. |
+| **PostgreSQL** | Fully supported. `DateTimeOffset` columns stored natively. |
+| **SQLite** | ⚠️ **Not for production use.** SQLite has no native `DateTimeOffset` type. When `Database.ProviderName` contains `"Sqlite"`, the library automatically applies a value converter that stores all `DateTimeOffset` columns as UTC ticks (`long` / `INTEGER`), preserving sort order on the pending-message and saga-timeout indexes. Useful for local development, testing, and demos. |
 
 Then add a migration:
 

--- a/tests/OpinionatedEventing.EntityFramework.Tests/OpinionatedEventing.EntityFramework.Tests.csproj
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/OpinionatedEventing.EntityFramework.Tests.csproj
@@ -17,16 +17,19 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="8.0.25" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" VersionOverride="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="8.0.25" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="9.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" VersionOverride="9.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="9.0.14" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OpinionatedEventing.EntityFramework.Tests/SqliteDateTimeOffsetConverterTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/SqliteDateTimeOffsetConverterTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using OpinionatedEventing.EntityFramework.Tests.TestSupport;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Sagas;
+using Xunit;
+
+namespace OpinionatedEventing.EntityFramework.Tests;
+
+/// <summary>
+/// Unit tests verifying that a UTC-ticks <see cref="ValueConverter{TModel,TProvider}"/> is
+/// applied to all <see cref="DateTimeOffset"/> properties on <see cref="OutboxMessage"/> and
+/// <see cref="SagaState"/> when the SQLite provider is active, and that no converter is applied
+/// for non-SQLite providers.
+/// </summary>
+public sealed class SqliteDateTimeOffsetConverterTests : IDisposable
+{
+    private readonly SqliteDbContextFactory _factory = new();
+
+    public void Dispose() => _factory.Dispose();
+
+    [Theory]
+    [InlineData(nameof(OutboxMessage.CreatedAt))]
+    [InlineData(nameof(OutboxMessage.ProcessedAt))]
+    [InlineData(nameof(OutboxMessage.FailedAt))]
+    public void OutboxMessage_DateTimeOffset_properties_use_long_converter_on_SQLite(string propertyName)
+    {
+        using var ctx = _factory.CreateContext();
+        var property = ctx.Model.FindEntityType(typeof(OutboxMessage))!.FindProperty(propertyName)!;
+
+        var converter = property.GetValueConverter();
+
+        Assert.NotNull(converter);
+        Assert.Equal(typeof(long), converter.ProviderClrType);
+    }
+
+    [Theory]
+    [InlineData(nameof(SagaState.CreatedAt))]
+    [InlineData(nameof(SagaState.UpdatedAt))]
+    [InlineData(nameof(SagaState.ExpiresAt))]
+    public void SagaState_DateTimeOffset_properties_use_long_converter_on_SQLite(string propertyName)
+    {
+        using var ctx = _factory.CreateContext();
+        var property = ctx.Model.FindEntityType(typeof(SagaState))!.FindProperty(propertyName)!;
+
+        var converter = property.GetValueConverter();
+
+        Assert.NotNull(converter);
+        Assert.Equal(typeof(long), converter.ProviderClrType);
+    }
+
+    [Theory]
+    [InlineData(nameof(OutboxMessage.CreatedAt))]
+    [InlineData(nameof(OutboxMessage.ProcessedAt))]
+    [InlineData(nameof(OutboxMessage.FailedAt))]
+    public void OutboxMessage_DateTimeOffset_properties_have_no_converter_for_non_SQLite(string propertyName)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var ctx = new TestDbContext(options);
+        var property = ctx.Model.FindEntityType(typeof(OutboxMessage))!.FindProperty(propertyName)!;
+
+        Assert.Null(property.GetValueConverter());
+    }
+
+    [Theory]
+    [InlineData(nameof(SagaState.CreatedAt))]
+    [InlineData(nameof(SagaState.UpdatedAt))]
+    [InlineData(nameof(SagaState.ExpiresAt))]
+    public void SagaState_DateTimeOffset_properties_have_no_converter_for_non_SQLite(string propertyName)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var ctx = new TestDbContext(options);
+        var property = ctx.Model.FindEntityType(typeof(SagaState))!.FindProperty(propertyName)!;
+
+        Assert.Null(property.GetValueConverter());
+    }
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/SqliteIntegrationTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/SqliteIntegrationTests.cs
@@ -1,0 +1,156 @@
+using OpinionatedEventing.EntityFramework.Sagas;
+using OpinionatedEventing.EntityFramework.Tests.TestSupport;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Sagas;
+using Xunit;
+
+namespace OpinionatedEventing.EntityFramework.Tests;
+
+/// <summary>
+/// Integration tests verifying that pending-message dispatch and saga timeout queries
+/// work correctly against an in-process SQLite database using UTC-ticks storage for
+/// <see cref="DateTimeOffset"/> columns.
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class SqliteIntegrationTests : IDisposable
+{
+    // xUnit v3 creates a new class instance per test method, so each test gets its own
+    // factory (and therefore its own isolated in-memory SQLite database).
+    private readonly SqliteDbContextFactory _factory = new();
+
+    public void Dispose() => _factory.Dispose();
+
+    private EFCoreOutboxStore<SqliteTestDbContext> CreateOutboxStore(SqliteTestDbContext ctx)
+        => new(ctx, TimeProvider.System);
+
+    private EFCoreSagaStateStore<SqliteTestDbContext> CreateSagaStore(SqliteTestDbContext ctx)
+        => new(ctx);
+
+    private static OutboxMessage MakeMessage(DateTimeOffset? createdAt = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        MessageType = "SomeType, SomeAssembly",
+        Payload = "{}",
+        MessageKind = "Event",
+        CorrelationId = Guid.NewGuid(),
+        CreatedAt = createdAt ?? DateTimeOffset.UtcNow,
+    };
+
+    private static SagaState MakeSagaState(DateTimeOffset? expiresAt = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        SagaType = "OrderSaga",
+        CorrelationId = Guid.NewGuid().ToString(),
+        State = "{}",
+        Status = SagaStatus.Active,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow,
+        ExpiresAt = expiresAt,
+    };
+
+    // --- Outbox ---
+
+    [Fact]
+    public async Task GetPendingAsync_returns_messages_ordered_by_CreatedAt_on_SQLite()
+    {
+        await using var ctx = _factory.CreateContext();
+        var store = CreateOutboxStore(ctx);
+        var ct = TestContext.Current.CancellationToken;
+
+        var older = MakeMessage(DateTimeOffset.UtcNow.AddMinutes(-5));
+        var newer = MakeMessage(DateTimeOffset.UtcNow);
+
+        await store.SaveAsync(older, ct);
+        await store.SaveAsync(newer, ct);
+        await ctx.SaveChangesAsync(ct);
+
+        var pending = await store.GetPendingAsync(10, ct);
+
+        Assert.Equal(2, pending.Count);
+        Assert.Equal(older.Id, pending[0].Id);
+        Assert.Equal(newer.Id, pending[1].Id);
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_excludes_processed_and_failed_messages_on_SQLite()
+    {
+        await using var ctx = _factory.CreateContext();
+        var store = CreateOutboxStore(ctx);
+        var ct = TestContext.Current.CancellationToken;
+
+        var pending = MakeMessage();
+        var processed = MakeMessage(DateTimeOffset.UtcNow.AddMinutes(-2));
+        var failed = MakeMessage(DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        await store.SaveAsync(pending, ct);
+        await store.SaveAsync(processed, ct);
+        await store.SaveAsync(failed, ct);
+        await ctx.SaveChangesAsync(ct);
+
+        await store.MarkProcessedAsync(processed.Id, ct);
+        await store.MarkFailedAsync(failed.Id, "error", ct);
+
+        var results = await store.GetPendingAsync(10, ct);
+
+        Assert.Single(results);
+        Assert.Equal(pending.Id, results[0].Id);
+    }
+
+    [Fact]
+    public async Task MarkProcessedAsync_sets_ProcessedAt_and_message_leaves_pending_queue_on_SQLite()
+    {
+        await using var ctx = _factory.CreateContext();
+        var store = CreateOutboxStore(ctx);
+        var ct = TestContext.Current.CancellationToken;
+        var message = MakeMessage();
+
+        await store.SaveAsync(message, ct);
+        await ctx.SaveChangesAsync(ct);
+        await store.MarkProcessedAsync(message.Id, ct);
+
+        var saved = await ctx.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        Assert.NotNull(saved!.ProcessedAt);
+        Assert.Empty(await store.GetPendingAsync(10, ct));
+    }
+
+    // --- Saga state ---
+
+    [Fact]
+    public async Task GetExpiredAsync_returns_states_whose_ExpiresAt_is_in_the_past_on_SQLite()
+    {
+        await using var ctx = _factory.CreateContext();
+        var store = CreateSagaStore(ctx);
+        var ct = TestContext.Current.CancellationToken;
+
+        var expired = MakeSagaState(DateTimeOffset.UtcNow.AddMinutes(-1));
+        var notExpired = MakeSagaState(DateTimeOffset.UtcNow.AddHours(1));
+        var noTimeout = MakeSagaState(expiresAt: null);
+
+        await store.SaveAsync(expired, ct);
+        await store.SaveAsync(notExpired, ct);
+        await store.SaveAsync(noTimeout, ct);
+
+        var results = await store.GetExpiredAsync(DateTimeOffset.UtcNow, ct);
+
+        Assert.Single(results);
+        Assert.Equal(expired.Id, results[0].Id);
+    }
+
+    [Fact]
+    public async Task FindAsync_round_trips_SagaState_through_SQLite()
+    {
+        await using var ctx = _factory.CreateContext();
+        var store = CreateSagaStore(ctx);
+        var ct = TestContext.Current.CancellationToken;
+
+        var state = MakeSagaState(DateTimeOffset.UtcNow.AddHours(1));
+        await store.SaveAsync(state, ct);
+
+        var found = await store.FindAsync(state.SagaType, state.CorrelationId, ct);
+
+        Assert.NotNull(found);
+        Assert.Equal(state.Id, found.Id);
+        Assert.Equal(SagaStatus.Active, found.Status);
+        Assert.NotNull(found.ExpiresAt);
+    }
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/TestSupport/SqliteDbContextFactory.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/TestSupport/SqliteDbContextFactory.cs
@@ -1,0 +1,32 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace OpinionatedEventing.EntityFramework.Tests.TestSupport;
+
+/// <summary>
+/// Creates <see cref="SqliteTestDbContext"/> instances backed by a shared in-process SQLite database.
+/// Uses a persistent <see cref="SqliteConnection"/> so the in-memory database survives across
+/// multiple context instances within the same test.
+/// </summary>
+internal sealed class SqliteDbContextFactory : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public SqliteDbContextFactory()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        // Ensure the schema is created once for the shared connection.
+        using var ctx = CreateContext();
+        ctx.Database.EnsureCreated();
+    }
+
+    /// <summary>Creates a new <see cref="SqliteTestDbContext"/> sharing the same in-memory database.</summary>
+    public SqliteTestDbContext CreateContext()
+        => new(new DbContextOptionsBuilder<SqliteTestDbContext>()
+            .UseSqlite(_connection)
+            .Options);
+
+    public void Dispose() => _connection.Dispose();
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/TestSupport/SqliteTestDbContext.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/TestSupport/SqliteTestDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace OpinionatedEventing.EntityFramework.Tests.TestSupport;
+
+internal sealed class SqliteTestDbContext : DbContext
+{
+    public SqliteTestDbContext(DbContextOptions<SqliteTestDbContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyOutboxConfiguration(Database.ProviderName);
+        modelBuilder.ApplySagaStateConfiguration(Database.ProviderName);
+    }
+}


### PR DESCRIPTION
Closes #75.

## Summary

- `ApplyOutboxConfiguration` / `ApplySagaStateConfiguration` accept a new optional `providerName` parameter — pass `Database.ProviderName` to activate the SQLite path
- A stateless `ValueConverter<DateTimeOffset, long>` (UTC ticks) is applied to all six `DateTimeOffset` columns (`CreatedAt`, `ProcessedAt`, `FailedAt`, `UpdatedAt`, `ExpiresAt`) when the provider name contains `"Sqlite"`, preserving `ORDER BY` correctness on the pending-message and saga-timeout indexes
- `MigrationBuilderExtensions.CreateOutboxTable` / `CreateSagaStateTable` detect `ActiveProvider` and emit `long` DDL columns for SQLite, keeping migrations in sync with the converter
- Entity type configuration XML docs warn that `ApplyConfigurationsFromAssembly` bypasses the SQLite converters
- README updated with a supported-databases table (SQL Server ✅, PostgreSQL ✅, SQLite ⚠️ not for production)

## Test plan

- [ ] Unit tests (`SqliteDateTimeOffsetConverterTests`) — verify converter presence/absence via EF model metadata; no containers needed, run in fast CI step
- [ ] Integration tests (`SqliteIntegrationTests`, `Category=Integration`) — run `GetPendingAsync` ordering and `GetExpiredAsync` saga-timeout queries against an in-process SQLite database; no Docker required
- [ ] Existing `EFCoreOutboxStoreTests` and `DomainEventInterceptorTests` unchanged and still pass
- [ ] Build succeeds with 0 warnings across net8.0 / net9.0 / net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)