### PR TITLE
docs: enforce issue branch creation and workflow steps in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,11 @@ See [AGENTS.md](AGENTS.md) for the full project context, design rules, conventio
 
 - **Before committing:** always run `/review` on staged changes and address any findings.
 - **GitHub interactions:** use the `gh` CLI for all GitHub operations (issues, PRs, comments, etc.).
+
+## Implementing an issue (mandatory steps — do not skip)
+
+1. `git fetch origin && git reset --hard origin/main` — start clean from main
+2. Create branch: `git checkout -b issue/<number>-<short-description>` (e.g. `issue/42-fix-outbox-retry`)
+3. Present a plan and wait for explicit approval before writing any code (see AGENTS.md § Planning)
+4. Implement, then run `/review` on staged changes before committing
+5. Open a PR targeting `main` via `gh pr create`


### PR DESCRIPTION
## Summary

- Adds an explicit **"Implementing an issue"** section to `CLAUDE.md` with mandatory, numbered steps
- Ensures Claude always fetches/resets to `origin/main`, creates a branch named `issue/<number>-<short-description>`, gets plan approval, runs `/review` before committing, and opens a PR via `gh`
- Fixes recurring issue where the branch creation step was skipped or named incorrectly

## Test plan

- [ ] Verify the steps match the conventions already documented in `AGENTS.md`
- [ ] Confirm no `.cs` or project files are changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)