### PR TITLE
fix: scope WithConsumerPause to "pause" tag to prevent oscillation

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -152,9 +152,9 @@ app.MapHealthChecks("/health");
 
 The Aspire dashboard polls `/health` and reflects the status in the resources view.
 
-| Health check | Tag | Condition |
+| Health check | Tags | Condition |
 |---|---|---|
-| Broker connectivity | `ready`, `broker` | Unhealthy if broker is unreachable |
+| Broker connectivity | `live`, `broker` | Unhealthy if broker is unreachable |
 | Outbox backlog | `ready`, `outbox` | Degraded above `OutboxBacklogThreshold` |
 | Saga timeout backlog | `ready`, `saga` | Degraded above `SagaTimeoutBacklogThreshold` |
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -116,19 +116,29 @@ app.MapHealthChecks("/health/live",  new HealthCheckOptions { Predicate = c => c
 app.MapHealthChecks("/health/ready", new HealthCheckOptions { Predicate = c => c.Tags.Contains("ready") });
 ```
 
-All three built-in checks are tagged `ready`. Broker connectivity belongs on readiness, not liveness: a broker outage is a dependency failure that restarting the process cannot fix — failing liveness would just cause needless container restarts.
+The built-in checks use two tags:
 
-**Readiness and broker consumers:** readiness probes only control the Kubernetes `Service` endpoint, which governs *HTTP* traffic. The broker consumer workers are `BackgroundService` instances that pull messages directly from the broker, independent of any load balancer. By default, failing readiness does **not** pause event consumption.
+| Tag | Checks |
+|---|---|
+| `live` | Broker connectivity |
+| `ready` | Outbox backlog, saga timeout backlog |
 
-To automatically pause consumers when readiness probes become unhealthy, chain `WithConsumerPause()` onto `AddOpinionatedEventingHealthChecks()`:
+Broker connectivity is a liveness check (`live`), not readiness: if the broker is unreachable the process is genuinely broken and a restart may help re-establish the connection. Backlog checks are readiness signals — a load balancer can stop routing HTTP traffic to the instance while the background workers drain the queue.
+
+**Readiness and broker consumers:** readiness probes only control the Kubernetes `Service` endpoint, which governs *HTTP* traffic. The broker consumer workers are `BackgroundService` instances that pull messages directly from the broker, independent of any load balancer. By default, a degraded readiness check does **not** pause event consumption.
+
+To automatically pause consumers when a dependency becomes unavailable, chain `WithConsumerPause()` and tag the relevant checks with `"pause"`:
 
 ```csharp
 services.AddHealthChecks()
     .AddOpinionatedEventingHealthChecks()
+    .AddNpgsql(connectionString, tags: ["pause"])   // pause consumers when DB is unreachable
     .WithConsumerPause();
 ```
 
-When any check tagged `ready` reports `Degraded` or `Unhealthy`, the consumer workers stop accepting new messages from the broker. They resume automatically once all readiness checks recover to `Healthy`. This is opt-in — the default behaviour (always consuming) is preserved when `WithConsumerPause()` is not called.
+When any check tagged `"pause"` reports `Degraded` or `Unhealthy`, the consumer workers stop accepting new messages from the broker. They resume automatically once all `"pause"`-tagged checks recover to `Healthy`. This is opt-in — the default behaviour (always consuming) is preserved when `WithConsumerPause()` is not called.
+
+The built-in backlog checks (`"ready"`) intentionally do **not** carry the `"pause"` tag. Pausing consumers does not help drain the outbox or saga-timeout backlogs — those are drained by `OutboxDispatcherWorker` and `SagaTimeoutWorker`, which are never paused. Wiring backlog checks to consumer pause would cause oscillation: consumers pause → broker queue grows → backlogs eventually drain → consumers resume → new messages create more backlog → repeat.
 
 ## Correlation and causation IDs
 

--- a/src/OpinionatedEventing.Aspire/HealthChecks/HealthCheckConsumerPauseController.cs
+++ b/src/OpinionatedEventing.Aspire/HealthChecks/HealthCheckConsumerPauseController.cs
@@ -7,12 +7,15 @@ using OpinionatedEventing;
 namespace OpinionatedEventing.Aspire.HealthChecks;
 
 /// <summary>
-/// Pauses broker consumer workers when any readiness health check reports
+/// Pauses broker consumer workers when any health check tagged <c>"pause"</c> reports
 /// <see cref="HealthStatus.Degraded"/> or <see cref="HealthStatus.Unhealthy"/>,
-/// and resumes them when all readiness checks recover to <see cref="HealthStatus.Healthy"/>.
+/// and resumes them when all such checks recover to <see cref="HealthStatus.Healthy"/>.
 /// </summary>
 /// <remarks>
 /// Register via <c>AddOpinionatedEventingHealthChecks().WithConsumerPause()</c>.
+/// Only checks explicitly tagged <c>"pause"</c> influence the pause decision — backlog
+/// checks (tagged <c>"ready"</c>) are intentionally excluded because pausing consumers
+/// does not help drain internal backlogs.
 /// </remarks>
 public sealed class HealthCheckConsumerPauseController : IConsumerPauseController, IHealthCheckPublisher
 {
@@ -35,26 +38,26 @@ public sealed class HealthCheckConsumerPauseController : IConsumerPauseControlle
         => _stateChangedTcs.Task.WaitAsync(cancellationToken);
 
     /// <summary>
-    /// Evaluates the health report and pauses or resumes consumers based on readiness check results.
+    /// Evaluates the health report and pauses or resumes consumers based on <c>"pause"</c>-tagged check results.
     /// </summary>
     /// <param name="report">The health report published by the health check framework.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
     {
         var shouldPause = report.Entries.Any(e =>
-            e.Value.Tags.Contains("ready") &&
+            e.Value.Tags.Contains("pause") &&
             e.Value.Status != HealthStatus.Healthy);
 
         if (shouldPause && !_isPaused)
         {
             _isPaused = true;
-            _logger.LogWarning("Readiness probes unhealthy — pausing broker consumers.");
+            _logger.LogWarning("Dependency health checks unhealthy — pausing broker consumers.");
             SignalStateChanged();
         }
         else if (!shouldPause && _isPaused)
         {
             _isPaused = false;
-            _logger.LogInformation("Readiness probes recovered — resuming broker consumers.");
+            _logger.LogInformation("Dependency health checks recovered — resuming broker consumers.");
             SignalStateChanged();
         }
 

--- a/src/OpinionatedEventing.Aspire/HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/OpinionatedEventing.Aspire/HealthChecks/HealthChecksBuilderExtensions.cs
@@ -59,15 +59,24 @@ public static class OpinionatedEventingHealthChecksBuilderExtensions
     /// <summary>
     /// Registers <see cref="HealthCheckConsumerPauseController"/> as both
     /// <see cref="IConsumerPauseController"/> and <see cref="IHealthCheckPublisher"/>,
-    /// so that broker consumer workers automatically pause when readiness probes are
-    /// unhealthy and resume when they recover.
+    /// so that broker consumer workers automatically pause when a health check tagged
+    /// <c>"pause"</c> becomes unhealthy, and resume when all such checks recover.
     /// </summary>
     /// <param name="builder">The health checks builder to extend.</param>
     /// <returns>The same <paramref name="builder"/> for chaining.</returns>
     /// <remarks>
+    /// <para>
     /// Call this after <see cref="AddOpinionatedEventingHealthChecks"/> and before
     /// building the service provider. The default (always-consuming) behaviour is
     /// preserved when this method is not called.
+    /// </para>
+    /// <para>
+    /// Only checks explicitly tagged <c>"pause"</c> influence the pause decision.
+    /// The built-in backlog checks (<c>"ready"</c>) are intentionally excluded —
+    /// pausing consumers does not help drain the outbox or saga-timeout backlogs.
+    /// Tag your own dependency checks (e.g. database connectivity) with <c>"pause"</c>
+    /// to use this feature.
+    /// </para>
     /// </remarks>
     public static IHealthChecksBuilder WithConsumerPause(this IHealthChecksBuilder builder)
     {

--- a/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/HealthCheckConsumerPauseControllerTests.cs
+++ b/tests/OpinionatedEventing.Aspire.Tests/HealthChecks/HealthCheckConsumerPauseControllerTests.cs
@@ -30,31 +30,31 @@ public sealed class HealthCheckConsumerPauseControllerTests
     }
 
     [Fact]
-    public async Task PublishAsync_pauses_when_ready_check_is_Degraded()
+    public async Task PublishAsync_pauses_when_pause_check_is_Degraded()
     {
         var ct = TestContext.Current.CancellationToken;
         var controller = CreateController();
 
-        var report = BuildReport(("check1", HealthStatus.Degraded, ["ready"]));
+        var report = BuildReport(("check1", HealthStatus.Degraded, ["pause"]));
         await controller.PublishAsync(report, ct);
 
         Assert.True(controller.IsPaused);
     }
 
     [Fact]
-    public async Task PublishAsync_pauses_when_ready_check_is_Unhealthy()
+    public async Task PublishAsync_pauses_when_pause_check_is_Unhealthy()
     {
         var ct = TestContext.Current.CancellationToken;
         var controller = CreateController();
 
-        var report = BuildReport(("check1", HealthStatus.Unhealthy, ["ready"]));
+        var report = BuildReport(("check1", HealthStatus.Unhealthy, ["pause"]));
         await controller.PublishAsync(report, ct);
 
         Assert.True(controller.IsPaused);
     }
 
     [Fact]
-    public async Task PublishAsync_does_not_pause_for_non_ready_tags()
+    public async Task PublishAsync_does_not_pause_for_non_pause_tags()
     {
         var ct = TestContext.Current.CancellationToken;
         var controller = CreateController();
@@ -66,12 +66,28 @@ public sealed class HealthCheckConsumerPauseControllerTests
     }
 
     [Fact]
-    public async Task PublishAsync_does_not_pause_when_ready_check_is_Healthy()
+    public async Task PublishAsync_does_not_pause_for_ready_tag_without_pause()
+    {
+        // "ready"-tagged checks (e.g. backlog) must not trigger consumer pause —
+        // pausing consumers does not help drain internal backlogs.
+        var ct = TestContext.Current.CancellationToken;
+        var controller = CreateController();
+
+        var report = BuildReport(
+            ("outbox-backlog", HealthStatus.Degraded, ["ready", "outbox"]),
+            ("saga-backlog", HealthStatus.Degraded, ["ready", "saga"]));
+        await controller.PublishAsync(report, ct);
+
+        Assert.False(controller.IsPaused);
+    }
+
+    [Fact]
+    public async Task PublishAsync_does_not_pause_when_pause_check_is_Healthy()
     {
         var ct = TestContext.Current.CancellationToken;
         var controller = CreateController();
 
-        var report = BuildReport(("check1", HealthStatus.Healthy, ["ready"]));
+        var report = BuildReport(("check1", HealthStatus.Healthy, ["pause"]));
         await controller.PublishAsync(report, ct);
 
         Assert.False(controller.IsPaused);
@@ -83,10 +99,10 @@ public sealed class HealthCheckConsumerPauseControllerTests
         var ct = TestContext.Current.CancellationToken;
         var controller = CreateController();
 
-        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Degraded, ["ready"])), ct);
+        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Degraded, ["pause"])), ct);
         Assert.True(controller.IsPaused);
 
-        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Healthy, ["ready"])), ct);
+        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Healthy, ["pause"])), ct);
         Assert.False(controller.IsPaused);
     }
 
@@ -99,7 +115,7 @@ public sealed class HealthCheckConsumerPauseControllerTests
         var waitTask = controller.WhenStateChangedAsync(ct);
         Assert.False(waitTask.IsCompleted);
 
-        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Degraded, ["ready"])), ct);
+        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Degraded, ["pause"])), ct);
 
         await waitTask.WaitAsync(TimeSpan.FromSeconds(1), ct);
         Assert.True(waitTask.IsCompletedSuccessfully);
@@ -112,13 +128,13 @@ public sealed class HealthCheckConsumerPauseControllerTests
         var controller = CreateController();
 
         // First, pause
-        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Degraded, ["ready"])), ct);
+        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Degraded, ["pause"])), ct);
 
         var waitTask = controller.WhenStateChangedAsync(ct);
         Assert.False(waitTask.IsCompleted);
 
         // Now resume
-        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Healthy, ["ready"])), ct);
+        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Healthy, ["pause"])), ct);
 
         await waitTask.WaitAsync(TimeSpan.FromSeconds(1), ct);
         Assert.True(waitTask.IsCompletedSuccessfully);
@@ -145,13 +161,13 @@ public sealed class HealthCheckConsumerPauseControllerTests
         var controller = CreateController();
 
         // Pause first
-        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Degraded, ["ready"])), ct);
+        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Degraded, ["pause"])), ct);
 
         // Capture the next state-changed task
         var waitTask = controller.WhenStateChangedAsync(ct);
 
         // Publish degraded again — state doesn't change, so no signal
-        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Unhealthy, ["ready"])), ct);
+        await controller.PublishAsync(BuildReport(("check1", HealthStatus.Unhealthy, ["pause"])), ct);
 
         Assert.False(waitTask.IsCompleted);
     }


### PR DESCRIPTION
Closes #86

## Summary

- `WithConsumerPause()` now filters on a dedicated `"pause"` tag instead of `"ready"`. Only checks explicitly tagged `"pause"` trigger consumer pause.
- The built-in backlog checks (`OutboxBacklogHealthCheck`, `SagaTimeoutBacklogHealthCheck`) retain their `"ready"` tag for readiness endpoints — they do **not** get `"pause"`, because pausing consumers does nothing to drain those backlogs.
- Users opt in to consumer pause by tagging their own dependency checks (e.g. database connectivity) with `"pause"`.
- Fixes a long-standing docs error: broker connectivity was documented as `ready` but was always `live` in the code.

## Test plan

- [x] Existing pause/resume/signalling tests updated to use `"pause"` tag
- [x] New regression test `PublishAsync_does_not_pause_for_ready_tag_without_pause` explicitly verifies that degraded outbox and saga-timeout backlog checks no longer trigger consumer pause
- [x] All 66 tests pass across net8.0, net9.0, net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)