### PR TITLE
fix: backfill MessageHandlerRegistry from IServiceCollection at topology startup

### DIFF
--- a/src/OpinionatedEventing.AzureServiceBus/TopologyInitializer.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/TopologyInitializer.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,6 +20,7 @@ internal sealed class TopologyInitializer : IHostedService
 {
     private readonly ServiceBusAdministrationClient _adminClient;
     private readonly MessageHandlerRegistry _registry;
+    private readonly IServiceCollection _serviceCollection;
     private readonly IOptions<AzureServiceBusOptions> _options;
     private readonly ILogger<TopologyInitializer> _logger;
 
@@ -26,11 +28,13 @@ internal sealed class TopologyInitializer : IHostedService
     public TopologyInitializer(
         ServiceBusAdministrationClient adminClient,
         MessageHandlerRegistry registry,
+        IServiceCollection serviceCollection,
         IOptions<AzureServiceBusOptions> options,
         ILogger<TopologyInitializer> logger)
     {
         _adminClient = adminClient;
         _registry = registry;
+        _serviceCollection = serviceCollection;
         _options = options;
         _logger = logger;
     }
@@ -38,6 +42,9 @@ internal sealed class TopologyInitializer : IHostedService
     /// <inheritdoc/>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // Backfill handler types registered via factory lambdas (not AddHandlersFromAssemblies).
+        _registry.BackfillFromServiceCollection(_serviceCollection);
+
         var opts = _options.Value;
         if (!opts.AutoCreateResources)
             return;

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQTopologyInitializer.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQTopologyInitializer.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -18,6 +19,7 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
 {
     private readonly IConnection _connection;
     private readonly MessageHandlerRegistry _registry;
+    private readonly IServiceCollection _serviceCollection;
     private readonly IOptions<RabbitMQOptions> _options;
     private readonly ILogger<RabbitMQTopologyInitializer> _logger;
 
@@ -25,11 +27,13 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
     public RabbitMQTopologyInitializer(
         IConnection connection,
         MessageHandlerRegistry registry,
+        IServiceCollection serviceCollection,
         IOptions<RabbitMQOptions> options,
         ILogger<RabbitMQTopologyInitializer> logger)
     {
         _connection = connection;
         _registry = registry;
+        _serviceCollection = serviceCollection;
         _options = options;
         _logger = logger;
     }
@@ -37,6 +41,9 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
     /// <inheritdoc/>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // Backfill handler types registered via factory lambdas (not AddHandlersFromAssemblies).
+        _registry.BackfillFromServiceCollection(_serviceCollection);
+
         var opts = _options.Value;
         if (!opts.AutoDeclareTopology)
             return;

--- a/src/OpinionatedEventing/DependencyInjection/MessageHandlerRegistry.cs
+++ b/src/OpinionatedEventing/DependencyInjection/MessageHandlerRegistry.cs
@@ -1,11 +1,15 @@
 #nullable enable
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace OpinionatedEventing.DependencyInjection;
 
 /// <summary>
 /// Holds the set of event and command types that have registered handlers.
 /// Populated during DI configuration by <see cref="OpinionatedEventingBuilder.AddHandlersFromAssemblies"/>,
 /// <c>AddSaga&lt;TOrchestrator&gt;</c>, and <c>AddSagaParticipant&lt;TParticipant&gt;</c>.
+/// Also backfilled at host startup by transport topology initializers to catch handler types that were
+/// registered directly on <see cref="IServiceCollection"/> via factory lambdas.
 /// Consumed by transport workers and topology initializers at host startup.
 /// </summary>
 public sealed class MessageHandlerRegistry
@@ -22,4 +26,35 @@ public sealed class MessageHandlerRegistry
 
     internal void RegisterEventType(Type eventType) => _eventTypes.Add(eventType);
     internal void RegisterCommandType(Type commandType) => _commandTypes.Add(commandType);
+
+    /// <summary>
+    /// Scans <paramref name="services"/> for any <c>IEventHandler&lt;T&gt;</c> and
+    /// <c>ICommandHandler&lt;T&gt;</c> service descriptors and registers their message types.
+    /// This is called by transport topology initializers at host startup to capture handler types
+    /// that were registered via factory lambdas rather than
+    /// <see cref="OpinionatedEventingBuilder.AddHandlersFromAssemblies"/>.
+    /// </summary>
+    internal void BackfillFromServiceCollection(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        foreach (var descriptor in services)
+        {
+            var serviceType = descriptor.ServiceType;
+            if (!serviceType.IsGenericType)
+                continue;
+
+            var definition = serviceType.GetGenericTypeDefinition();
+            var typeArg = serviceType.GetGenericArguments()[0];
+
+            // Skip open generic parameters (FullName is null for unbound type arguments).
+            if (typeArg.FullName is null)
+                continue;
+
+            if (definition == typeof(IEventHandler<>))
+                RegisterEventType(typeArg);
+            else if (definition == typeof(ICommandHandler<>))
+                RegisterCommandType(typeArg);
+        }
+    }
 }

--- a/src/OpinionatedEventing/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/OpinionatedEventing/DependencyInjection/ServiceCollectionExtensions.cs
@@ -31,6 +31,12 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IMessagingContext>(sp => sp.GetRequiredService<MessagingContext>());
         services.TryAddSingleton<IMessageHandlerRunner, MessageHandlerRunner>();
 
+        // Expose the service collection itself so topology initializers can backfill
+        // MessageHandlerRegistry with handler types registered via factory lambdas.
+        // Safe as a singleton: the collection is fully populated before any IHostedService.StartAsync
+        // runs, so topology initializers only ever read it — never write to it.
+        services.TryAddSingleton<IServiceCollection>(services);
+
         // Re-use existing instances when AddOpinionatedEventing is called more than once so that
         // all builders always write to the same instances that the DI container will resolve.
         var handlerRegistry =

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusIntegrationTests.cs
@@ -201,7 +201,7 @@ public sealed class AzureServiceBusIntegrationTests
         => new()
         {
             Id = Guid.NewGuid(),
-            MessageType = typeof(T).AssemblyQualifiedName!,
+            MessageType = typeof(T).FullName!,
             MessageKind = kind,
             Payload = System.Text.Json.JsonSerializer.Serialize(payload),
             CorrelationId = Guid.NewGuid(),

--- a/tests/OpinionatedEventing.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/OpinionatedEventing.Tests/ServiceCollectionExtensionsTests.cs
@@ -177,6 +177,73 @@ public sealed class ServiceCollectionExtensionsTests
         Assert.NotNull(handler);
     }
 
+    [Fact]
+    public void AddOpinionatedEventing_RegistersIServiceCollectionAsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetService<IServiceCollection>();
+
+        Assert.NotNull(resolved);
+        // Must be the same instance that was registered, not a copy.
+        Assert.Same(services, resolved);
+    }
+
+    [Fact]
+    public void MessageHandlerRegistry_BackfillFromServiceCollection_PicksUpFactoryRegisteredEventHandler()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+
+        // Register handler via factory lambda — the pattern used in integration tests.
+        services.AddScoped<IEventHandler<TestEvent>>(_ => new TestEventHandler());
+
+        var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<MessageHandlerRegistry>();
+        var serviceCollection = provider.GetRequiredService<IServiceCollection>();
+
+        registry.BackfillFromServiceCollection(serviceCollection);
+
+        Assert.Contains(typeof(TestEvent), registry.EventTypes);
+    }
+
+    [Fact]
+    public void MessageHandlerRegistry_BackfillFromServiceCollection_PicksUpFactoryRegisteredCommandHandler()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+
+        services.AddScoped<ICommandHandler<TestCommand>>(_ => new TestCommandHandler());
+
+        var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<MessageHandlerRegistry>();
+        var serviceCollection = provider.GetRequiredService<IServiceCollection>();
+
+        registry.BackfillFromServiceCollection(serviceCollection);
+
+        Assert.Contains(typeof(TestCommand), registry.CommandTypes);
+    }
+
+    [Fact]
+    public void MessageHandlerRegistry_BackfillFromServiceCollection_IsIdempotent()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+        services.AddScoped<IEventHandler<TestEvent>>(_ => new TestEventHandler());
+
+        var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<MessageHandlerRegistry>();
+        var serviceCollection = provider.GetRequiredService<IServiceCollection>();
+
+        // Calling twice must not throw and must not duplicate the entry.
+        registry.BackfillFromServiceCollection(serviceCollection);
+        registry.BackfillFromServiceCollection(serviceCollection);
+
+        Assert.Single(registry.EventTypes, t => t == typeof(TestEvent));
+    }
+
     // ---- test fakes ----
 
     public sealed record TestEvent(Guid Id) : IEvent;


