### PR TITLE
feat: add GitVersion for automatic SemVer from git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET ${{ matrix.dotnet }}
         uses: actions/setup-dotnet@v5

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,12 +32,12 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <Version>0.1.0-preview.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(IsSampleProject)' != 'true'">
     <None Include="README.md" Pack="true" PackagePath="\"/>
+    <PackageReference Include="GitVersion.MsBuild" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,6 +55,11 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
   </ItemGroup>
 
+  <!-- GitVersion (versioning from git tags) -->
+  <ItemGroup>
+    <PackageVersion Include="GitVersion.MsBuild" Version="6.3.0" />
+  </ItemGroup>
+
   <!-- Reqnroll (BDD) -->
   <ItemGroup>
     <PackageVersion Include="Reqnroll" Version="3.3.4" />

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,2 @@
+workflow: GitHubFlow/v1
+next-version: 1.0.0


### PR DESCRIPTION
## Summary

- Adds `GitVersion.MsBuild` (6.3.0) to replace the hardcoded `Version` in `Directory.Build.props`
- Configures `GitVersion.yml` with `GitHubFlow/v1` workflow and `next-version: 1.0.0` — pre-release packages on feature branches will be `1.0.0-<branch>.<n>`, and tagging `v1.0.0` on main produces `1.0.0` exactly
- Updates CI checkout to `fetch-depth: 0` so GitVersion has the full git history

## Test plan

- [x] `dotnet restore` and `dotnet build` pass cleanly with no warnings
- [x] `dotnet pack` on a feature branch produces `1.0.0-issue-78-gitversion.1.nupkg` (correct pre-release version)
- [ ] After merge, tag `v1.0.0` on main and verify CI produces `1.0.0` packages

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)