### PR TITLE
feat(rabbitmq): delivery hardening — publisher confirms, mandatory routing, DLX/DLQ, channel pool

### DIFF
--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQTopologyInitializer.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQTopologyInitializer.cs
@@ -14,6 +14,8 @@ namespace OpinionatedEventing.RabbitMQ;
 /// Hosted service that idempotently declares RabbitMQ exchanges, queues, and bindings at
 /// application startup when <see cref="RabbitMQOptions.AutoDeclareTopology"/> is
 /// <see langword="true"/>.
+/// Each consumer queue gets a paired dead-letter exchange (<c>{queue}.dlx</c>) and dead-letter
+/// queue (<c>{queue}.dlq</c>) so that nacked messages are captured rather than dropped.
 /// </summary>
 internal sealed class RabbitMQTopologyInitializer : IHostedService
 {
@@ -44,29 +46,29 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
         // Backfill handler types registered via factory lambdas (not AddHandlersFromAssemblies).
         _registry.BackfillFromServiceCollection(_serviceCollection);
 
-        var opts = _options.Value;
+        RabbitMQOptions opts = _options.Value;
         if (!opts.AutoDeclareTopology)
             return;
 
-        var connection = await _connectionHolder.GetConnectionAsync(cancellationToken).ConfigureAwait(false);
+        IConnection connection = await _connectionHolder.GetConnectionAsync(cancellationToken).ConfigureAwait(false);
 
-        var eventTypes = _registry.EventTypes;
-        var commandTypes = _registry.CommandTypes;
+        IEnumerable<Type> eventTypes = _registry.EventTypes;
+        IEnumerable<Type> commandTypes = _registry.CommandTypes;
 
-        await using var channel = await connection
+        await using IChannel channel = await connection
             .CreateChannelAsync(cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        foreach (var eventType in eventTypes)
+        foreach (Type eventType in eventTypes)
         {
-            var exchangeName = MessageNamingConvention.GetExchangeName(eventType);
+            string exchangeName = MessageNamingConvention.GetExchangeName(eventType);
             await DeclareEventTopologyAsync(channel, exchangeName, opts.ServiceName, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        foreach (var commandType in commandTypes)
+        foreach (Type commandType in commandTypes)
         {
-            var queueName = MessageNamingConvention.GetQueueName(commandType);
+            string queueName = MessageNamingConvention.GetQueueName(commandType);
             await DeclareCommandTopologyAsync(channel, queueName, cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -101,13 +103,20 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
                 return;
             }
 
-            var queueName = $"{serviceName}.{exchangeName}";
+            string queueName = $"{serviceName}.{exchangeName}";
+
+            await DeclareDlxForQueueAsync(channel, queueName, ct).ConfigureAwait(false);
+
             await channel.QueueDeclareAsync(
                 queue: queueName,
                 durable: true,
                 exclusive: false,
                 autoDelete: false,
-                arguments: null,
+                arguments: new Dictionary<string, object?>
+                {
+                    ["x-dead-letter-exchange"] = $"{queueName}.dlx",
+                    ["x-dead-letter-routing-key"] = queueName,
+                },
                 cancellationToken: ct).ConfigureAwait(false);
 
             await channel.QueueBindAsync(
@@ -118,8 +127,8 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
                 cancellationToken: ct).ConfigureAwait(false);
 
             _logger.LogInformation(
-                "Declared queue '{Queue}' bound to exchange '{Exchange}'.",
-                queueName, exchangeName);
+                "Declared queue '{Queue}' bound to exchange '{Exchange}' with DLX '{DlxExchange}'.",
+                queueName, exchangeName, $"{queueName}.dlx");
         }
         catch (Exception ex)
         {
@@ -144,12 +153,18 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
                 arguments: null,
                 cancellationToken: ct).ConfigureAwait(false);
 
+            await DeclareDlxForQueueAsync(channel, queueName, ct).ConfigureAwait(false);
+
             await channel.QueueDeclareAsync(
                 queue: queueName,
                 durable: true,
                 exclusive: false,
                 autoDelete: false,
-                arguments: null,
+                arguments: new Dictionary<string, object?>
+                {
+                    ["x-dead-letter-exchange"] = $"{queueName}.dlx",
+                    ["x-dead-letter-routing-key"] = queueName,
+                },
                 cancellationToken: ct).ConfigureAwait(false);
 
             await channel.QueueBindAsync(
@@ -160,8 +175,8 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
                 cancellationToken: ct).ConfigureAwait(false);
 
             _logger.LogInformation(
-                "Declared command queue '{Queue}' bound to direct exchange '{Exchange}'.",
-                queueName, queueName);
+                "Declared command queue '{Queue}' bound to direct exchange '{Exchange}' with DLX '{DlxExchange}'.",
+                queueName, queueName, $"{queueName}.dlx");
         }
         catch (Exception ex)
         {
@@ -169,5 +184,37 @@ internal sealed class RabbitMQTopologyInitializer : IHostedService
                 "Failed to declare command topology for queue '{Queue}'.", queueName);
             throw;
         }
+    }
+
+    private async Task DeclareDlxForQueueAsync(IChannel channel, string mainQueueName, CancellationToken ct)
+    {
+        string dlxExchange = $"{mainQueueName}.dlx";
+        string dlqQueue = $"{mainQueueName}.dlq";
+
+        await channel.ExchangeDeclareAsync(
+            exchange: dlxExchange,
+            type: ExchangeType.Direct,
+            durable: true,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: ct).ConfigureAwait(false);
+
+        await channel.QueueDeclareAsync(
+            queue: dlqQueue,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: ct).ConfigureAwait(false);
+
+        await channel.QueueBindAsync(
+            queue: dlqQueue,
+            exchange: dlxExchange,
+            routingKey: mainQueueName,
+            arguments: null,
+            cancellationToken: ct).ConfigureAwait(false);
+
+        _logger.LogDebug("Declared DLX '{DlxExchange}' and DLQ '{DlqQueue}' for queue '{Queue}'.",
+            dlxExchange, dlqQueue, mainQueueName);
     }
 }

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQTransport.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQTransport.cs
@@ -1,7 +1,10 @@
 #nullable enable
 
+using System.Collections.Concurrent;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpinionatedEventing.Options;
 using OpinionatedEventing.Outbox;
 using OpinionatedEventing.RabbitMQ.Routing;
 using RabbitMQ.Client;
