### PR TITLE
test(workers): verify clean shutdown while paused (#83)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,10 @@ dotnet test -- --filter-trait "Category=Integration"    # requires Docker (Testc
 
 On Windows, use `pwsh` (PowerShell) for scripting tasks — never Python. Example: `pwsh -Command "..."`.
 
+## Planning
+
+For any non-trivial implementation task, **present a plan and get explicit confirmation before writing code**. A task is non-trivial if it touches more than one file, introduces a new abstraction, or has architectural trade-offs worth discussing. Keep the plan concise: what will change, why, and any notable trade-offs. Only proceed once the user approves.
+
 ## Issue tracking & branching
 
 The GitHub repository is **`SierraNL/OpinionatedEventing`**.

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/ConsumerWorkerPauseTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/ConsumerWorkerPauseTests.cs
@@ -93,6 +93,48 @@ public sealed class ConsumerWorkerPauseTests
         await ((IHostedService)worker).StopAsync(CancellationToken.None);
     }
 
+    [Fact]
+    public async Task Worker_stops_cleanly_when_cancelled_while_paused()
+    {
+        // Simulates the host stopping during an active readiness failure — the worker
+        // must exit via the OperationCanceledException path without hanging.
+        var ct = TestContext.Current.CancellationToken;
+        var pauseController = new FakeConsumerPauseController(startPaused: true);
+        var worker = CreateWorker(pauseController);
+
+        await ((IHostedService)worker).StartAsync(CancellationToken.None);
+
+        // Give the worker time to enter the paused branch and block on WhenStateChangedAsync
+        await Task.Delay(50, ct);
+
+        // Stop without ever resuming — stoppingToken cancellation must unblock the worker
+        await ((IHostedService)worker).StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Worker_stops_cleanly_after_rapid_pause_resume_cycle()
+    {
+        // Stress-tests the volatile flag + Interlocked.Exchange state machine to ensure
+        // no stuck state survives multiple rapid transitions before shutdown.
+        var ct = TestContext.Current.CancellationToken;
+        var pauseController = new FakeConsumerPauseController(startPaused: false);
+        var worker = CreateWorker(pauseController);
+
+        await ((IHostedService)worker).StartAsync(CancellationToken.None);
+        await Task.Delay(20, ct);
+
+        pauseController.SetPaused(true);
+        await Task.Delay(20, ct);
+        pauseController.SetPaused(false);
+        await Task.Delay(20, ct);
+        pauseController.SetPaused(true);
+        await Task.Delay(20, ct);
+        pauseController.SetPaused(false);
+        await Task.Delay(20, ct);
+
+        await ((IHostedService)worker).StopAsync(CancellationToken.None);
+    }
+
     // ─── Minimal fakes ────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/ConsumerWorkerPauseTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/ConsumerWorkerPauseTests.cs
@@ -91,6 +91,48 @@ public sealed class ConsumerWorkerPauseTests
         await ((IHostedService)worker).StopAsync(CancellationToken.None);
     }
 
+    [Fact]
+    public async Task Worker_stops_cleanly_when_cancelled_while_paused()
+    {
+        // Simulates the host stopping during an active readiness failure — the worker
+        // must exit via the OperationCanceledException path without hanging.
+        var ct = TestContext.Current.CancellationToken;
+        var pauseController = new FakeConsumerPauseController(startPaused: true);
+        var worker = CreateWorker(pauseController);
+
+        await ((IHostedService)worker).StartAsync(CancellationToken.None);
+
+        // Give the worker time to enter the paused branch and block on WhenStateChangedAsync
+        await Task.Delay(50, ct);
+
+        // Stop without ever resuming — stoppingToken cancellation must unblock the worker
+        await ((IHostedService)worker).StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Worker_stops_cleanly_after_rapid_pause_resume_cycle()
+    {
+        // Stress-tests the volatile flag + Interlocked.Exchange state machine to ensure
+        // no stuck state survives multiple rapid transitions before shutdown.
+        var ct = TestContext.Current.CancellationToken;
+        var pauseController = new FakeConsumerPauseController(startPaused: false);
+        var worker = CreateWorker(pauseController);
+
+        await ((IHostedService)worker).StartAsync(CancellationToken.None);
+        await Task.Delay(20, ct);
+
+        pauseController.SetPaused(true);
+        await Task.Delay(20, ct);
+        pauseController.SetPaused(false);
+        await Task.Delay(20, ct);
+        pauseController.SetPaused(true);
+        await Task.Delay(20, ct);
+        pauseController.SetPaused(false);
+        await Task.Delay(20, ct);
+
+        await ((IHostedService)worker).StopAsync(CancellationToken.None);
+    }
+
     // ─── Minimal fakes — none of these are ever called in no-handler tests ────────
 
     private sealed class NeverCalledHandlerRunner : IMessageHandlerRunner


### PR DESCRIPTION
## Summary

Closes #83.

- Adds `Worker_stops_cleanly_when_cancelled_while_paused` to both `AzureServiceBusConsumerWorker` and `RabbitMQConsumerWorker` pause test suites. This is the primary missing scenario from #83: the host stopping the service while a readiness failure is still active (paused state, never resumed). It exercises the `catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)` exit path in `RunPauseLoopAsync`.
- Adds `Worker_stops_cleanly_after_rapid_pause_resume_cycle` to both suites. Stress-tests the `volatile` flag + `Interlocked.Exchange` state machine across multiple fast transitions to confirm no stuck state can survive before shutdown.
- Adds a **Planning** section to `AGENTS.md` requiring a concise plan and explicit confirmation before writing code on non-trivial tasks.

## What was audited

The existing production code (`RunPauseLoopAsync` in both transport workers, `HealthCheckConsumerPauseController`) was reviewed and found to be correct — no bugs. The gap was purely in test coverage for the "host cancels while paused" path.

A related design concern was also surfaced: backlog-based health checks (`OutboxBacklogHealthCheck`, `SagaTimeoutBacklogHealthCheck`) triggering the consumer pause may cause oscillation under sustained load because pausing consumers does not help drain those backlogs. Tracked separately in #86.

## Test plan

- [x] `dotnet test --project tests/OpinionatedEventing.AzureServiceBus.Tests` — 66 passed (net8/9/10)
- [x] `dotnet test --project tests/OpinionatedEventing.RabbitMQ.Tests` — 63 passed (net8/9/10)