### PR TITLE
feat: add EFCoreOutboxTransactionGuard and EFCoreOutboxMonitor

### DIFF
--- a/src/OpinionatedEventing.EntityFramework/DependencyInjection/EntityFrameworkBuilderExtensions.cs
+++ b/src/OpinionatedEventing.EntityFramework/DependencyInjection/EntityFrameworkBuilderExtensions.cs
@@ -52,6 +52,8 @@ public static class EntityFrameworkBuilderExtensions
     {
         services.TryAddScoped<IOutboxStore, EFCoreOutboxStore<TDbContext>>();
         services.TryAddScoped<ISagaStateStore, EFCoreSagaStateStore<TDbContext>>();
+        services.TryAddScoped<IOutboxTransactionGuard, EFCoreOutboxTransactionGuard<TDbContext>>();
+        services.TryAddScoped<IOutboxMonitor, EFCoreOutboxMonitor<TDbContext>>();
         services.TryAddScoped<DomainEventInterceptor>();
 
         return services;

--- a/src/OpinionatedEventing.EntityFramework/EFCoreOutboxMonitor.cs
+++ b/src/OpinionatedEventing.EntityFramework/EFCoreOutboxMonitor.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.EntityFramework;
+
+/// <summary>
+/// EF Core implementation of <see cref="IOutboxMonitor"/>.
+/// Queries the <c>outbox_messages</c> table directly to return live pending and dead-letter counts.
+/// </summary>
+/// <typeparam name="TDbContext">The application's <see cref="DbContext"/> type.</typeparam>
+internal sealed class EFCoreOutboxMonitor<TDbContext> : IOutboxMonitor
+    where TDbContext : DbContext
+{
+    private readonly TDbContext _dbContext;
+
+    public EFCoreOutboxMonitor(TDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    /// <inheritdoc/>
+    public Task<int> GetPendingCountAsync(CancellationToken cancellationToken = default)
+        => _dbContext.Set<OutboxMessage>()
+            .CountAsync(m => m.ProcessedAt == null && m.FailedAt == null, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<int> GetDeadLetterCountAsync(CancellationToken cancellationToken = default)
+        => _dbContext.Set<OutboxMessage>()
+            .CountAsync(m => m.FailedAt != null, cancellationToken);
+}

--- a/src/OpinionatedEventing.EntityFramework/EFCoreOutboxTransactionGuard.cs
+++ b/src/OpinionatedEventing.EntityFramework/EFCoreOutboxTransactionGuard.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using OpinionatedEventing.Outbox;
+
+namespace OpinionatedEventing.EntityFramework;
+
+/// <summary>
+/// EF Core implementation of <see cref="IOutboxTransactionGuard"/>.
+/// Verifies that either an explicit EF Core database transaction or an ambient
+/// <see cref="System.Transactions.TransactionScope"/> is active before a message is written to the outbox.
+/// </summary>
+/// <typeparam name="TDbContext">The application's <see cref="DbContext"/> type.</typeparam>
+internal sealed class EFCoreOutboxTransactionGuard<TDbContext> : IOutboxTransactionGuard
+    where TDbContext : DbContext
+{
+    private readonly TDbContext _dbContext;
+
+    public EFCoreOutboxTransactionGuard(TDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when neither an EF Core database transaction nor an ambient
+    /// <see cref="System.Transactions.TransactionScope"/> is active.
+    /// </exception>
+    public void EnsureTransaction()
+    {
+        if (_dbContext.Database.CurrentTransaction is not null ||
+            System.Transactions.Transaction.Current is not null)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "IPublisher was called outside an active transaction. " +
+            "Wrap the call inside a database transaction (e.g. await db.Database.BeginTransactionAsync()) " +
+            "or a TransactionScope so the outbox message is committed atomically with your business data.");
+    }
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxMonitorTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxMonitorTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.EntityFrameworkCore;
+using OpinionatedEventing.EntityFramework.Tests.TestSupport;
+using OpinionatedEventing.Outbox;
+using Xunit;
+
+namespace OpinionatedEventing.EntityFramework.Tests;
+
+/// <summary>
+/// Tests for <see cref="EFCoreOutboxMonitor{TDbContext}"/> covering pending and dead-letter counts.
+/// Uses an in-process SQLite database.
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class EFCoreOutboxMonitorTests : IDisposable
+{
+    private readonly SqliteDbContextFactory _factory = new();
+
+    public void Dispose() => _factory.Dispose();
+
+    private EFCoreOutboxMonitor<SqliteTestDbContext> CreateMonitor(SqliteTestDbContext context)
+        => new(context);
+
+    private static OutboxMessage MakeMessage(DateTimeOffset? processedAt = null, DateTimeOffset? failedAt = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        MessageType = "SomeType, SomeAssembly",
+        Payload = "{}",
+        MessageKind = "Event",
+        CorrelationId = Guid.NewGuid(),
+        CreatedAt = DateTimeOffset.UtcNow,
+        ProcessedAt = processedAt,
+        FailedAt = failedAt,
+    };
+
+    [Fact]
+    public async Task GetPendingCountAsync_returns_zero_when_outbox_is_empty()
+    {
+        await using SqliteTestDbContext context = _factory.CreateContext();
+        var monitor = CreateMonitor(context);
+
+        int count = await monitor.GetPendingCountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task GetDeadLetterCountAsync_returns_zero_when_outbox_is_empty()
+    {
+        await using SqliteTestDbContext context = _factory.CreateContext();
+        var monitor = CreateMonitor(context);
+
+        int count = await monitor.GetDeadLetterCountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task GetPendingCountAsync_counts_only_unprocessed_non_failed_messages()
+    {
+        await using SqliteTestDbContext context = _factory.CreateContext();
+        var monitor = CreateMonitor(context);
+
+        context.Set<OutboxMessage>().AddRange(
+            MakeMessage(),
+            MakeMessage(processedAt: DateTimeOffset.UtcNow),
+            MakeMessage(failedAt: DateTimeOffset.UtcNow));
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        int count = await monitor.GetPendingCountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task GetDeadLetterCountAsync_counts_only_failed_messages()
+    {
+        await using SqliteTestDbContext context = _factory.CreateContext();
+        var monitor = CreateMonitor(context);
+
+        context.Set<OutboxMessage>().AddRange(
+            MakeMessage(),
+            MakeMessage(processedAt: DateTimeOffset.UtcNow),
+            MakeMessage(failedAt: DateTimeOffset.UtcNow),
+            MakeMessage(failedAt: DateTimeOffset.UtcNow));
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        int count = await monitor.GetDeadLetterCountAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, count);
+    }
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxMonitorTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxMonitorTests.cs
@@ -9,7 +9,6 @@ namespace OpinionatedEventing.EntityFramework.Tests;
 /// Tests for <see cref="EFCoreOutboxMonitor{TDbContext}"/> covering pending and dead-letter counts.
 /// Uses an in-process SQLite database.
 /// </summary>
-[Trait("Category", "Integration")]
 public sealed class EFCoreOutboxMonitorTests : IDisposable
 {
     private readonly SqliteDbContextFactory _factory = new();

--- a/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxTransactionGuardTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxTransactionGuardTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using OpinionatedEventing.EntityFramework.Tests.TestSupport;
+using OpinionatedEventing.Outbox;
+using System.Transactions;
+using Xunit;
+
+namespace OpinionatedEventing.EntityFramework.Tests;
+
+/// <summary>
+/// Tests for <see cref="EFCoreOutboxTransactionGuard{TDbContext}"/>.
+/// Uses SQLite because <c>Database.CurrentTransaction</c> requires a relational provider.
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class EFCoreOutboxTransactionGuardTests : IDisposable
+{
+    private readonly SqliteDbContextFactory _factory = new();
+
+    public void Dispose() => _factory.Dispose();
+
+    private EFCoreOutboxTransactionGuard<SqliteTestDbContext> CreateGuard(SqliteTestDbContext context)
+        => new(context);
+
+    [Fact]
+    public void EnsureTransaction_throws_when_no_transaction_is_active()
+    {
+        using SqliteTestDbContext context = _factory.CreateContext();
+        var guard = CreateGuard(context);
+
+        Assert.Throws<InvalidOperationException>(() => guard.EnsureTransaction());
+    }
+
+    [Fact]
+    public async Task EnsureTransaction_does_not_throw_inside_BeginTransactionAsync()
+    {
+        await using SqliteTestDbContext context = _factory.CreateContext();
+        var guard = CreateGuard(context);
+
+        await using IDbContextTransaction tx = await context.Database.BeginTransactionAsync(TestContext.Current.CancellationToken);
+
+        guard.EnsureTransaction(); // must not throw
+    }
+
+    [Fact]
+    public void EnsureTransaction_does_not_throw_inside_TransactionScope()
+    {
+        using SqliteTestDbContext context = _factory.CreateContext();
+        var guard = CreateGuard(context);
+
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+        guard.EnsureTransaction(); // must not throw
+    }
+}

--- a/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxTransactionGuardTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxTransactionGuardTests.cs
@@ -11,7 +11,6 @@ namespace OpinionatedEventing.EntityFramework.Tests;
 /// Tests for <see cref="EFCoreOutboxTransactionGuard{TDbContext}"/>.
 /// Uses SQLite because <c>Database.CurrentTransaction</c> requires a relational provider.
 /// </summary>
-[Trait("Category", "Integration")]
 public sealed class EFCoreOutboxTransactionGuardTests : IDisposable
 {
     private readonly SqliteDbContextFactory _factory = new();


### PR DESCRIPTION
Closes #100.

## Summary

- **`EFCoreOutboxTransactionGuard<TDbContext>`** — checks `Database.CurrentTransaction` and `System.Transactions.Transaction.Current` before each outbox write; throws `InvalidOperationException` when neither is active, enforcing REQUIREMENTS.md §3.3 (silent data loss when `SaveChanges` is omitted is now a loud exception).
- **`EFCoreOutboxMonitor<TDbContext>`** — COUNT queries against `outbox_messages` for pending (`ProcessedAt IS NULL AND FailedAt IS NULL`) and dead-letter (`FailedAt IS NOT NULL`) counts; makes `OutboxBacklogHealthCheck` functional by default.
- Both wired into `AddOpinionatedEventingEntityFramework<TDbContext>()` via `TryAddScoped` so application-provided overrides continue to take precedence.

## Test plan

- [ ] `EFCoreOutboxTransactionGuardTests`: guard throws outside a transaction, passes inside `BeginTransactionAsync`, passes inside `TransactionScope`
- [ ] `EFCoreOutboxMonitorTests`: correct pending/dead-letter counts, zero counts on empty outbox
- [ ] Full `OpinionatedEventing.EntityFramework.Tests` suite: 53/53 passed (net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)