@@ -12,6 +15,19 @@ namespace OpinionatedEventing.RabbitMQ;
 /// RabbitMQ implementation of <see cref="ITransport"/>.
 /// Forwards outbox messages to the correct RabbitMQ exchange (events) or queue (commands).
 /// </summary>
+/// <remarks>
+/// Each channel in the pool has publisher confirmations enabled via
+/// <see cref="CreateChannelOptions"/>. <c>BasicPublishAsync</c>
+/// awaits the broker ack before returning, so a failed publish throws and the outbox dispatcher
+/// increments the attempt count rather than marking the message processed.
+/// <para>
+/// <c>mandatory: true</c> is set on every publish. When the broker cannot route a message it
+/// returns it and the client library throws <c>PublishReturnException</c> from
+/// <c>BasicPublishAsync</c>, propagating the failure to the outbox dispatcher.
+/// </para>
+/// The pool is sized by <see cref="OutboxOptions.ConcurrentWorkers"/> so each concurrent dispatch
+/// worker gets its own channel.
+/// </remarks>
 internal sealed class RabbitMQTransport : ITransport, IAsyncDisposable
 {
     private readonly RabbitMqConnectionHolder _connectionHolder;
@@ -19,41 +35,47 @@ internal sealed class RabbitMQTransport : ITransport, IAsyncDisposable
     private readonly ILogger<RabbitMQTransport> _logger;
 
     private IConnection? _connection;
-    private IChannel? _publishChannel;
-    private readonly SemaphoreSlim _channelLock = new(1, 1);
+    private readonly ConcurrentQueue<IChannel> _channelPool = new();
+    private readonly SemaphoreSlim _poolSemaphore;
+
+    private static readonly CreateChannelOptions ConfirmChannelOptions =
+        new(publisherConfirmationsEnabled: true, publisherConfirmationTrackingEnabled: true);
 
     /// <summary>Initialises a new <see cref="RabbitMQTransport"/>.</summary>
     public RabbitMQTransport(
         RabbitMqConnectionHolder connectionHolder,
         IMessageTypeRegistry registry,
+        IOptions<OutboxOptions> outboxOptions,
         ILogger<RabbitMQTransport> logger)
     {
         _connectionHolder = connectionHolder;
         _registry = registry;
         _logger = logger;
+        int poolSize = Math.Max(1, outboxOptions.Value.ConcurrentWorkers);
+        _poolSemaphore = new SemaphoreSlim(poolSize, poolSize);
     }
 
     /// <inheritdoc/>
     public async Task SendAsync(OutboxMessage message, CancellationToken cancellationToken = default)
     {
-        var type = _registry.Resolve(message.MessageType);
-
         string exchange;
         string routingKey;
 
         if (message.MessageKind == MessageKind.Event)
         {
+            Type type = _registry.Resolve(message.MessageType);
             exchange = MessageNamingConvention.GetExchangeName(type);
             routingKey = string.Empty;
         }
         else
         {
+            Type type = _registry.Resolve(message.MessageType);
             exchange = MessageNamingConvention.GetQueueName(type);
             routingKey = MessageNamingConvention.GetQueueName(type);
         }
 
-        var body = Encoding.UTF8.GetBytes(message.Payload);
-        var properties = new BasicProperties
+        ReadOnlyMemory<byte> body = Encoding.UTF8.GetBytes(message.Payload);
+        BasicProperties properties = new()
         {
             MessageId = message.Id.ToString(),
             ContentType = "application/json",
@@ -69,39 +91,59 @@ internal sealed class RabbitMQTransport : ITransport, IAsyncDisposable
         if (message.CausationId.HasValue)
             properties.Headers["CausationId"] = message.CausationId.Value.ToString();
 
-        await _channelLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _poolSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        IChannel? channel = null;
+        bool channelHealthy = false;
         try
         {
+            // Safe: GetConnectionAsync is TCS-backed (idempotent), CLR reference writes are
+            // atomic, so concurrent null-checks with pool size > 1 always assign the same object.
             _connection ??= await _connectionHolder.GetConnectionAsync(cancellationToken).ConfigureAwait(false);
 
-            if (_publishChannel is null || !_publishChannel.IsOpen)
-                _publishChannel = await _connection
-                    .CreateChannelAsync(cancellationToken: cancellationToken)
+            if (!_channelPool.TryDequeue(out channel) || !channel.IsOpen)
+            {
+                if (channel is not null)
+                    await channel.DisposeAsync().ConfigureAwait(false);
+                channel = await _connection
+                    .CreateChannelAsync(ConfirmChannelOptions, cancellationToken)
                     .ConfigureAwait(false);
+            }
 
-            await _publishChannel.BasicPublishAsync(
+            // BasicPublishAsync awaits the broker ack when publisherConfirmationTrackingEnabled
+            // is true. A broker nack or a basic.return (mandatory + no binding) throws
+            // PublishReturnException here, propagating the failure to the outbox dispatcher
+            // which will increment the attempt count rather than marking the row processed.
+            await channel.BasicPublishAsync(
                 exchange: exchange,
                 routingKey: routingKey,
-                mandatory: false,
+                mandatory: true,
                 basicProperties: properties,
                 body: body,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            channelHealthy = true;
+
+            _logger.LogDebug(
+                "Forwarded outbox message {MessageId} ({MessageKind}: {MessageType}) to exchange '{Exchange}'.",
+                message.Id, message.MessageKind, message.MessageType, exchange);
         }
         finally
         {
-            _channelLock.Release();
-        }
+            if (channelHealthy && channel is not null && channel.IsOpen)
+                _channelPool.Enqueue(channel);
+            else if (channel is not null)
+                await channel.DisposeAsync().ConfigureAwait(false);
 
-        _logger.LogDebug(
-            "Forwarded outbox message {MessageId} ({MessageKind}: {MessageType}) to exchange '{Exchange}'.",
-            message.Id, message.MessageKind, message.MessageType, exchange);
+            _poolSemaphore.Release();
+        }
     }
 
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        _channelLock.Dispose();
-        if (_publishChannel is not null)
-            await _publishChannel.DisposeAsync().ConfigureAwait(false);
+        _poolSemaphore.Dispose();
+        while (_channelPool.TryDequeue(out IChannel? ch))
+            await ch.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
@@ -131,7 +131,7 @@ public sealed class RabbitMQIntegrationTests
         await Task.Delay(500, ct);
 
         var transport = host.Services.GetRequiredService<ITransport>();
-        await transport.SendAsync(BuildOutboxMessage(new OrderPlaced("dlq-test"), "Event"), ct);
+        await transport.SendAsync(BuildOutboxMessage(new OrderPlaced("dlq-test"), MessageKind.Event), ct);
 
         // After nack the message should appear in the DLQ. Poll via direct BasicGet.
         string queueName = $"test-service-{_testRunId}.order-placed";

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using OpinionatedEventing.Outbox;
 using OpinionatedEventing.RabbitMQ.Tests.TestSupport;
 using OpinionatedEventing.Testing;
+using RabbitMqClient = RabbitMQ.Client;
 using Xunit;
 
 namespace OpinionatedEventing.RabbitMQ.Tests;
@@ -114,6 +115,32 @@ public sealed class RabbitMQIntegrationTests
         await host.StopAsync(ct);
     }
 
+    // --- delivery hardening tests ---
+
+    [Fact]
+    public async Task Failed_handler_routes_message_to_dlq()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var host = BuildHost(services =>
+        {
+            services.AddScoped<IEventHandler<OrderPlaced>>(_ => new ThrowingEventHandler());
+        });
+
+        await host.StartAsync(ct);
+        await Task.Delay(500, ct);
+
+        var transport = host.Services.GetRequiredService<ITransport>();
+        await transport.SendAsync(BuildOutboxMessage(new OrderPlaced("dlq-test"), "Event"), ct);
+
+        // After nack the message should appear in the DLQ. Poll via direct BasicGet.
+        string queueName = $"test-service-{_testRunId}.order-placed";
+        string dlqName = $"{queueName}.dlq";
+        await WaitForDlqMessageAsync(dlqName, ct);
+
+        await host.StopAsync(ct);
+    }
+
     // --- helpers ---
 
     private IHost BuildHost(
@@ -172,6 +199,34 @@ public sealed class RabbitMQIntegrationTests
         private readonly List<T> _captured;
         public CapturingCommandHandler(List<T> captured) => _captured = captured;
         public Task HandleAsync(T command, CancellationToken ct) { _captured.Add(command); return Task.CompletedTask; }
+    }
+
+    private sealed class ThrowingEventHandler : IEventHandler<OrderPlaced>
+    {
+        public Task HandleAsync(OrderPlaced @event, CancellationToken ct)
+            => throw new InvalidOperationException("Deliberate handler failure for DLQ test.");
+    }
+
+    private async Task WaitForDlqMessageAsync(string dlqName, CancellationToken ct, int timeoutMs = 15_000)
+    {
+        var factory = new RabbitMqClient.ConnectionFactory { Uri = new Uri(_fixture.ConnectionString) };
+        await using var connection = await factory.CreateConnectionAsync(ct);
+        await using var channel = await connection.CreateChannelAsync(cancellationToken: ct);
+
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(200, ct);
+            try
+            {
+                var result = await channel.BasicGetAsync(dlqName, autoAck: false, ct);
+                if (result is not null)
+                    return;
+            }
+            catch (RabbitMqClient.Exceptions.OperationInterruptedException) { }
+        }
+
+        Assert.Fail($"DLQ '{dlqName}' did not receive a message within the timeout.");
     }
 
 }

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQTopologyInitializerTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQTopologyInitializerTests.cs
@@ -1,0 +1,325 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MSOptions = Microsoft.Extensions.Options.Options;
+using OpinionatedEventing.DependencyInjection;
+using OpinionatedEventing.RabbitMQ;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests;
+
+public sealed class RabbitMQTopologyInitializerTests
+{
+    private static (RabbitMQTopologyInitializer Initializer, TopologyRecordingChannel Channel)
+        CreateInitializer(
+            Action<IServiceCollection>? configure = null,
+            string serviceName = "test-svc",
+            bool autoDeclare = true)
+    {
+        var channel = new TopologyRecordingChannel();
+        var holder = new RabbitMqConnectionHolder();
+        holder.SetConnection(new StubTopologyConnection(channel));
+
+        var services = new ServiceCollection();
+        configure?.Invoke(services);
+
+        var registry = new MessageHandlerRegistry();
+
+        var options = MSOptions.Create(new RabbitMQOptions
+        {
+            ConnectionString = "amqp://localhost",
+            ServiceName = serviceName,
+            AutoDeclareTopology = autoDeclare,
+        });
+
+        return (
+            new RabbitMQTopologyInitializer(
+                holder, registry, services, options,
+                NullLogger<RabbitMQTopologyInitializer>.Instance),
+            channel);
+    }
+
+    [Fact]
+    public async Task StartAsync_skips_all_declarations_when_AutoDeclareTopology_is_false()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            configure: s => s.AddScoped<IEventHandler<TopologyTestEvent>>(_ => null!),
+            autoDeclare: false);
+
+        await initializer.StartAsync(ct);
+
+        Assert.Empty(channel.DeclaredExchanges);
+        Assert.Empty(channel.DeclaredQueues);
+    }
+
+    [Fact]
+    public async Task StartAsync_declares_fanout_exchange_for_event()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            s => s.AddScoped<IEventHandler<TopologyTestEvent>>(_ => null!));
+
+        await initializer.StartAsync(ct);
+
+        Assert.True(channel.DeclaredExchanges.ContainsKey("topology-test-event"));
+        Assert.Equal(ExchangeType.Fanout, channel.DeclaredExchanges["topology-test-event"]);
+    }
+
+    [Fact]
+    public async Task StartAsync_declares_event_consumer_queue_with_dlx_arguments()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            s => s.AddScoped<IEventHandler<TopologyTestEvent>>(_ => null!));
+
+        await initializer.StartAsync(ct);
+
+        const string queueName = "test-svc.topology-test-event";
+        Assert.True(channel.DeclaredQueues.ContainsKey(queueName));
+        var args = channel.DeclaredQueues[queueName];
+        Assert.Equal($"{queueName}.dlx", args["x-dead-letter-exchange"]);
+        Assert.Equal(queueName, args["x-dead-letter-routing-key"]);
+    }
+
+    [Fact]
+    public async Task StartAsync_declares_dlx_exchange_and_dlq_for_event_queue()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            s => s.AddScoped<IEventHandler<TopologyTestEvent>>(_ => null!));
+
+        await initializer.StartAsync(ct);
+
+        const string queueName = "test-svc.topology-test-event";
+        Assert.True(channel.DeclaredExchanges.ContainsKey($"{queueName}.dlx"));
+        Assert.Equal(ExchangeType.Direct, channel.DeclaredExchanges[$"{queueName}.dlx"]);
+        Assert.True(channel.DeclaredQueues.ContainsKey($"{queueName}.dlq"));
+    }
+
+    [Fact]
+    public async Task StartAsync_binds_dlq_to_dlx_with_queue_name_as_routing_key_for_event()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            s => s.AddScoped<IEventHandler<TopologyTestEvent>>(_ => null!));
+
+        await initializer.StartAsync(ct);
+
+        const string queueName = "test-svc.topology-test-event";
+        Assert.Contains(channel.Bindings,
+            b => b.Queue == $"{queueName}.dlq"
+              && b.Exchange == $"{queueName}.dlx"
+              && b.RoutingKey == queueName);
+    }
+
+    [Fact]
+    public async Task StartAsync_declares_direct_exchange_for_command()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            s => s.AddScoped<ICommandHandler<TopologyTestCommand>>(_ => null!));
+
+        await initializer.StartAsync(ct);
+
+        Assert.True(channel.DeclaredExchanges.ContainsKey("topology-test-command"));
+        Assert.Equal(ExchangeType.Direct, channel.DeclaredExchanges["topology-test-command"]);
+    }
+
+    [Fact]
+    public async Task StartAsync_declares_command_queue_with_dlx_arguments()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            s => s.AddScoped<ICommandHandler<TopologyTestCommand>>(_ => null!));
+
+        await initializer.StartAsync(ct);
+
+        const string queueName = "topology-test-command";
+        Assert.True(channel.DeclaredQueues.ContainsKey(queueName));
+        var args = channel.DeclaredQueues[queueName];
+        Assert.Equal($"{queueName}.dlx", args["x-dead-letter-exchange"]);
+        Assert.Equal(queueName, args["x-dead-letter-routing-key"]);
+    }
+
+    [Fact]
+    public async Task StartAsync_declares_dlx_exchange_and_dlq_for_command_queue()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            s => s.AddScoped<ICommandHandler<TopologyTestCommand>>(_ => null!));
+
+        await initializer.StartAsync(ct);
+
+        const string queueName = "topology-test-command";
+        Assert.True(channel.DeclaredExchanges.ContainsKey($"{queueName}.dlx"));
+        Assert.Equal(ExchangeType.Direct, channel.DeclaredExchanges[$"{queueName}.dlx"]);
+        Assert.True(channel.DeclaredQueues.ContainsKey($"{queueName}.dlq"));
+    }
+
+    [Fact]
+    public async Task StartAsync_binds_dlq_to_dlx_with_queue_name_as_routing_key_for_command()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            s => s.AddScoped<ICommandHandler<TopologyTestCommand>>(_ => null!));
+
+        await initializer.StartAsync(ct);
+
+        const string queueName = "topology-test-command";
+        Assert.Contains(channel.Bindings,
+            b => b.Queue == $"{queueName}.dlq"
+              && b.Exchange == $"{queueName}.dlx"
+              && b.RoutingKey == queueName);
+    }
+
+    [Fact]
+    public async Task StartAsync_skips_queue_but_declares_exchange_when_ServiceName_is_empty()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (initializer, channel) = CreateInitializer(
+            configure: s => s.AddScoped<IEventHandler<TopologyTestEvent>>(_ => null!),
+            serviceName: "");
+
+        await initializer.StartAsync(ct);
+
+        Assert.True(channel.DeclaredExchanges.ContainsKey("topology-test-event"));
+        Assert.DoesNotContain(channel.DeclaredQueues.Keys, k => k.Contains("topology-test-event"));
+    }
+
+    // --- test message types ---
+
+    private sealed record TopologyTestEvent : IEvent;
+    private sealed record TopologyTestCommand : ICommand;
+
+    // --- test doubles ---
+
+    private sealed class StubTopologyConnection : IConnection
+    {
+        private readonly IChannel _channel;
+        public StubTopologyConnection(IChannel channel) => _channel = channel;
+        public Task<IChannel> CreateChannelAsync(CreateChannelOptions? options = null, CancellationToken ct = default)
+            => Task.FromResult(_channel);
+
+        public ushort ChannelMax => 0;
+        public IDictionary<string, object?> ClientProperties => new Dictionary<string, object?>();
+        public string? ClientProvidedName => null;
+        public ShutdownEventArgs? CloseReason => null;
+        public AmqpTcpEndpoint Endpoint => new("localhost");
+        public uint FrameMax => 0;
+        public TimeSpan Heartbeat => TimeSpan.Zero;
+        public bool IsOpen => true;
+        public IProtocol Protocol => throw new NotImplementedException();
+        public IDictionary<string, object?> ServerProperties => new Dictionary<string, object?>();
+        public IEnumerable<ShutdownReportEntry> ShutdownReport => [];
+        public int LocalPort => 0;
+        public int RemotePort => 0;
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ConnectionShutdownAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? RecoverySucceededAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionRecoveryErrorEventArgs>? ConnectionRecoveryErrorAsync { add { } remove { } }
+        public event AsyncEventHandler<ConsumerTagChangedAfterRecoveryEventArgs>? ConsumerTagChangeAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<QueueNameChangedAfterRecoveryEventArgs>? QueueNameChangedAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<RecoveringConsumerEventArgs>? RecoveringConsumerAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionBlockedEventArgs>? ConnectionBlockedAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? ConnectionUnblockedAsync { add { } remove { } }
+        public Task CloseAsync(ushort reasonCode, string reasonText, TimeSpan timeout, bool abort, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSecretAsync(string newSecret, string reason, CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private sealed class TopologyRecordingChannel : IChannel
+    {
+        public Dictionary<string, string> DeclaredExchanges { get; } = new();
+        public Dictionary<string, IDictionary<string, object?>> DeclaredQueues { get; } = new();
+        public List<(string Queue, string Exchange, string RoutingKey)> Bindings { get; } = new();
+
+        public bool IsOpen => true;
+        public bool IsClosed => false;
+        public int ChannelNumber => 1;
+        public ShutdownEventArgs? CloseReason => null;
+        public ulong NextPublishSeqNo => 0;
+        public string? CurrentQueue => null;
+        public IAsyncBasicConsumer? DefaultConsumer { get => null; set { } }
+        public TimeSpan ContinuationTimeout { get => TimeSpan.Zero; set { } }
+
+        public event AsyncEventHandler<BasicAckEventArgs>? BasicAcksAsync { add { } remove { } }
+        public event AsyncEventHandler<BasicNackEventArgs>? BasicNacksAsync { add { } remove { } }
+#pragma warning disable CS0067
+        public event AsyncEventHandler<BasicReturnEventArgs>? BasicReturnAsync;
+#pragma warning restore CS0067
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<FlowControlEventArgs>? FlowControlAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ChannelShutdownAsync { add { } remove { } }
+
+        public Task ExchangeDeclareAsync(string exchange, string type, bool durable = false,
+            bool autoDelete = false, IDictionary<string, object?>? arguments = null,
+            bool passive = false, bool noWait = false, CancellationToken ct = default)
+        {
+            DeclaredExchanges[exchange] = type;
+            return Task.CompletedTask;
+        }
+
+        public Task<QueueDeclareOk> QueueDeclareAsync(string queue = "", bool durable = false,
+            bool exclusive = true, bool autoDelete = true, IDictionary<string, object?>? arguments = null,
+            bool passive = false, bool noWait = false, CancellationToken ct = default)
+        {
+            DeclaredQueues[queue] = arguments ?? new Dictionary<string, object?>();
+            return Task.FromResult(new QueueDeclareOk(queue, 0, 0));
+        }
+
+        public Task QueueBindAsync(string queue, string exchange, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false, CancellationToken ct = default)
+        {
+            Bindings.Add((queue, exchange, routingKey));
+            return Task.CompletedTask;
+        }
+
+        public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, bool mandatory,
+            TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken ct = default)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();
+        public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, bool mandatory,
+            TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken ct = default)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();
+        public ValueTask<ulong> GetNextPublishSequenceNumberAsync(CancellationToken ct = default) => ValueTask.FromResult(0UL);
+        public Task AbortAsync(ushort replyCode = 200, string replyText = "Goodbye", CancellationToken ct = default) => Task.CompletedTask;
+        public Task CloseAsync(ushort replyCode = 200, string replyText = "Goodbye", bool abort = false, CancellationToken ct = default) => Task.CompletedTask;
+        public Task CloseAsync(ShutdownEventArgs reason, bool abort, CancellationToken ct = default) => Task.CompletedTask;
+        public Task CloseAsync(ShutdownEventArgs reason, bool abort) => Task.CompletedTask;
+        public Task<string> BasicConsumeAsync(string queue, bool autoAck, string consumerTag,
+            bool noLocal, bool exclusive, IDictionary<string, object?>? arguments,
+            IAsyncBasicConsumer consumer, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task BasicCancelAsync(string tag, bool noWait = false, CancellationToken ct = default) => throw new NotImplementedException();
+        public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple, CancellationToken ct = default) => throw new NotImplementedException();
+        public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue, CancellationToken ct = default) => throw new NotImplementedException();
+        public ValueTask BasicRejectAsync(ulong deliveryTag, bool requeue, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<BasicGetResult?> BasicGetAsync(string queue, bool autoAck, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task BasicQosAsync(uint prefetchSize, ushort prefetchCount, bool global, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task ExchangeDeclarePassiveAsync(string exchange, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, bool noWait = false, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task ExchangeBindAsync(string destination, string source, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task ExchangeUnbindAsync(string destination, string source, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<QueueDeclareOk> QueueDeclarePassiveAsync(string queue, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<uint> QueueDeleteAsync(string queue, bool ifUnused = false, bool ifEmpty = false,
+            bool noWait = false, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<uint> MessageCountAsync(string queue, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<uint> ConsumerCountAsync(string queue, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<uint> QueuePurgeAsync(string queue, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task QueueUnbindAsync(string queue, string exchange, string routingKey,
+            IDictionary<string, object?>? arguments = null, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task TxSelectAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task TxCommitAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task TxRollbackAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> WaitForConfirmsAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task WaitForConfirmsOrDieAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task ConfirmSelectAsync(bool trackConfirmations = true, CancellationToken ct = default) => throw new NotImplementedException();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQTransportTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQTransportTests.cs
@@ -32,7 +32,7 @@ public sealed class RabbitMQTransportTests
             logger: NullLogger<RabbitMQTransport>.Instance);
     }
 
-    private static OutboxMessage BuildMessage(string kind, Type type) => new()
+    private static OutboxMessage BuildMessage(MessageKind kind, Type type) => new()
     {
         Id = Guid.NewGuid(),
         MessageType = type.FullName!,
@@ -51,7 +51,7 @@ public sealed class RabbitMQTransportTests
         PublishRecordingChannel channel = new();
         await using RabbitMQTransport transport = CreateTransport(channel);
 
-        await transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct);
+        await transport.SendAsync(BuildMessage(MessageKind.Event, typeof(TestEvent)), ct);
 
         Assert.Equal("test-event", channel.LastExchange);
         Assert.Equal(string.Empty, channel.LastRoutingKey);
@@ -65,7 +65,7 @@ public sealed class RabbitMQTransportTests
         PublishRecordingChannel channel = new();
         await using RabbitMQTransport transport = CreateTransport(channel);
 
-        await transport.SendAsync(BuildMessage("Command", typeof(TestCommand)), ct);
+        await transport.SendAsync(BuildMessage(MessageKind.Command, typeof(TestCommand)), ct);
 
         Assert.Equal("test-command", channel.LastExchange);
         Assert.Equal("test-command", channel.LastRoutingKey);
@@ -82,7 +82,7 @@ public sealed class RabbitMQTransportTests
         await using RabbitMQTransport transport = CreateTransport(channel);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct));
+            () => transport.SendAsync(BuildMessage(MessageKind.Event, typeof(TestEvent)), ct));
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public sealed class RabbitMQTransportTests
         await using RabbitMQTransport transport = CreateTransport(channel);
 
         await Assert.ThrowsAsync<PublishReturnException>(
-            () => transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct));
+            () => transport.SendAsync(BuildMessage(MessageKind.Event, typeof(TestEvent)), ct));
     }
 
     // ── channel pool ───────────────────────────────────────────────────────────
@@ -117,8 +117,8 @@ public sealed class RabbitMQTransportTests
             MSOptions.Create(new OutboxOptions { ConcurrentWorkers = 1 }),
             NullLogger<RabbitMQTransport>.Instance);
 
-        await transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct);
-        await transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct);
+        await transport.SendAsync(BuildMessage(MessageKind.Event, typeof(TestEvent)), ct);
+        await transport.SendAsync(BuildMessage(MessageKind.Event, typeof(TestEvent)), ct);
 
         Assert.Equal(1, connection.ChannelsCreated);
     }
@@ -142,10 +142,10 @@ public sealed class RabbitMQTransportTests
             NullLogger<RabbitMQTransport>.Instance);
 
         await Assert.ThrowsAsync<Exception>(
-            () => transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct));
+            () => transport.SendAsync(BuildMessage(MessageKind.Event, typeof(TestEvent)), ct));
 
         // Second publish succeeds with a freshly created channel