### PR DESCRIPTION
## Summary

- `TopologyInitializer` (ASB) and `RabbitMQTopologyInitializer` were reading an empty `MessageHandlerRegistry` when handlers were registered via factory lambdas (`services.AddScoped<IEventHandler<T>>(_ => ...)`), because only `AddHandlersFromAssemblies` populates the registry. This caused `MessagingEntityNotFound` at runtime for the integration tests after PR #118 introduced the registry design.
- Fix: expose the `IServiceCollection` instance as a singleton in `AddOpinionatedEventing` and call `MessageHandlerRegistry.BackfillFromServiceCollection` at the start of each topology initializer's `StartAsync`. The collection is read-only at that point (fully built before any hosted service starts).
- Also aligns `AzureServiceBusIntegrationTests.BuildOutboxMessage` to use `FullName` (stable wire identifier) instead of `AssemblyQualifiedName`, per issue #105.

## Test plan

- [ ] 4 new unit tests in `ServiceCollectionExtensionsTests` cover: `IServiceCollection` singleton registration, event handler backfill, command handler backfill, idempotency
- [ ] All 195 `OpinionatedEventing.Tests` unit tests pass locally
- [ ] All 84 `OpinionatedEventing.AzureServiceBus.Tests` unit tests pass locally (integration tests require Docker/emulator — CI only)
- [ ] Integration tests on CI should no longer fail with `MessagingEntityNotFound` for `order-placed`, `process-payment`, and `checkout-order`

🤖 Generated with [Claude Code](https://claude.com/claude-code)