### PR TITLE
feat: stop sync-over-async at DI resolution for RabbitMQ.IConnection (#104)

### DIFF
--- a/src/OpinionatedEventing.RabbitMQ/DependencyInjection/RabbitMQServiceCollectionExtensions.cs
+++ b/src/OpinionatedEventing.RabbitMQ/DependencyInjection/RabbitMQServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -8,7 +7,6 @@ using OpinionatedEventing;
 using OpinionatedEventing.DependencyInjection;
 using OpinionatedEventing.Outbox;
 using OpinionatedEventing.RabbitMQ;
-using RabbitMQ.Client;
 
 // Placed in this namespace so the extension is available without an extra using directive.
 namespace Microsoft.Extensions.DependencyInjection;
@@ -34,37 +32,19 @@ public static class RabbitMQServiceCollectionExtensions
         services.Configure(configure);
         services.TryAddSingleton(TimeProvider.System);
 
-        services.TryAddSingleton<IConnection>(sp =>
-        {
-            var opts = sp.GetRequiredService<IOptions<RabbitMQOptions>>().Value;
-            var config = sp.GetService<IConfiguration>();
-            var connectionString = ResolveConnectionString(opts, config);
-            var factory = new ConnectionFactory { Uri = new Uri(connectionString) };
-            return factory.CreateConnectionAsync().GetAwaiter().GetResult();
-        });
-
+        services.TryAddSingleton<RabbitMqConnectionHolder>();
         services.TryAddSingleton<IConsumerPauseController, NullConsumerPauseController>();
         services.TryAddSingleton<ITransport, RabbitMQTransport>();
 
+        // Connection initializer must be registered before topology and consumer so that
+        // StartAsync runs first and the holder is populated before the others await it.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, RabbitMqConnectionInitializer>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostedService, RabbitMQTopologyInitializer>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostedService, RabbitMQConsumerWorker>());
 
         return services;
-    }
-
-    private static string ResolveConnectionString(RabbitMQOptions opts, IConfiguration? config)
-    {
-        if (!string.IsNullOrWhiteSpace(opts.ConnectionString))
-            return opts.ConnectionString;
-
-        var aspireConnectionString = config?["ConnectionStrings:rabbitmq"];
-        if (!string.IsNullOrWhiteSpace(aspireConnectionString))
-            return aspireConnectionString;
-
-        throw new InvalidOperationException(
-            "RabbitMQOptions requires either ConnectionString to be set, " +
-            "or a 'ConnectionStrings:rabbitmq' entry in IConfiguration (Aspire service discovery).");
     }
 }