-        await transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct);
+        await transport.SendAsync(BuildMessage(MessageKind.Event, typeof(TestEvent)), ct);
 
         Assert.Equal(2, connection.ChannelsCreated);
         Assert.Equal(1, secondChannel.PublishCount);

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQTransportTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQTransportTests.cs
@@ -1,0 +1,369 @@
+#nullable enable
+
+using Microsoft.Extensions.Logging.Abstractions;
+using MSOptions = Microsoft.Extensions.Options.Options;
+using OpinionatedEventing.Options;
+using OpinionatedEventing.Outbox;
+using OpinionatedEventing.RabbitMQ;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using RabbitMQ.Client.Exceptions;
+using Xunit;
+
+namespace OpinionatedEventing.RabbitMQ.Tests;
+
+public sealed class RabbitMQTransportTests
+{
+    private static RabbitMQTransport CreateTransport(
+        PublishRecordingChannel channel,
+        int concurrentWorkers = 1)
+    {
+        MessageTypeRegistry registry = new();
+        registry.Register(typeof(TestEvent));
+        registry.Register(typeof(TestCommand));
+
+        RabbitMqConnectionHolder holder = new();
+        holder.SetConnection(new StubConnection(channel));
+
+        return new RabbitMQTransport(
+            connectionHolder: holder,
+            registry: registry,
+            outboxOptions: MSOptions.Create(new OutboxOptions { ConcurrentWorkers = concurrentWorkers }),
+            logger: NullLogger<RabbitMQTransport>.Instance);
+    }
+
+    private static OutboxMessage BuildMessage(string kind, Type type) => new()
+    {
+        Id = Guid.NewGuid(),
+        MessageType = type.FullName!,
+        MessageKind = kind,
+        Payload = "{}",
+        CorrelationId = Guid.NewGuid(),
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+
+    // ── happy-path routing ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_publishes_event_to_exchange_with_empty_routing_key()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        PublishRecordingChannel channel = new();
+        await using RabbitMQTransport transport = CreateTransport(channel);
+
+        await transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct);
+
+        Assert.Equal("test-event", channel.LastExchange);
+        Assert.Equal(string.Empty, channel.LastRoutingKey);
+        Assert.True(channel.LastMandatory);
+    }
+
+    [Fact]
+    public async Task SendAsync_publishes_command_to_queue_exchange_with_routing_key()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        PublishRecordingChannel channel = new();
+        await using RabbitMQTransport transport = CreateTransport(channel);
+
+        await transport.SendAsync(BuildMessage("Command", typeof(TestCommand)), ct);
+
+        Assert.Equal("test-command", channel.LastExchange);
+        Assert.Equal("test-command", channel.LastRoutingKey);
+        Assert.True(channel.LastMandatory);
+    }
+
+    // ── confirm gate ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_throws_when_BasicPublishAsync_throws()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        PublishRecordingChannel channel = new() { PublishException = new InvalidOperationException("broker nack") };
+        await using RabbitMQTransport transport = CreateTransport(channel);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct));
+    }
+
+    [Fact]
+    public async Task SendAsync_throws_PublishReturnException_when_message_unroutable()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        // Simulate what the library does: throw PublishReturnException from BasicPublishAsync
+        // when mandatory=true and the broker returns the message.
+        PublishReturnException returnEx = new(1UL, "Returned", "test-event", "", 312, "NO_ROUTE");
+        PublishRecordingChannel channel = new() { PublishException = returnEx };
+        await using RabbitMQTransport transport = CreateTransport(channel);
+
+        await Assert.ThrowsAsync<PublishReturnException>(
+            () => transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct));
+    }
+
+    // ── channel pool ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SendAsync_reuses_channel_across_sequential_calls()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        PublishRecordingChannel channel = new();
+        StubConnection connection = new(channel);
+        MessageTypeRegistry registry = new();
+        registry.Register(typeof(TestEvent));
+        RabbitMqConnectionHolder holder = new();
+        holder.SetConnection(connection);
+
+        await using RabbitMQTransport transport = new(
+            holder, registry,
+            MSOptions.Create(new OutboxOptions { ConcurrentWorkers = 1 }),
+            NullLogger<RabbitMQTransport>.Instance);
+
+        await transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct);
+        await transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct);
+
+        Assert.Equal(1, connection.ChannelsCreated);
+    }
+
+    [Fact]
+    public async Task SendAsync_discards_faulted_channel_and_creates_new_one_next_call()
+    {
+        CancellationToken ct = TestContext.Current.CancellationToken;
+        // First call: channel throws. Second call: new channel succeeds.
+        PublishRecordingChannel firstChannel = new() { PublishException = new Exception("simulated nack") };
+        PublishRecordingChannel secondChannel = new();
+        CountingConnection connection = new(firstChannel, secondChannel);
+        MessageTypeRegistry registry = new();
+        registry.Register(typeof(TestEvent));
+        RabbitMqConnectionHolder holder = new();
+        holder.SetConnection(connection);
+
+        await using RabbitMQTransport transport = new(
+            holder, registry,
+            MSOptions.Create(new OutboxOptions { ConcurrentWorkers = 1 }),
+            NullLogger<RabbitMQTransport>.Instance);
+
+        await Assert.ThrowsAsync<Exception>(
+            () => transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct));
+
+        // Second publish succeeds with a freshly created channel
+        await transport.SendAsync(BuildMessage("Event", typeof(TestEvent)), ct);
+
+        Assert.Equal(2, connection.ChannelsCreated);
+        Assert.Equal(1, secondChannel.PublishCount);
+    }
+
+    // ── test doubles ──────────────────────────────────────────────────────────
+
+    private sealed record TestEvent : IEvent;
+    private sealed record TestCommand : ICommand;
+
+    private sealed class PublishRecordingChannel : IChannel
+    {
+        public string? LastExchange { get; private set; }
+        public string? LastRoutingKey { get; private set; }
+        public bool LastMandatory { get; private set; }
+        public int PublishCount { get; private set; }
+        public Exception? PublishException { get; init; }
+
+        public bool IsOpen => true;
+        public bool IsClosed => false;
+        public int ChannelNumber => 1;
+        public ShutdownEventArgs? CloseReason => null;
+        public ulong NextPublishSeqNo => 1;
+        public string? CurrentQueue => null;
+        public IAsyncBasicConsumer? DefaultConsumer { get => null; set { } }
+        public TimeSpan ContinuationTimeout { get => TimeSpan.Zero; set { } }
+
+        public event AsyncEventHandler<BasicAckEventArgs>? BasicAcksAsync { add { } remove { } }
+        public event AsyncEventHandler<BasicNackEventArgs>? BasicNacksAsync { add { } remove { } }
+#pragma warning disable CS0067
+        public event AsyncEventHandler<BasicReturnEventArgs>? BasicReturnAsync;
+#pragma warning restore CS0067
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<FlowControlEventArgs>? FlowControlAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ChannelShutdownAsync { add { } remove { } }
+
+        public async ValueTask BasicPublishAsync<TProperties>(
+            string exchange, string routingKey, bool mandatory,
+            TProperties basicProperties, ReadOnlyMemory<byte> body,
+            CancellationToken cancellationToken = default)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
+        {
+            LastExchange = exchange;
+            LastRoutingKey = routingKey;
+            LastMandatory = mandatory;
+            PublishCount++;
+
+            if (PublishException is not null)
+                throw PublishException;
+        }
+
+        public ValueTask BasicPublishAsync<TProperties>(
+            CachedString exchange, CachedString routingKey, bool mandatory,
+            TProperties basicProperties, ReadOnlyMemory<byte> body,
+            CancellationToken cancellationToken = default)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
+            => throw new NotImplementedException();
+
+        public ValueTask<ulong> GetNextPublishSequenceNumberAsync(CancellationToken ct = default)
+            => ValueTask.FromResult(NextPublishSeqNo);
+
+        public Task AbortAsync(ushort replyCode = 200, string replyText = "Goodbye",
+            CancellationToken ct = default) => Task.CompletedTask;
+        public Task CloseAsync(ushort replyCode = 200, string replyText = "Goodbye", bool abort = false,
+            CancellationToken ct = default) => Task.CompletedTask;
+        public Task CloseAsync(ShutdownEventArgs reason, bool abort, CancellationToken ct = default)
+            => Task.CompletedTask;
+        public Task CloseAsync(ShutdownEventArgs reason, bool abort) => Task.CompletedTask;
+
+        public Task<string> BasicConsumeAsync(string queue, bool autoAck, string consumerTag,
+            bool noLocal, bool exclusive, IDictionary<string, object?>? arguments,
+            IAsyncBasicConsumer consumer, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task BasicCancelAsync(string tag, bool noWait = false, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public ValueTask BasicRejectAsync(ulong deliveryTag, bool requeue, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<BasicGetResult?> BasicGetAsync(string queue, bool autoAck, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task BasicQosAsync(uint prefetchSize, ushort prefetchCount, bool global, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task ExchangeDeclareAsync(string exchange, string type, bool durable = false,
+            bool autoDelete = false, IDictionary<string, object?>? arguments = null,
+            bool passive = false, bool noWait = false, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task ExchangeDeclarePassiveAsync(string exchange, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, bool noWait = false,
+            CancellationToken ct = default) => throw new NotImplementedException();
+        public Task ExchangeBindAsync(string destination, string source, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task ExchangeUnbindAsync(string destination, string source, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<QueueDeclareOk> QueueDeclareAsync(string queue = "", bool durable = false,
+            bool exclusive = true, bool autoDelete = true, IDictionary<string, object?>? arguments = null,
+            bool passive = false, bool noWait = false, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<QueueDeclareOk> QueueDeclarePassiveAsync(string queue, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task QueueBindAsync(string queue, string exchange, string routingKey,
+            IDictionary<string, object?>? arguments = null, bool noWait = false, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<uint> QueueDeleteAsync(string queue, bool ifUnused = false, bool ifEmpty = false,
+            bool noWait = false, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<uint> MessageCountAsync(string queue, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<uint> ConsumerCountAsync(string queue, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<uint> QueuePurgeAsync(string queue, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task QueueUnbindAsync(string queue, string exchange, string routingKey,
+            IDictionary<string, object?>? arguments = null, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task TxSelectAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task TxCommitAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task TxRollbackAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> WaitForConfirmsAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task WaitForConfirmsOrDieAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task ConfirmSelectAsync(bool trackConfirmations = true, CancellationToken ct = default) => throw new NotImplementedException();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private sealed class StubConnection : IConnection
+    {
+        private readonly IChannel _channel;
+        public int ChannelsCreated { get; private set; }
+
+        public StubConnection(IChannel channel) => _channel = channel;
+
+        public Task<IChannel> CreateChannelAsync(CreateChannelOptions? options = null, CancellationToken ct = default)
+        {
+            ChannelsCreated++;
+            return Task.FromResult(_channel);
+        }
+
+        public ushort ChannelMax => 0;
+        public IDictionary<string, object?> ClientProperties => new Dictionary<string, object?>();
+        public string? ClientProvidedName => null;
+        public ShutdownEventArgs? CloseReason => null;
+        public AmqpTcpEndpoint Endpoint => new("localhost");
+        public uint FrameMax => 0;
+        public TimeSpan Heartbeat => TimeSpan.Zero;
+        public bool IsOpen => true;
+        public IProtocol Protocol => throw new NotImplementedException();
+        public IDictionary<string, object?> ServerProperties => new Dictionary<string, object?>();
+        public IEnumerable<ShutdownReportEntry> ShutdownReport => [];
+        public int LocalPort => 0;
+        public int RemotePort => 0;
+
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ConnectionShutdownAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? RecoverySucceededAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionRecoveryErrorEventArgs>? ConnectionRecoveryErrorAsync { add { } remove { } }
+        public event AsyncEventHandler<ConsumerTagChangedAfterRecoveryEventArgs>? ConsumerTagChangeAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<QueueNameChangedAfterRecoveryEventArgs>? QueueNameChangedAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<RecoveringConsumerEventArgs>? RecoveringConsumerAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionBlockedEventArgs>? ConnectionBlockedAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? ConnectionUnblockedAsync { add { } remove { } }
+
+        public Task CloseAsync(ushort reasonCode, string reasonText, TimeSpan timeout, bool abort,
+            CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSecretAsync(string newSecret, string reason, CancellationToken ct = default)
+            => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private sealed class CountingConnection : IConnection
+    {
+        private readonly IChannel[] _channels;
+        private int _index;
+        public int ChannelsCreated { get; private set; }
+
+        public CountingConnection(params IChannel[] channels) => _channels = channels;
+
+        public Task<IChannel> CreateChannelAsync(CreateChannelOptions? options = null, CancellationToken ct = default)
+        {
+            ChannelsCreated++;
+            return Task.FromResult(_channels[_index++]);
+        }
+
+        public ushort ChannelMax => 0;
+        public IDictionary<string, object?> ClientProperties => new Dictionary<string, object?>();
+        public string? ClientProvidedName => null;
+        public ShutdownEventArgs? CloseReason => null;
+        public AmqpTcpEndpoint Endpoint => new("localhost");
+        public uint FrameMax => 0;
+        public TimeSpan Heartbeat => TimeSpan.Zero;
+        public bool IsOpen => true;
+        public IProtocol Protocol => throw new NotImplementedException();
+        public IDictionary<string, object?> ServerProperties => new Dictionary<string, object?>();
+        public IEnumerable<ShutdownReportEntry> ShutdownReport => [];
+        public int LocalPort => 0;
+        public int RemotePort => 0;
+
+        public event AsyncEventHandler<CallbackExceptionEventArgs>? CallbackExceptionAsync { add { } remove { } }
+        public event AsyncEventHandler<ShutdownEventArgs>? ConnectionShutdownAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? RecoverySucceededAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionRecoveryErrorEventArgs>? ConnectionRecoveryErrorAsync { add { } remove { } }
+        public event AsyncEventHandler<ConsumerTagChangedAfterRecoveryEventArgs>? ConsumerTagChangeAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<QueueNameChangedAfterRecoveryEventArgs>? QueueNameChangedAfterRecoveryAsync { add { } remove { } }
+        public event AsyncEventHandler<RecoveringConsumerEventArgs>? RecoveringConsumerAsync { add { } remove { } }
+        public event AsyncEventHandler<ConnectionBlockedEventArgs>? ConnectionBlockedAsync { add { } remove { } }
+        public event AsyncEventHandler<AsyncEventArgs>? ConnectionUnblockedAsync { add { } remove { } }
+
+        public Task CloseAsync(ushort replyCode, string replyText, TimeSpan timeout, bool abort,
+            CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSecretAsync(string newSecret, string reason, CancellationToken ct = default)
+            => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/TestSupport/RabbitMqFixture.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/TestSupport/RabbitMqFixture.cs
@@ -10,7 +10,7 @@ public sealed class RabbitMqFixture : IAsyncLifetime
 {
     private RabbitMqContainer? _container;
 
-    /// <summary>Gets the connection string for the running RabbitMQ container.</summary>
+    /// <summary>Gets the AMQP connection string for the running RabbitMQ container.</summary>
     // InitializeAsync guarantees _container is set before any test accesses this property
     public string ConnectionString => _container!.GetConnectionString();
 


### PR DESCRIPTION
Closes #103.

## Summary

- **Publisher confirms**: channels are created with `publisherConfirmationsEnabled=true`; `BasicPublishAsync` awaits the broker ack natively — failed publishes throw and let the outbox dispatcher increment the retry count.
- **Mandatory routing**: `mandatory: true` on every publish; the RabbitMQ.Client library throws `PublishReturnException` from `BasicPublishAsync` when no binding exists, surfacing unroutable messages as failures rather than silent drops.
- **Channel pool**: replaces the single `SemaphoreSlim(1,1)` + one channel with a `ConcurrentQueue<IChannel>` pool sized by `OutboxOptions.ConcurrentWorkers`; faulted channels are discarded.
- **DLX/DLQ topology**: `RabbitMQTopologyInitializer` now declares a dead-letter exchange (`{queue}.dlx`, direct) and dead-letter queue (`{queue}.dlq`) for every consumer queue, and sets `x-dead-letter-exchange` + `x-dead-letter-routing-key` queue arguments so nacked messages land in the DLQ rather than being dropped. The explicit routing-key override is required because fanout-exchange messages carry an empty routing key that would not match a DLQ binding without it.

## Tests

- **`RabbitMQTransportTests`** (new, unit): 6 tests using hand-written fakes covering event/command routing, `PublishReturnException` propagation, generic exception propagation, channel reuse across sequential sends, and faulted-channel discard + replacement.
- **`Failed_handler_routes_message_to_dlq`** (integration): publishes an event, lets a throwing handler nack it, then polls the DLQ via `BasicGet` to confirm end-to-end dead-letter delivery.

## Test plan

- [ ] All unit tests pass: `dotnet test tests/OpinionatedEventing.RabbitMQ.Tests --filter "Category!=Integration"`
- [ ] All integration tests pass (requires Docker): `dotnet test tests/OpinionatedEventing.RabbitMQ.Tests --filter "Category=Integration"`
- [ ] CI green — `codecov/patch` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)