### PR TITLE
fix: thread inbound MessageId as CausationId (#99)

### DIFF
--- a/src/OpinionatedEventing.Abstractions/IMessageHandlerRunner.cs
+++ b/src/OpinionatedEventing.Abstractions/IMessageHandlerRunner.cs
@@ -24,8 +24,10 @@ public interface IMessageHandlerRunner
     /// <param name="payload">JSON-serialised message body.</param>
     /// <param name="correlationId">Correlation identifier propagated from the inbound envelope.</param>
     /// <param name="causationId">
-    /// Identifier of the outbox message that caused this one, or <see langword="null"/> for
-    /// originating messages.
+    /// The inbound message's own identifier (its <c>MessageId</c> on the wire). Any message
+    /// published during handling will carry this value as its <c>CausationId</c>, establishing the
+    /// direct parent–child link. Pass <see langword="null"/> for originating messages that have no
+    /// parseable <c>MessageId</c>.
     /// </param>
     /// <param name="ct">Cancellation token.</param>
     Task RunAsync(

--- a/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusConsumerWorker.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusConsumerWorker.cs
@@ -248,9 +248,6 @@ internal sealed class AzureServiceBusConsumerWorker : BackgroundService
                 ? mk as string : null;
             var correlationIdStr = message.ApplicationProperties.TryGetValue("CorrelationId", out var cid)
                 ? cid as string : null;
-            var causationIdStr = message.ApplicationProperties.TryGetValue("CausationId", out var caus)
-                ? caus as string : null;
-
             if (messageType is null || messageKind is null || correlationIdStr is null)
             {
                 _logger.LogWarning(
@@ -268,7 +265,7 @@ internal sealed class AzureServiceBusConsumerWorker : BackgroundService
                 return;
             }
 
-            Guid? causationId = Guid.TryParse(causationIdStr, out var c) ? c : null;
+            Guid? causationId = Guid.TryParse(message.MessageId, out var c) ? c : null;
             var payload = message.Body.ToString();
 
             await _handlerRunner.RunAsync(messageType, messageKind, payload, correlationId, causationId, ct)

--- a/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusConsumerWorker.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusConsumerWorker.cs
@@ -233,7 +233,7 @@ internal sealed class AzureServiceBusConsumerWorker : BackgroundService
     }
 
 
-    private async Task ProcessReceivedMessageAsync(
+    internal async Task ProcessReceivedMessageAsync(
         ServiceBusReceivedMessage message,
         Func<CancellationToken, Task> complete,
         Func<CancellationToken, Task> abandon,

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
@@ -206,7 +206,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
         entry.ConsumerTag = tag;
     }
 
-    private async Task ProcessDeliveryAsync(
+    internal async Task ProcessDeliveryAsync(
         IChannel channel,
         BasicDeliverEventArgs ea,
         CancellationToken ct)

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
@@ -216,7 +216,6 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
             var messageType = GetHeader(ea.BasicProperties, "MessageType");
             var messageKind = GetHeader(ea.BasicProperties, "MessageKind");
             var correlationIdStr = GetHeader(ea.BasicProperties, "CorrelationId");
-            var causationIdStr = GetHeader(ea.BasicProperties, "CausationId");
 
             if (messageType is null || messageKind is null || correlationIdStr is null)
             {
@@ -237,7 +236,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
                 return;
             }
 
-            Guid? causationId = Guid.TryParse(causationIdStr, out var c) ? c : null;
+            Guid? causationId = Guid.TryParse(ea.BasicProperties.MessageId, out var c) ? c : null;
             var payload = Encoding.UTF8.GetString(ea.Body.Span);
 
             await _handlerRunner

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusConsumerWorkerTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusConsumerWorkerTests.cs
@@ -1,0 +1,145 @@
+#nullable enable
+
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MSOptions = Microsoft.Extensions.Options.Options;
+using OpinionatedEventing;
+using OpinionatedEventing.AzureServiceBus;
+using OpinionatedEventing.AzureServiceBus.DependencyInjection;
+using Xunit;
+
+namespace OpinionatedEventing.AzureServiceBus.Tests;
+
+public sealed class AzureServiceBusConsumerWorkerTests
+{
+    private static AzureServiceBusConsumerWorker CreateWorker(IMessageHandlerRunner runner)
+    {
+        var emptyServices = new ServiceCollection();
+        var accessor = new ServiceCollectionAccessor(emptyServices);
+        var options = MSOptions.Create(new AzureServiceBusOptions
+        {
+            ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;" +
+                               "SharedAccessKeyName=RootManageSharedAccessKey;" +
+                               "SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        });
+
+        return new AzureServiceBusConsumerWorker(
+            client: new NoOpServiceBusClient(),
+            handlerRunner: runner,
+            scopeFactory: new NeverCalledScopeFactory(),
+            accessor: accessor,
+            options: options,
+            pauseController: new FakeConsumerPauseController(startPaused: false),
+            timeProvider: TimeProvider.System,
+            logger: NullLogger<AzureServiceBusConsumerWorker>.Instance);
+    }
+
+    [Fact]
+    public async Task ProcessReceivedMessageAsync_passes_inbound_MessageId_as_causationId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var messageId = Guid.NewGuid();
+        var correlationId = Guid.NewGuid();
+        var runner = new RecordingHandlerRunner();
+        var worker = CreateWorker(runner);
+
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"),
+            messageId: messageId.ToString(),
+            properties: new Dictionary<string, object>
+            {
+                ["MessageType"] = typeof(object).AssemblyQualifiedName!,
+                ["MessageKind"] = "Event",
+                ["CorrelationId"] = correlationId.ToString(),
+            });
+
+        await worker.ProcessReceivedMessageAsync(
+            message,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
+            ct);
+
+        var call = Assert.Single(runner.Calls);
+        Assert.Equal(messageId, call.CausationId);
+        Assert.Equal(correlationId, call.CorrelationId);
+    }
+
+    [Fact]
+    public async Task ProcessReceivedMessageAsync_causationId_is_null_when_MessageId_is_not_a_guid()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var correlationId = Guid.NewGuid();
+        var runner = new RecordingHandlerRunner();
+        var worker = CreateWorker(runner);
+
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"),
+            messageId: "not-a-guid",
+            properties: new Dictionary<string, object>
+            {
+                ["MessageType"] = typeof(object).AssemblyQualifiedName!,
+                ["MessageKind"] = "Event",
+                ["CorrelationId"] = correlationId.ToString(),
+            });
+
+        await worker.ProcessReceivedMessageAsync(
+            message,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
+            ct);
+
+        var call = Assert.Single(runner.Calls);
+        Assert.Null(call.CausationId);
+    }
+
+    [Fact]
+    public async Task ProcessReceivedMessageAsync_dead_letters_message_missing_required_properties()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var runner = new RecordingHandlerRunner();
+        var worker = CreateWorker(runner);
+        var deadLettered = false;
+
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"));
+
+        await worker.ProcessReceivedMessageAsync(
+            message,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            (_, _, _) => { deadLettered = true; return Task.CompletedTask; },
+            ct);
+
+        Assert.True(deadLettered);
+        Assert.Empty(runner.Calls);
+    }
+
+    // ─── Fakes ────────────────────────────────────────────────────────────────────
+
+    private sealed class NoOpServiceBusClient : ServiceBusClient { }
+
+    private sealed class NeverCalledScopeFactory : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope()
+            => throw new InvalidOperationException("Should not be called.");
+    }
+
+    private sealed record RunnerCall(
+        string MessageType, string MessageKind, string Payload,
+        Guid CorrelationId, Guid? CausationId);
+
+    private sealed class RecordingHandlerRunner : IMessageHandlerRunner
+    {
+        public List<RunnerCall> Calls { get; } = [];
+
+        public Task RunAsync(string messageType, string messageKind, string payload,
+            Guid correlationId, Guid? causationId, CancellationToken ct)
+        {
+            Calls.Add(new RunnerCall(messageType, messageKind, payload, correlationId, causationId));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQConsumerWorkerTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQConsumerWorkerTests.cs
@@ -1,0 +1,307 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MSOptions = Microsoft.Extensions.Options.Options;
+using OpinionatedEventing;
+using OpinionatedEventing.RabbitMQ;
+using OpinionatedEventing.RabbitMQ.DependencyInjection;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System.Text;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests;
+
+public sealed class RabbitMQConsumerWorkerTests
+{
+    private static RabbitMQConsumerWorker CreateWorker(IMessageHandlerRunner runner)
+    {
+        var emptyServices = new ServiceCollection();
+        var accessor = new ServiceCollectionAccessor(emptyServices);
+        var options = MSOptions.Create(new RabbitMQOptions { ConnectionString = "amqp://localhost" });
+
+        return new RabbitMQConsumerWorker(
+            connection: new NeverCalledConnection(),
+            handlerRunner: runner,
+            scopeFactory: new NeverCalledScopeFactory(),
+            accessor: accessor,
+            options: options,
+            pauseController: new FakeConsumerPauseController(startPaused: false),
+            timeProvider: TimeProvider.System,
+            logger: NullLogger<RabbitMQConsumerWorker>.Instance);
+    }
+
+    [Fact]
+    public async Task ProcessDeliveryAsync_passes_inbound_MessageId_as_causationId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var messageId = Guid.NewGuid();
+        var correlationId = Guid.NewGuid();
+        var runner = new RecordingHandlerRunner();
+        var worker = CreateWorker(runner);
+        var channel = new AckRecordingChannel();
+
+        var props = new BasicProperties
+        {
+            MessageId = messageId.ToString(),
+            Headers = new Dictionary<string, object?>
+            {
+                ["MessageType"] = typeof(object).AssemblyQualifiedName,
+                ["MessageKind"] = "Event",
+                ["CorrelationId"] = correlationId.ToString(),
+            }
+        };
+        var ea = new BasicDeliverEventArgs(
+            consumerTag: "",
+            deliveryTag: 1,
+            redelivered: false,
+            exchange: "",
+            routingKey: "",
+            properties: props,
+            body: Encoding.UTF8.GetBytes("{}"));
+
+        await worker.ProcessDeliveryAsync(channel, ea, ct);
+
+        var call = Assert.Single(runner.Calls);
+        Assert.Equal(messageId, call.CausationId);
+        Assert.Equal(correlationId, call.CorrelationId);
+        Assert.True(channel.Acked);
+    }
+
+    [Fact]
+    public async Task ProcessDeliveryAsync_causationId_is_null_when_MessageId_is_not_a_guid()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var correlationId = Guid.NewGuid();
+        var runner = new RecordingHandlerRunner();
+        var worker = CreateWorker(runner);
+        var channel = new AckRecordingChannel();
+
+        var props = new BasicProperties
+        {
+            MessageId = "not-a-guid",
+            Headers = new Dictionary<string, object?>
+            {
+                ["MessageType"] = typeof(object).AssemblyQualifiedName,
+                ["MessageKind"] = "Event",
+                ["CorrelationId"] = correlationId.ToString(),
+            }
+        };
+        var ea = new BasicDeliverEventArgs(
+            consumerTag: "",
+            deliveryTag: 1,
+            redelivered: false,
+            exchange: "",
+            routingKey: "",
+            properties: props,
+            body: Encoding.UTF8.GetBytes("{}"));
+
+        await worker.ProcessDeliveryAsync(channel, ea, ct);
+
+        var call = Assert.Single(runner.Calls);
+        Assert.Null(call.CausationId);
+    }
+
+    [Fact]
+    public async Task ProcessDeliveryAsync_nacks_message_missing_required_headers()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var runner = new RecordingHandlerRunner();
+        var worker = CreateWorker(runner);
+        var channel = new AckRecordingChannel();
+
+        var ea = new BasicDeliverEventArgs(
+            consumerTag: "",
+            deliveryTag: 1,
+            redelivered: false,
+            exchange: "",
+            routingKey: "",
+            properties: new BasicProperties(),
+            body: Encoding.UTF8.GetBytes("{}"));
+
+        await worker.ProcessDeliveryAsync(channel, ea, ct);
+
+        Assert.True(channel.Nacked);
+        Assert.Empty(runner.Calls);
+    }
+
+    // ─── Fakes ────────────────────────────────────────────────────────────────────
+
+    private sealed class NeverCalledScopeFactory : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope()
+            => throw new InvalidOperationException("Should not be called.");
+    }
+
+    private sealed record RunnerCall(
+        string MessageType, string MessageKind, string Payload,
+        Guid CorrelationId, Guid? CausationId);
+
+    private sealed class RecordingHandlerRunner : IMessageHandlerRunner
+    {
+        public List<RunnerCall> Calls { get; } = [];
+
+        public Task RunAsync(string messageType, string messageKind, string payload,
+            Guid correlationId, Guid? causationId, CancellationToken ct)
+        {
+            Calls.Add(new RunnerCall(messageType, messageKind, payload, correlationId, causationId));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class AckRecordingChannel : IChannel
+    {
+        public bool Acked { get; private set; }
+        public bool Nacked { get; private set; }
+
+        public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple,
+            CancellationToken cancellationToken = default)
+        {
+            Acked = true;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue,
+            CancellationToken cancellationToken = default)
+        {
+            Nacked = true;
+            return ValueTask.CompletedTask;
+        }
+
+        // ── remaining interface members (not called in ProcessDeliveryAsync) ──────
+
+        public int ChannelNumber => 0;
+        public ShutdownEventArgs? CloseReason => null;
+        public bool IsOpen => true;
+        public bool IsClosed => false;
+        public ulong NextPublishSeqNo => 0;
+        public string? CurrentQueue => null;
+        public IAsyncBasicConsumer? DefaultConsumer { get => null; set { } }
+        public TimeSpan ContinuationTimeout { get => TimeSpan.Zero; set { } }
+
+        public event AsyncEventHandler<BasicAckEventArgs>? BasicAcksAsync { add { } remove { } }
+        public event AsyncEventHandler<BasicNackEventArgs>? BasicNacksAsync { add { } remove { } }
+        public event AsyncEventHandler<BasicReturnEventArgs>? BasicReturnAsync { add { } remove { } }
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<FlowControlEventArgs>? FlowControlAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ChannelShutdownAsync { add { } remove { } }
+
+        public Task AbortAsync(ushort replyCode = 200, string replyText = "Goodbye",
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CloseAsync(ushort replyCode = 200, string replyText = "Goodbye", bool abort = false,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CloseAsync(ShutdownEventArgs reason, bool abort,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CloseAsync(ShutdownEventArgs reason, bool abort) => Task.CompletedTask;
+
+        public ValueTask<ulong> GetNextPublishSequenceNumberAsync(
+            CancellationToken cancellationToken = default) => ValueTask.FromResult(0UL);
+
+        public Task<string> BasicConsumeAsync(string queue, bool autoAck, string consumerTag,
+            bool noLocal, bool exclusive, IDictionary<string, object?>? arguments,
+            IAsyncBasicConsumer consumer, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task BasicCancelAsync(string consumerTag, bool noWait = false,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<BasicGetResult?> BasicGetAsync(string queue, bool autoAck,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey,
+            bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body,
+            CancellationToken cancellationToken = default)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
+            => throw new NotImplementedException();
+        public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey,
+            bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body,
+            CancellationToken cancellationToken = default)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
+            => throw new NotImplementedException();
+        public Task BasicQosAsync(uint prefetchSize, ushort prefetchCount, bool global,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public ValueTask BasicRejectAsync(ulong deliveryTag, bool requeue,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ConfirmSelectAsync(bool trackConfirmations = true,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExchangeBindAsync(string destination, string source, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExchangeDeclareAsync(string exchange, string type, bool durable = false,
+            bool autoDelete = false, IDictionary<string, object?>? arguments = null,
+            bool passive = false, bool noWait = false,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExchangeDeclarePassiveAsync(string exchange,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, bool noWait = false,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ExchangeUnbindAsync(string destination, string source, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<QueueDeclareOk> QueueDeclareAsync(string queue = "", bool durable = false,
+            bool exclusive = true, bool autoDelete = true,
+            IDictionary<string, object?>? arguments = null, bool passive = false,
+            bool noWait = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<QueueDeclareOk> QueueDeclarePassiveAsync(string queue,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task QueueBindAsync(string queue, string exchange, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<uint> QueueDeleteAsync(string queue, bool ifUnused = false, bool ifEmpty = false,
+            bool noWait = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<uint> MessageCountAsync(string queue,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<uint> ConsumerCountAsync(string queue,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<uint> QueuePurgeAsync(string queue,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task QueueUnbindAsync(string queue, string exchange, string routingKey,
+            IDictionary<string, object?>? arguments = null,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task TxCommitAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task TxRollbackAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task TxSelectAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> WaitForConfirmsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task WaitForConfirmsOrDieAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private sealed class NeverCalledConnection : IConnection
+    {
+        public ushort ChannelMax => 0;
+        public IDictionary<string, object?> ClientProperties => new Dictionary<string, object?>();
+        public string? ClientProvidedName => null;
+        public ShutdownEventArgs? CloseReason => null;
+        public AmqpTcpEndpoint Endpoint => new("localhost");
+        public uint FrameMax => 0;
+        public TimeSpan Heartbeat => TimeSpan.Zero;
+        public bool IsOpen => true;
+        public IProtocol Protocol => throw new InvalidOperationException("Should not be called.");
+        public IDictionary<string, object?> ServerProperties => new Dictionary<string, object?>();
+        public IEnumerable<ShutdownReportEntry> ShutdownReport => Array.Empty<ShutdownReportEntry>();
+        public int LocalPort => 0;
+        public int RemotePort => 0;
+
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ConnectionShutdownAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? RecoverySucceededAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionRecoveryErrorEventArgs>? ConnectionRecoveryErrorAsync { add { } remove { } }
+        public event AsyncEventHandler<ConsumerTagChangedAfterRecoveryEventArgs>? ConsumerTagChangeAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<QueueNameChangedAfterRecoveryEventArgs>? QueueNameChangedAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<RecoveringConsumerEventArgs>? RecoveringConsumerAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionBlockedEventArgs>? ConnectionBlockedAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? ConnectionUnblockedAsync { add { } remove { } }
+
+        public Task CloseAsync(ushort reasonCode, string reasonText, TimeSpan timeout, bool abort,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IChannel> CreateChannelAsync(CreateChannelOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Should not be called in no-handler tests.");
+        public Task UpdateSecretAsync(string newSecret, string reason,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/tests/OpinionatedEventing.Tests/MessageHandlerRunnerTests.cs
+++ b/tests/OpinionatedEventing.Tests/MessageHandlerRunnerTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.Testing;
 using Xunit;
 
 namespace OpinionatedEventing.Tests;
@@ -349,5 +351,57 @@ public sealed class MessageHandlerRunnerTests
 
         Assert.Equal(2, capturedContexts.Count);
         Assert.NotSame(capturedContexts[0], capturedContexts[1]);
+    }
+
+    // ---- causation chain test ----
+
+    private sealed record ChainEvent : IEvent;
+
+    private sealed class PublishingChainHandler(IPublisher publisher) : IEventHandler<ChainEvent>
+    {
+        public Task HandleAsync(ChainEvent @event, CancellationToken ct) =>
+            publisher.PublishEventAsync(new ChainEvent(), ct);
+    }
+
+    [Fact]
+    public async Task RunAsync_causation_chain_threads_inbound_message_id_as_causation_id()
+    {
+        // Verifies the A → B → C causation chain promised by the docs.
+        // The transport passes the inbound message's own Id as causationId to RunAsync;
+        // any message published inside the handler must carry that value as its CausationId.
+        var ct = TestContext.Current.CancellationToken;
+        var store = new InMemoryOutboxStore();
+        var correlationId = Guid.NewGuid();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddOpinionatedEventing().AddOutbox();
+        services.AddSingleton<IOutboxStore>(store);
+        services.AddScoped<IEventHandler<ChainEvent>>(sp =>
+            new PublishingChainHandler(sp.GetRequiredService<IPublisher>()));
+        await using var provider = services.BuildServiceProvider();
+
+        var runner = provider.GetRequiredService<IMessageHandlerRunner>();
+        var messageAId = Guid.NewGuid();
+
+        // Process A — transport passes A's own MessageId as causationId
+        await runner.RunAsync(
+            typeof(ChainEvent).AssemblyQualifiedName!, "Event",
+            JsonSerializer.Serialize(new ChainEvent()),
+            correlationId, messageAId, ct);
+
+        var messageB = Assert.Single(store.Messages);
+        Assert.Equal(messageAId, messageB.CausationId);
+
+        // Process B — transport passes B.Id (its MessageId on the wire) as causationId
+        await runner.RunAsync(
+            typeof(ChainEvent).AssemblyQualifiedName!, "Event",
+            JsonSerializer.Serialize(new ChainEvent()),
+            correlationId, messageB.Id, ct);
+
+        Assert.Equal(2, store.Messages.Count);
+        var messageC = store.Messages.Single(m => m.Id != messageB.Id);
+        Assert.Equal(messageB.Id, messageC.CausationId);
     }
 }

--- a/tests/OpinionatedEventing.Tests/OpinionatedEventing.Tests.csproj
+++ b/tests/OpinionatedEventing.Tests/OpinionatedEventing.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpinionatedEventing\OpinionatedEventing.csproj" />
+    <ProjectReference Include="..\..\src\OpinionatedEventing.Outbox\OpinionatedEventing.Outbox.csproj" />
     <ProjectReference Include="..\..\src\OpinionatedEventing.Testing\OpinionatedEventing.Testing.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Both ASB and RabbitMQ consumer workers were passing the inbound `CausationId` header/property to `IMessageHandlerRunner.RunAsync` — this caused every follow-up message in a chain to inherit the *same* ancestor id rather than pointing at its direct parent
- Fix: parse the inbound `MessageId` (the message's own wire identity = `outbox.Id.ToString()`) and pass that as `causationId`; the `CausationId` header was only useful for observability and is no longer read on the consumer path
- Updates the `IMessageHandlerRunner` XML doc to describe the `causationId` parameter accurately
- Adds a `RunAsync_causation_chain_threads_inbound_message_id_as_causation_id` test that wires the runner with `OutboxPublisher` + `InMemoryOutboxStore` and asserts `B.CausationId == A.MessageId` and `C.CausationId == B.Id`

## Test plan

- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet test tests/OpinionatedEventing.Tests` — 102/102 passed on net8/net9/net10
- [x] `/review` — approved, one cosmetic nit not acted on

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)