--- a/src/OpinionatedEventing.RabbitMQ/HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/OpinionatedEventing.RabbitMQ/HealthChecks/HealthChecksBuilderExtensions.cs
@@ -13,7 +13,8 @@ public static class RabbitMqHealthChecksBuilderExtensions
 {
     /// <summary>
     /// Registers a liveness health check that verifies the RabbitMQ broker connection is open.
-    /// Requires <c>IConnection</c> to be registered (provided by <c>AddRabbitMQTransport</c>).
+    /// Requires <c>AddRabbitMQTransport()</c> to have been called so that the internal
+    /// connection holder is available in the service collection.
     /// </summary>
     /// <param name="builder">The health checks builder to extend.</param>
     /// <returns>The same <paramref name="builder"/> for chaining.</returns>

--- a/src/OpinionatedEventing.RabbitMQ/HealthChecks/RabbitMqConnectivityHealthCheck.cs
+++ b/src/OpinionatedEventing.RabbitMQ/HealthChecks/RabbitMqConnectivityHealthCheck.cs
@@ -1,22 +1,22 @@
 #nullable enable
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using RabbitMQ.Client;
 
 namespace OpinionatedEventing.RabbitMQ.HealthChecks;
 
 /// <summary>
 /// Liveness health check that verifies the RabbitMQ broker connection is open.
-/// Reports <see cref="HealthStatus.Unhealthy"/> if the <see cref="IConnection"/> is closed.
+/// Reports <see cref="HealthStatus.Unhealthy"/> if the connection is not yet established or
+/// is closed.
 /// </summary>
 internal sealed class RabbitMqConnectivityHealthCheck : IHealthCheck
 {
-    private readonly IConnection _connection;
+    private readonly RabbitMqConnectionHolder _holder;
 
     /// <summary>Initialises a new <see cref="RabbitMqConnectivityHealthCheck"/>.</summary>
-    public RabbitMqConnectivityHealthCheck(IConnection connection)
+    public RabbitMqConnectivityHealthCheck(RabbitMqConnectionHolder holder)
     {
-        _connection = connection;
+        _holder = holder;
     }
 
     /// <inheritdoc/>
@@ -24,7 +24,9 @@ internal sealed class RabbitMqConnectivityHealthCheck : IHealthCheck
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
-        HealthCheckResult result = _connection.IsOpen
+        var connection = _holder.TryGetConnection();
+
+        HealthCheckResult result = connection?.IsOpen == true
             ? HealthCheckResult.Healthy("RabbitMQ connection is open.")
             : HealthCheckResult.Unhealthy("RabbitMQ connection is closed.");
 

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
@@ -20,7 +20,7 @@ namespace OpinionatedEventing.RabbitMQ;
 /// </summary>
 internal sealed class RabbitMQConsumerWorker : BackgroundService
 {
-    private readonly IConnection _connection;
+    private readonly RabbitMqConnectionHolder _connectionHolder;
     private readonly IMessageHandlerRunner _handlerRunner;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly MessageHandlerRegistry _registry;
@@ -40,7 +40,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
 
     /// <summary>Initialises a new <see cref="RabbitMQConsumerWorker"/>.</summary>
     public RabbitMQConsumerWorker(
-        IConnection connection,
+        RabbitMqConnectionHolder connectionHolder,
         IMessageHandlerRunner handlerRunner,
         IServiceScopeFactory scopeFactory,
         MessageHandlerRegistry registry,
@@ -49,7 +49,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
         TimeProvider timeProvider,
         ILogger<RabbitMQConsumerWorker> logger)
     {
-        _connection = connection;
+        _connectionHolder = connectionHolder;
         _handlerRunner = handlerRunner;
         _scopeFactory = scopeFactory;
         _registry = registry;
@@ -62,6 +62,8 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
     /// <inheritdoc/>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        var connection = await _connectionHolder.GetConnectionAsync(stoppingToken).ConfigureAwait(false);
+
         var opts = _options.Value;
         var eventTypes = _registry.EventTypes;
         var commandTypes = _registry.CommandTypes;
@@ -78,7 +80,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
 
             var queueName = MessageNamingConvention.GetEventQueueName(eventType, opts.ServiceName);
             var exchangeName = MessageNamingConvention.GetExchangeName(eventType);
-            await StartConsumerAsync(queueName, stoppingToken).ConfigureAwait(false);
+            await StartConsumerAsync(connection, queueName, stoppingToken).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Consuming event '{EventType}' from queue '{Queue}' (exchange '{Exchange}').",
@@ -88,7 +90,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
         foreach (var commandType in commandTypes)
         {
             var queueName = MessageNamingConvention.GetQueueName(commandType);
-            await StartConsumerAsync(queueName, stoppingToken).ConfigureAwait(false);
+            await StartConsumerAsync(connection, queueName, stoppingToken).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Consuming command '{CommandType}' from queue '{Queue}'.",
@@ -179,10 +181,11 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
     }
 
     private async Task StartConsumerAsync(
+        IConnection connection,
         string queueName,
         CancellationToken ct)
     {
-        var channel = await _connection.CreateChannelAsync(cancellationToken: ct).ConfigureAwait(false);
+        var channel = await connection.CreateChannelAsync(cancellationToken: ct).ConfigureAwait(false);
 
         await channel.BasicQosAsync(
             prefetchSize: 0,

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQTopologyInitializer.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQTopologyInitializer.cs
@@ -16,19 +16,19 @@ namespace OpinionatedEventing.RabbitMQ;
 /// </summary>
 internal sealed class RabbitMQTopologyInitializer : IHostedService
 {
-    private readonly IConnection _connection;
+    private readonly RabbitMqConnectionHolder _connectionHolder;
     private readonly MessageHandlerRegistry _registry;
     private readonly IOptions<RabbitMQOptions> _options;
     private readonly ILogger<RabbitMQTopologyInitializer> _logger;
 
     /// <summary>Initialises a new <see cref="RabbitMQTopologyInitializer"/>.</summary>
     public RabbitMQTopologyInitializer(
-        IConnection connection,
+        RabbitMqConnectionHolder connectionHolder,
         MessageHandlerRegistry registry,
         IOptions<RabbitMQOptions> options,
         ILogger<RabbitMQTopologyInitializer> logger)
     {
-        _connection = connection;
+        _connectionHolder = connectionHolder;
         _registry = registry;
         _options = options;
         _logger = logger;
@@ -41,10 +41,12 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
         if (!opts.AutoDeclareTopology)
             return;
 
+        var connection = await _connectionHolder.GetConnectionAsync(cancellationToken).ConfigureAwait(false);
+
         var eventTypes = _registry.EventTypes;
         var commandTypes = _registry.CommandTypes;
 
-        await using var channel = await _connection
+        await using var channel = await connection
             .CreateChannelAsync(cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
@@ -161,5 +163,4 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
             throw;
         }
     }
-
 }

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQTransport.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQTransport.cs
@@ -14,20 +14,21 @@ namespace OpinionatedEventing.RabbitMQ;
 /// </summary>
 internal sealed class RabbitMQTransport : ITransport, IAsyncDisposable
 {
-    private readonly IConnection _connection;
+    private readonly RabbitMqConnectionHolder _connectionHolder;
     private readonly IMessageTypeRegistry _registry;
     private readonly ILogger<RabbitMQTransport> _logger;
 
+    private IConnection? _connection;
     private IChannel? _publishChannel;
     private readonly SemaphoreSlim _channelLock = new(1, 1);
 
     /// <summary>Initialises a new <see cref="RabbitMQTransport"/>.</summary>
     public RabbitMQTransport(
-        IConnection connection,
+        RabbitMqConnectionHolder connectionHolder,
         IMessageTypeRegistry registry,
         ILogger<RabbitMQTransport> logger)
     {
-        _connection = connection;
+        _connectionHolder = connectionHolder;
         _registry = registry;
         _logger = logger;
     }
@@ -71,6 +72,8 @@ internal sealed class RabbitMQTransport : ITransport, IAsyncDisposable
         await _channelLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            _connection ??= await _connectionHolder.GetConnectionAsync(cancellationToken).ConfigureAwait(false);
+
             if (_publishChannel is null || !_publishChannel.IsOpen)
                 _publishChannel = await _connection
                     .CreateChannelAsync(cancellationToken: cancellationToken)

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMqConnectionHolder.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMqConnectionHolder.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+using RabbitMQ.Client;
+
+namespace OpinionatedEventing.RabbitMQ;
+
+/// <summary>
+/// Singleton that holds the RabbitMQ connection once established by
+/// <see cref="RabbitMqConnectionInitializer"/>. Consumers await
+/// <see cref="GetConnectionAsync"/> rather than blocking the DI thread.
+/// </summary>
+internal sealed class RabbitMqConnectionHolder
+{
+    private readonly TaskCompletionSource<IConnection> _tcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Returns the connection once it has been established, or throws if
+    /// initialization failed. Respects <paramref name="ct"/>.
+    /// </summary>
+    public Task<IConnection> GetConnectionAsync(CancellationToken ct)
+        => _tcs.Task.WaitAsync(ct);
+
+    /// <summary>
+    /// Returns the connection if already established; otherwise <see langword="null"/>.
+    /// Safe to call without awaiting (used by the health check).
+    /// </summary>
+    public IConnection? TryGetConnection()
+        => _tcs.Task.IsCompletedSuccessfully ? _tcs.Task.Result : null;
+
+    internal void SetConnection(IConnection connection) => _tcs.TrySetResult(connection);
+
+    internal void SetException(Exception exception) => _tcs.TrySetException(exception);
+}

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMqConnectionInitializer.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMqConnectionInitializer.cs
@@ -1,0 +1,87 @@
+#nullable enable
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+
+namespace OpinionatedEventing.RabbitMQ;
+
+/// <summary>
+/// Hosted service that establishes the RabbitMQ connection asynchronously during host startup.
+/// Stores the result in <see cref="RabbitMqConnectionHolder"/> so that
+/// <see cref="RabbitMQTransport"/>, <see cref="RabbitMQTopologyInitializer"/>, and
+/// <see cref="RabbitMQConsumerWorker"/> can await it without blocking.
+/// </summary>
+internal sealed class RabbitMqConnectionInitializer : IHostedService, IAsyncDisposable
+{
+    private readonly RabbitMqConnectionHolder _holder;
+    private readonly IOptions<RabbitMQOptions> _options;
+    private readonly IConfiguration? _config;
+    private readonly ILogger<RabbitMqConnectionInitializer> _logger;
+
+    private IConnection? _connection;
+
+    /// <summary>Initialises a new <see cref="RabbitMqConnectionInitializer"/>.</summary>
+    public RabbitMqConnectionInitializer(
+        RabbitMqConnectionHolder holder,
+        IOptions<RabbitMQOptions> options,
+        ILogger<RabbitMqConnectionInitializer> logger,
+        IConfiguration? config = null)
+    {
+        _holder = holder;
+        _options = options;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var opts = _options.Value;
+        var connectionString = ResolveConnectionString(opts, _config);
+        var factory = new ConnectionFactory { Uri = new Uri(connectionString) };
+
+        _logger.LogInformation("Establishing RabbitMQ connection to '{Host}'...", factory.HostName);
+
+        try
+        {
+            _connection = await factory.CreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+            _holder.SetConnection(_connection);
+            _logger.LogInformation("RabbitMQ connection established.");
+        }
+        catch (Exception ex)
+        {
+            _holder.SetException(ex);
+            _logger.LogError(ex, "Failed to establish RabbitMQ connection.");
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    // Intentional no-op: the connection must stay open until all consumers and the topology
+    // initializer have completed their own StopAsync teardown. Disposal happens in DisposeAsync.
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is not null)
+            await _connection.DisposeAsync().ConfigureAwait(false);
+    }
+
+    internal static string ResolveConnectionString(RabbitMQOptions opts, IConfiguration? config)
+    {
+        if (!string.IsNullOrWhiteSpace(opts.ConnectionString))
+            return opts.ConnectionString;
+
+        var aspireConnectionString = config?["ConnectionStrings:rabbitmq"];
+        if (!string.IsNullOrWhiteSpace(aspireConnectionString))
+            return aspireConnectionString;
+
+        throw new InvalidOperationException(
+            "RabbitMQOptions requires either ConnectionString to be set, " +
+            "or a 'ConnectionStrings:rabbitmq' entry in IConfiguration (Aspire service discovery).");
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/ConsumerWorkerPauseTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/ConsumerWorkerPauseTests.cs
@@ -15,18 +15,21 @@ namespace OpinionatedEventing.RabbitMQ.Tests;
 
 /// <summary>
 /// Unit tests for the pause/resume loop in <see cref="RabbitMQConsumerWorker"/>.
-/// These tests register no handlers so the worker never calls <see cref="IConnection"/>
+/// These tests register no handlers so the worker never creates channels
 /// — it proceeds directly to <c>RunPauseLoopAsync</c> where the pause logic lives.
 /// </summary>
 public sealed class ConsumerWorkerPauseTests
 {
     private static RabbitMQConsumerWorker CreateWorker(IConsumerPauseController pauseController)
     {
-        // Empty registry → no handlers registered → no channels created
+        // Empty registry → no handlers → GetConnectionAsync resolves immediately then no channels are created
+        var holder = new RabbitMqConnectionHolder();
+        holder.SetConnection(new NeverCalledConnection());
+
         var options = MSOptions.Create(new RabbitMQOptions { ConnectionString = "amqp://localhost" });
 
         return new RabbitMQConsumerWorker(
-            connection: new NeverCalledConnection(),
+            connectionHolder: holder,
             handlerRunner: new NeverCalledHandlerRunner(),
             scopeFactory: new NeverCalledScopeFactory(),
             registry: new MessageHandlerRegistry(),

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/HealthChecks/RabbitMqConnectivityHealthCheckTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/HealthChecks/RabbitMqConnectivityHealthCheckTests.cs
@@ -3,7 +3,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
+using OpinionatedEventing.RabbitMQ;
+using OpinionatedEventing.RabbitMQ.HealthChecks;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 using Xunit;
 
 namespace OpinionatedEventing.RabbitMQ.Tests.HealthChecks;
@@ -34,5 +37,87 @@ public sealed class RabbitMqConnectivityHealthCheckTests
 
         Assert.Contains("live", registration.Tags);
         Assert.Contains("broker", registration.Tags);
+    }
+
+    // ─── Behaviour tests ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckHealthAsync_returns_Unhealthy_when_connection_not_yet_established()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var holder = new RabbitMqConnectionHolder(); // never set
+        var check = new RabbitMqConnectivityHealthCheck(holder);
+
+        var result = await check.CheckHealthAsync(MakeContext(), ct);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_returns_Healthy_when_connection_is_open()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var holder = new RabbitMqConnectionHolder();
+        holder.SetConnection(new FakeConnection(isOpen: true));
+        var check = new RabbitMqConnectivityHealthCheck(holder);
+
+        var result = await check.CheckHealthAsync(MakeContext(), ct);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_returns_Unhealthy_when_connection_is_closed()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var holder = new RabbitMqConnectionHolder();
+        holder.SetConnection(new FakeConnection(isOpen: false));
+        var check = new RabbitMqConnectivityHealthCheck(holder);
+
+        var result = await check.CheckHealthAsync(MakeContext(), ct);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+    }
+
+    private static HealthCheckContext MakeContext() => new()
+    {
+        Registration = new HealthCheckRegistration("test", _ => null!, HealthStatus.Unhealthy, []),
+    };
+
+    private sealed class FakeConnection(bool isOpen) : IConnection
+    {
+        public bool IsOpen => isOpen;
+
+        public ushort ChannelMax => 0;
+        public IDictionary<string, object?> ClientProperties => new Dictionary<string, object?>();
+        public string? ClientProvidedName => null;
+        public ShutdownEventArgs? CloseReason => null;
+        public AmqpTcpEndpoint Endpoint => new("localhost");
+        public uint FrameMax => 0;
+        public TimeSpan Heartbeat => TimeSpan.Zero;
+        public IProtocol Protocol => throw new NotImplementedException();
+        public IDictionary<string, object?> ServerProperties => new Dictionary<string, object?>();
+        public IEnumerable<ShutdownReportEntry> ShutdownReport => [];
+        public int LocalPort => 0;
+        public int RemotePort => 0;
+
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ConnectionShutdownAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? RecoverySucceededAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionRecoveryErrorEventArgs>? ConnectionRecoveryErrorAsync { add { } remove { } }
+        public event AsyncEventHandler<ConsumerTagChangedAfterRecoveryEventArgs>? ConsumerTagChangeAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<QueueNameChangedAfterRecoveryEventArgs>? QueueNameChangedAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<RecoveringConsumerEventArgs>? RecoveringConsumerAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionBlockedEventArgs>? ConnectionBlockedAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? ConnectionUnblockedAsync { add { } remove { } }
+
+        public Task CloseAsync(ushort reasonCode, string reasonText, TimeSpan timeout, bool abort,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IChannel> CreateChannelAsync(CreateChannelOptions? options = null,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateSecretAsync(string newSecret, string reason,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
     }
 }

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQConsumerWorkerTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQConsumerWorkerTests.cs
@@ -17,10 +17,13 @@ public sealed class RabbitMQConsumerWorkerTests
 {
     private static RabbitMQConsumerWorker CreateWorker(IMessageHandlerRunner runner)
     {
+        var holder = new RabbitMqConnectionHolder();
+        holder.SetConnection(new NeverCalledConnection());
+
         var options = MSOptions.Create(new RabbitMQOptions { ConnectionString = "amqp://localhost" });
 
         return new RabbitMQConsumerWorker(
-            connection: new NeverCalledConnection(),
+            connectionHolder: holder,
             handlerRunner: runner,
             scopeFactory: new NeverCalledScopeFactory(),
             registry: new MessageHandlerRegistry(),

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMqConnectionHolderTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMqConnectionHolderTests.cs
@@ -1,0 +1,130 @@
+#nullable enable
+
+using OpinionatedEventing.RabbitMQ;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests;
+
+public sealed class RabbitMqConnectionHolderTests
+{
+    [Fact]
+    public async Task GetConnectionAsync_returns_connection_after_SetConnection()
+    {
+        var holder = new RabbitMqConnectionHolder();
+        var fakeConnection = new FakeConnection();
+
+        holder.SetConnection(fakeConnection);
+
+        var result = await holder.GetConnectionAsync(CancellationToken.None);
+
+        Assert.Same(fakeConnection, result);
+    }
+
+    [Fact]
+    public async Task GetConnectionAsync_awaits_until_connection_is_set()
+    {
+        var holder = new RabbitMqConnectionHolder();
+        var fakeConnection = new FakeConnection();
+
+        var task = holder.GetConnectionAsync(CancellationToken.None);
+        Assert.False(task.IsCompleted);
+
+        holder.SetConnection(fakeConnection);
+        var result = await task;
+
+        Assert.Same(fakeConnection, result);
+    }
+
+    [Fact]
+    public async Task GetConnectionAsync_propagates_exception_from_SetException()
+    {
+        var holder = new RabbitMqConnectionHolder();
+        var expected = new InvalidOperationException("broker down");
+
+        holder.SetException(expected);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => holder.GetConnectionAsync(CancellationToken.None));
+
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public async Task GetConnectionAsync_throws_OperationCanceledException_when_cancelled()
+    {
+        var holder = new RabbitMqConnectionHolder();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => holder.GetConnectionAsync(cts.Token));
+    }
+
+    [Fact]
+    public void TryGetConnection_returns_null_before_connection_is_set()
+    {
+        var holder = new RabbitMqConnectionHolder();
+
+        Assert.Null(holder.TryGetConnection());
+    }
+
+    [Fact]
+    public void TryGetConnection_returns_connection_after_SetConnection()
+    {
+        var holder = new RabbitMqConnectionHolder();
+        var fakeConnection = new FakeConnection();
+
+        holder.SetConnection(fakeConnection);
+
+        Assert.Same(fakeConnection, holder.TryGetConnection());
+    }
+
+    [Fact]
+    public void TryGetConnection_returns_null_when_holder_faulted()
+    {
+        var holder = new RabbitMqConnectionHolder();
+        holder.SetException(new Exception("boom"));
+
+        Assert.Null(holder.TryGetConnection());
+    }
+
+    // ─── Minimal fake ─────────────────────────────────────────────────────────────
+
+    private sealed class FakeConnection : IConnection
+    {
+        public ushort ChannelMax => 0;
+        public IDictionary<string, object?> ClientProperties => new Dictionary<string, object?>();
+        public string? ClientProvidedName => null;
+        public ShutdownEventArgs? CloseReason => null;
+        public AmqpTcpEndpoint Endpoint => new("localhost");
+        public uint FrameMax => 0;
+        public TimeSpan Heartbeat => TimeSpan.Zero;
+        public bool IsOpen => true;
+        public IProtocol Protocol => throw new NotImplementedException();
+        public IDictionary<string, object?> ServerProperties => new Dictionary<string, object?>();
+        public IEnumerable<ShutdownReportEntry> ShutdownReport => [];
+        public int LocalPort => 0;
+        public int RemotePort => 0;
+
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ConnectionShutdownAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? RecoverySucceededAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionRecoveryErrorEventArgs>? ConnectionRecoveryErrorAsync { add { } remove { } }
+        public event AsyncEventHandler<ConsumerTagChangedAfterRecoveryEventArgs>? ConsumerTagChangeAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<QueueNameChangedAfterRecoveryEventArgs>? QueueNameChangedAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<RecoveringConsumerEventArgs>? RecoveringConsumerAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionBlockedEventArgs>? ConnectionBlockedAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? ConnectionUnblockedAsync { add { } remove { } }
+
+        public Task CloseAsync(ushort reasonCode, string reasonText, TimeSpan timeout, bool abort,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IChannel> CreateChannelAsync(CreateChannelOptions? options = null,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task UpdateSecretAsync(string newSecret, string reason,
+            CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMqConnectionInitializerTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMqConnectionInitializerTests.cs
@@ -1,0 +1,88 @@
+#nullable enable
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using MSOptions = Microsoft.Extensions.Options.Options;
+using OpinionatedEventing.RabbitMQ;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests;
+
+public sealed class RabbitMqConnectionInitializerTests
+{
+    // ─── ResolveConnectionString ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveConnectionString_returns_explicit_ConnectionString()
+    {
+        var opts = new RabbitMQOptions { ConnectionString = "amqp://explicit/" };
+
+        var result = RabbitMqConnectionInitializer.ResolveConnectionString(opts, config: null);
+
+        Assert.Equal("amqp://explicit/", result);
+    }
+
+    [Fact]
+    public void ResolveConnectionString_falls_back_to_Aspire_config()
+    {
+        var opts = new RabbitMQOptions();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:rabbitmq"] = "amqp://aspire/",
+            })
+            .Build();
+
+        var result = RabbitMqConnectionInitializer.ResolveConnectionString(opts, config);
+
+        Assert.Equal("amqp://aspire/", result);
+    }
+
+    [Fact]
+    public void ResolveConnectionString_prefers_explicit_over_Aspire_config()
+    {
+        var opts = new RabbitMQOptions { ConnectionString = "amqp://explicit/" };
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:rabbitmq"] = "amqp://aspire/",
+            })
+            .Build();
+
+        var result = RabbitMqConnectionInitializer.ResolveConnectionString(opts, config);
+
+        Assert.Equal("amqp://explicit/", result);
+    }
+
+    [Fact]
+    public void ResolveConnectionString_throws_when_no_connection_string_available()
+    {
+        var opts = new RabbitMQOptions();
+
+        Assert.Throws<InvalidOperationException>(
+            () => RabbitMqConnectionInitializer.ResolveConnectionString(opts, config: null));
+    }
+
+    // ─── StartAsync failure ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StartAsync_faults_holder_and_rethrows_on_connection_failure()
+    {
+        // A connection string that points to a host that will refuse immediately
+        // on localhost with an unlikely port so the test doesn't hang.
+        var opts = MSOptions.Create(new RabbitMQOptions { ConnectionString = "amqp://127.0.0.1:1/" });
+        var holder = new RabbitMqConnectionHolder();
+
+        await using var initializer = new RabbitMqConnectionInitializer(
+            holder,
+            opts,
+            NullLogger<RabbitMqConnectionInitializer>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAnyAsync<Exception>(() => initializer.StartAsync(cts.Token));
+
+        // Holder must be faulted so that consumers surface the error instead of hanging.
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => holder.GetConnectionAsync(CancellationToken.None));
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMqConnectionInitializerTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMqConnectionInitializerTests.cs
@@ -63,6 +63,23 @@ public sealed class RabbitMqConnectionInitializerTests
             () => RabbitMqConnectionInitializer.ResolveConnectionString(opts, config: null));
     }
 
+    // ─── StopAsync ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StopAsync_completes_without_exception()
+    {
+        var opts = MSOptions.Create(new RabbitMQOptions { ConnectionString = "amqp://localhost/" });
+        var holder = new RabbitMqConnectionHolder();
+
+        await using var initializer = new RabbitMqConnectionInitializer(
+            holder,
+            opts,
+            NullLogger<RabbitMqConnectionInitializer>.Instance);
+
+        // StopAsync is a no-op — just verify it doesn't throw
+        await initializer.StopAsync(TestContext.Current.CancellationToken);
+    }
+
     // ─── StartAsync failure ────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RegistrationTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RegistrationTests.cs
@@ -1,11 +1,13 @@
 #nullable enable
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using OpinionatedEventing;
 using OpinionatedEventing.DependencyInjection;
 using OpinionatedEventing.Outbox;
 using OpinionatedEventing.RabbitMQ;
+using RabbitMQ.Client;
 using Xunit;
 
 namespace OpinionatedEventing.RabbitMQ.Tests;
@@ -73,6 +75,44 @@ public sealed class RegistrationTests
         Assert.Equal("order-service", opts.ServiceName);
         Assert.False(opts.AutoDeclareTopology);
         Assert.Equal(5, opts.PrefetchCount);
+    }
+
+    [Fact]
+    public void AddRabbitMQTransport_does_not_register_IConnection_singleton()
+    {
+        // IConnection must not be registered as a singleton — doing so would require
+        // sync-over-async at DI resolution time (see issue #104).
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+        services.AddRabbitMQTransport(o => o.ConnectionString = "amqp://guest:guest@localhost:5672/");
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IConnection));
+        Assert.Null(descriptor);
+    }
+
+    [Fact]
+    public void AddRabbitMQTransport_registers_RabbitMqConnectionHolder()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+        services.AddRabbitMQTransport(o => o.ConnectionString = "amqp://guest:guest@localhost:5672/");
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(RabbitMqConnectionHolder));
+        Assert.NotNull(descriptor);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddRabbitMQTransport_registers_RabbitMqConnectionInitializer_as_IHostedService()
+    {
+        var services = new ServiceCollection();
+        services.AddOpinionatedEventing();
+        services.AddRabbitMQTransport(o => o.ConnectionString = "amqp://guest:guest@localhost:5672/");
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IHostedService) &&
+            d.ImplementationType == typeof(RabbitMqConnectionInitializer));
+        Assert.NotNull(descriptor);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #104

## Summary

- Removes `factory.CreateConnectionAsync().GetAwaiter().GetResult()` from `AddRabbitMQTransport`
- Introduces `RabbitMqConnectionHolder` — an internal singleton backed by a `TaskCompletionSource<IConnection>` that consumers await without blocking
- Introduces `RabbitMqConnectionInitializer : IHostedService` that calls `CreateConnectionAsync` properly in `StartAsync`, stores the result in the holder, and surfaces failures as startup errors
- `RabbitMQTransport`, `RabbitMQTopologyInitializer`, `RabbitMQConsumerWorker`, and `RabbitMqConnectivityHealthCheck` now inject the holder instead of `IConnection` directly
- `IConnection` is no longer registered as a DI singleton

## Acceptance criteria

- [x] No sync-over-async in `AddRabbitMQTransport` — `IConnection` singleton registration removed entirely
- [x] Connection establishment logged at startup (`LogInformation`) and respects the host cancellation token (passed to `CreateConnectionAsync`)
- [x] Failure to connect surfaces as a startup error (exception rethrown from `StartAsync`) and faults the holder so consumers fail fast rather than hanging

## Test plan

- [x] `RabbitMqConnectionHolderTests` — `GetConnectionAsync` happy path, mid-wait resolution, exception propagation, cancellation; `TryGetConnection` before/after/on-fault
- [x] `RabbitMqConnectionInitializerTests` — `ResolveConnectionString` precedence rules; `StartAsync` failure faults holder and rethrows
- [x] `RegistrationTests` — verifies `IConnection` is absent, `RabbitMqConnectionHolder` is a singleton, `RabbitMqConnectionInitializer` is registered as `IHostedService`
- [x] All existing unit tests updated and passing (117 unit tests across 3 TFMs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)