### PR TITLE
fix: pre-1.0 correctness and consistency bundle

### DIFF
--- a/src/OpinionatedEventing.Abstractions/Attributes/MessageQueueAttribute.cs
+++ b/src/OpinionatedEventing.Abstractions/Attributes/MessageQueueAttribute.cs
@@ -8,6 +8,10 @@ namespace OpinionatedEventing.Attributes;
 /// <remarks>
 /// When not applied the queue name is derived from the message type by convention
 /// (e.g. <c>ProcessPayment</c> → <c>process-payment</c>).
+/// <para>
+/// Note: <c>AttributeTargets.Class</c> does not cover value types, so
+/// <c>record struct</c> commands are not supported. Use <c>record class</c> or a plain <c>class</c>.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 public sealed class MessageQueueAttribute : Attribute

--- a/src/OpinionatedEventing.Abstractions/Attributes/MessageTopicAttribute.cs
+++ b/src/OpinionatedEventing.Abstractions/Attributes/MessageTopicAttribute.cs
@@ -8,6 +8,10 @@ namespace OpinionatedEventing.Attributes;
 /// <remarks>
 /// When not applied the topic name is derived from the message type by convention
 /// (e.g. <c>OrderPlaced</c> → <c>order-placed</c>).
+/// <para>
+/// Note: <c>AttributeTargets.Class</c> does not cover value types, so
+/// <c>record struct</c> events are not supported. Use <c>record class</c> or a plain <c>class</c>.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 public sealed class MessageTopicAttribute : Attribute

--- a/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusConsumerWorker.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusConsumerWorker.cs
@@ -52,6 +52,18 @@ internal sealed class AzureServiceBusConsumerWorker : BackgroundService
     }
 
     /// <inheritdoc/>
+    public override Task StartAsync(CancellationToken cancellationToken)
+    {
+        var opts = _options.Value;
+        if (_registry.EventTypes.Count > 0 && string.IsNullOrEmpty(opts.ServiceName))
+            throw new InvalidOperationException(
+                "AzureServiceBusOptions.ServiceName must be set before the consumer can subscribe to events. " +
+                "Configure it via AddAzureServiceBus(options => options.ServiceName = \"my-service\").");
+
+        return base.StartAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var opts = _options.Value;
@@ -66,14 +78,6 @@ internal sealed class AzureServiceBusConsumerWorker : BackgroundService
 
         foreach (var eventType in eventTypes)
         {
-            if (string.IsNullOrEmpty(opts.ServiceName))
-            {
-                _logger.LogWarning(
-                    "ServiceName is not configured — skipping subscription for event '{EventType}'.",
-                    eventType.Name);
-                continue;
-            }
-
             var topicName = MessageNamingConvention.GetTopicName(eventType);
             var processor = _client.CreateProcessor(topicName, opts.ServiceName, processorOptions);
             processor.ProcessMessageAsync += OnMessageAsync;

--- a/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusOptions.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusOptions.cs
@@ -55,6 +55,13 @@ public sealed class AzureServiceBusOptions
     /// Gets or sets the maximum number of concurrent calls to the message handler for regular
     /// (non-session) processors. Defaults to <c>1</c>.
     /// </summary>
+    /// <remarks>
+    /// A value of <c>1</c> serialises message processing within each processor, making handler
+    /// idempotency easier to reason about and preventing database connection spikes. Increase to
+    /// a higher value (e.g. <c>16</c>–<c>32</c>) when throughput matters more than ordering and
+    /// handlers are already safe to run concurrently. The ideal value depends on handler latency,
+    /// downstream connection pool sizes, and Service Bus prefetch settings.
+    /// </remarks>
     public int MaxConcurrentCalls { get; set; } = 1;
 
     /// <summary>

--- a/src/OpinionatedEventing.AzureServiceBus/Routing/MessageNamingConvention.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/Routing/MessageNamingConvention.cs
@@ -39,9 +39,17 @@ internal static class MessageNamingConvention
         var sb = new StringBuilder(name.Length + 4);
         for (var i = 0; i < name.Length; i++)
         {
-            if (char.IsUpper(name[i]) && i > 0)
-                sb.Append('-');
-            sb.Append(char.ToLower(name[i]));
+            var c = name[i];
+            if (char.IsUpper(c) && i > 0)
+            {
+                var prev = name[i - 1];
+                var next = i + 1 < name.Length ? name[i + 1] : '\0';
+                // Insert hyphen at a word boundary: after lowercase, or before the last uppercase of a run
+                // e.g. HTTPRequest → http-request, OrderPlaced → order-placed
+                if (char.IsLower(prev) || (char.IsUpper(prev) && char.IsLower(next)))
+                    sb.Append('-');
+            }
+            sb.Append(char.ToLower(c));
         }
         return sb.ToString();
     }

--- a/src/OpinionatedEventing.EntityFramework/DependencyInjection/EntityFrameworkBuilderExtensions.cs
+++ b/src/OpinionatedEventing.EntityFramework/DependencyInjection/EntityFrameworkBuilderExtensions.cs
@@ -30,7 +30,10 @@ public static class EntityFrameworkBuilderExtensions
     /// <para>
     /// Wire the interceptor into your <c>DbContext</c> configuration by adding
     /// <c>options.AddInterceptors(sp.GetRequiredService&lt;DomainEventInterceptor&gt;())</c>
-    /// inside your <c>AddDbContext</c> delegate:
+    /// inside your <c>AddDbContext</c> delegate. The <c>sp</c> parameter is the
+    /// <em>scoped</em> service provider supplied by EF Core's factory; resolving from it
+    /// ensures that <c>IMessagingContext</c> is obtained per request and not captured
+    /// once from the root container:
     /// </para>
     /// <code>
     /// services.AddDbContext&lt;AppDbContext&gt;((sp, options) =>

--- a/src/OpinionatedEventing.EntityFramework/DomainEventInterceptor.cs
+++ b/src/OpinionatedEventing.EntityFramework/DomainEventInterceptor.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpinionatedEventing.Options;
 using OpinionatedEventing.Outbox;
@@ -15,23 +16,26 @@ namespace OpinionatedEventing.EntityFramework;
 /// <remarks>
 /// Register this interceptor with the application's <see cref="DbContext"/> by calling
 /// <c>options.AddInterceptors(sp.GetRequiredService&lt;DomainEventInterceptor&gt;())</c>
-/// inside the <c>AddDbContext</c> configuration delegate.
+/// inside the <c>AddDbContext</c> configuration delegate. The <c>sp</c> passed
+/// to the factory must be the <em>scoped</em> service provider so that
+/// <c>IMessagingContext</c> is resolved per request rather than captured once at
+/// startup, which would cause stale correlation IDs to be written to the outbox.
 /// </remarks>
 public sealed class DomainEventInterceptor : SaveChangesInterceptor
 {
-    private readonly IMessagingContext _messagingContext;
+    private readonly IServiceProvider _serviceProvider;
     private readonly IMessageTypeRegistry _registry;
     private readonly IOptions<OpinionatedEventingOptions> _options;
     private readonly TimeProvider _timeProvider;
 
     /// <summary>Initialises a new <see cref="DomainEventInterceptor"/>.</summary>
     public DomainEventInterceptor(
-        IMessagingContext messagingContext,
+        IServiceProvider serviceProvider,
         IMessageTypeRegistry registry,
         IOptions<OpinionatedEventingOptions> options,
         TimeProvider timeProvider)
     {
-        _messagingContext = messagingContext;
+        _serviceProvider = serviceProvider;
         _registry = registry;
         _options = options;
         _timeProvider = timeProvider;
@@ -68,6 +72,7 @@ public sealed class DomainEventInterceptor : SaveChangesInterceptor
 
         if (aggregates.Count == 0) return;
 
+        var messagingContext = _serviceProvider.GetRequiredService<IMessagingContext>();
         var serializerOptions = _options.Value.SerializerOptions;
         var now = _timeProvider.GetUtcNow();
         var outboxSet = context.Set<OutboxMessage>();
@@ -83,8 +88,8 @@ public sealed class DomainEventInterceptor : SaveChangesInterceptor
                     MessageType = _registry.GetIdentifier(eventType),
                     Payload = JsonSerializer.Serialize(domainEvent, eventType, serializerOptions),
                     MessageKind = MessageKind.Event,
-                    CorrelationId = _messagingContext.CorrelationId,
-                    CausationId = _messagingContext.CausationId,
+                    CorrelationId = messagingContext.CorrelationId,
+                    CausationId = messagingContext.CausationId,
                     CreatedAt = now,
                 });
             }

--- a/src/OpinionatedEventing.EntityFramework/EFCoreOutboxStore.cs
+++ b/src/OpinionatedEventing.EntityFramework/EFCoreOutboxStore.cs
@@ -109,37 +109,37 @@ internal sealed class EFCoreOutboxStore<TDbContext> : IOutboxStore
     /// <inheritdoc/>
     public async Task MarkProcessedAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        OutboxMessage? message = await _dbContext.Set<OutboxMessage>().FindAsync([id], cancellationToken);
-        if (message is null) return;
-
-        message.ProcessedAt = _timeProvider.GetUtcNow();
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        await _dbContext.Set<OutboxMessage>()
+            .Where(m => m.Id == id)
+            .ExecuteUpdateAsync(s => s.SetProperty(m => m.ProcessedAt, now), cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task MarkFailedAsync(Guid id, string error, CancellationToken cancellationToken = default)
     {
-        OutboxMessage? message = await _dbContext.Set<OutboxMessage>().FindAsync([id], cancellationToken);
-        if (message is null) return;
-
-        message.FailedAt = _timeProvider.GetUtcNow();
-        message.Error = error;
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        await _dbContext.Set<OutboxMessage>()
+            .Where(m => m.Id == id)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(m => m.FailedAt, now)
+                .SetProperty(m => m.Error, error),
+            cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task IncrementAttemptAsync(Guid id, string error, DateTimeOffset? nextAttemptAt, CancellationToken cancellationToken = default)
     {
-        OutboxMessage? message = await _dbContext.Set<OutboxMessage>().FindAsync([id], cancellationToken);
-        if (message is null) return;
-
-        message.AttemptCount++;
-        message.Error = error;
-        message.NextAttemptAt = nextAttemptAt;
-        // Clear the claim so the message is re-eligible after the backoff delay.
-        message.LockedBy = null;
-        message.LockedUntil = null;
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        await _dbContext.Set<OutboxMessage>()
+            .Where(m => m.Id == id)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(m => m.AttemptCount, m => m.AttemptCount + 1)
+                .SetProperty(m => m.Error, error)
+                .SetProperty(m => m.NextAttemptAt, nextAttemptAt)
+                // Clear the claim so the message is re-eligible after the backoff delay.
+                .SetProperty(m => m.LockedBy, (string?)null)
+                .SetProperty(m => m.LockedUntil, (DateTimeOffset?)null),
+            cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/OpinionatedEventing.Outbox/Diagnostics/OutboxDiagnostics.cs
+++ b/src/OpinionatedEventing.Outbox/Diagnostics/OutboxDiagnostics.cs
@@ -50,9 +50,9 @@ internal static class OutboxDiagnostics
         activity.SetTag("messaging.operation", "publish");
         activity.SetTag("messaging.message.type", StripAssemblyInfo(messageType));
         activity.SetTag("messaging.message.kind", messageKind);
-        activity.AddBaggage("correlation.id", correlationId.ToString());
+        activity.AddBaggage("messaging.message.correlation_id", correlationId.ToString());
         if (causationId.HasValue)
-            activity.AddBaggage("causation.id", causationId.Value.ToString());
+            activity.AddBaggage("messaging.message.causation_id", causationId.Value.ToString());
 
         return activity;
     }

--- a/src/OpinionatedEventing.Outbox/OutboxPublisher.cs
+++ b/src/OpinionatedEventing.Outbox/OutboxPublisher.cs
@@ -89,12 +89,13 @@ internal sealed class OutboxPublisher : IPublisher
 
     private OutboxMessage CreateMessage<T>(T payload, MessageKind kind)
     {
+        var runtimeType = payload!.GetType();
         var serializerOptions = _options.Value.SerializerOptions;
         return new OutboxMessage
         {
             Id = Guid.NewGuid(),
-            MessageType = _registry.GetIdentifier(typeof(T)),
-            Payload = JsonSerializer.Serialize(payload, serializerOptions),
+            MessageType = _registry.GetIdentifier(runtimeType),
+            Payload = JsonSerializer.Serialize(payload, runtimeType, serializerOptions),
             MessageKind = kind,
             CorrelationId = _messagingContext.CorrelationId,
             CausationId = _messagingContext.CausationId,

--- a/src/OpinionatedEventing.RabbitMQ/Routing/MessageNamingConvention.cs
+++ b/src/OpinionatedEventing.RabbitMQ/Routing/MessageNamingConvention.cs
@@ -46,9 +46,17 @@ internal static class MessageNamingConvention
         var sb = new StringBuilder(name.Length + 4);
         for (var i = 0; i < name.Length; i++)
         {
-            if (char.IsUpper(name[i]) && i > 0)
-                sb.Append('-');
-            sb.Append(char.ToLower(name[i]));
+            var c = name[i];
+            if (char.IsUpper(c) && i > 0)
+            {
+                var prev = name[i - 1];
+                var next = i + 1 < name.Length ? name[i + 1] : '\0';
+                // Insert hyphen at a word boundary: after lowercase, or before the last uppercase of a run
+                // e.g. HTTPRequest → http-request, OrderPlaced → order-placed
+                if (char.IsLower(prev) || (char.IsUpper(prev) && char.IsLower(next)))
+                    sb.Append('-');
+            }
+            sb.Append(char.ToLower(c));
         }
         return sb.ToString();
     }

--- a/src/OpinionatedEventing.Sagas/Diagnostics/SagaDiagnostics.cs
+++ b/src/OpinionatedEventing.Sagas/Diagnostics/SagaDiagnostics.cs
@@ -43,7 +43,7 @@ internal static class SagaDiagnostics
         if (activity is null) return null;
 
         activity.SetTag("saga.type", StripAssemblyInfo(sagaTypeName));
-        activity.AddBaggage("correlation.id", correlationId);
+        activity.AddBaggage("messaging.message.correlation_id", correlationId);
 
         return activity;
     }

--- a/src/OpinionatedEventing.Sagas/Internals/SagaDispatcher.cs
+++ b/src/OpinionatedEventing.Sagas/Internals/SagaDispatcher.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.Options;
+using OpinionatedEventing.Options;
 using OpinionatedEventing.Sagas.Options;
 
 namespace OpinionatedEventing.Sagas;
@@ -21,7 +22,8 @@ internal sealed class SagaDispatcher : ISagaDispatcher
         ISagaStateStore stateStore,
         IPublisher publisher,
         TimeProvider timeProvider,
-        IOptions<SagaOptions> options)
+        IOptions<SagaOptions> sagaOptions,
+        IOptions<OpinionatedEventingOptions> globalOptions)
     {
         _sp = sp;
         _sagaDescriptors = sagaDescriptors;
@@ -29,7 +31,7 @@ internal sealed class SagaDispatcher : ISagaDispatcher
         _stateStore = stateStore;
         _publisher = publisher;
         _timeProvider = timeProvider;
-        _serializerOptions = options.Value.SerializerOptions;
+        _serializerOptions = sagaOptions.Value.SerializerOptions ?? globalOptions.Value.SerializerOptions;
     }
 
     public async Task DispatchAsync<TEvent>(TEvent @event, CancellationToken cancellationToken = default)

--- a/src/OpinionatedEventing.Sagas/Options/SagaOptions.cs
+++ b/src/OpinionatedEventing.Sagas/Options/SagaOptions.cs
@@ -13,7 +13,9 @@ public sealed class SagaOptions
 
     /// <summary>
     /// <see cref="JsonSerializerOptions"/> used to serialise and deserialise saga state payloads.
-    /// Defaults to <see langword="null"/>, which uses <see cref="JsonSerializerOptions.Default"/>.
+    /// When <see langword="null"/> (the default), falls back to
+    /// <c>OpinionatedEventingOptions.SerializerOptions</c>; if that is also <see langword="null"/>,
+    /// <see cref="JsonSerializerOptions.Default"/> is used.
     /// </summary>
     public JsonSerializerOptions? SerializerOptions { get; set; }
 }

--- a/src/OpinionatedEventing.Sagas/SagaTimeoutWorker.cs
+++ b/src/OpinionatedEventing.Sagas/SagaTimeoutWorker.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpinionatedEventing.Options;
 using OpinionatedEventing.Sagas.Diagnostics;
 using OpinionatedEventing.Sagas.Options;
 
@@ -18,6 +19,7 @@ public sealed class SagaTimeoutWorker : BackgroundService
     private readonly IServiceProvider _serviceProvider;
     private readonly TimeProvider _timeProvider;
     private readonly IOptions<SagaOptions> _options;
+    private readonly IOptions<OpinionatedEventingOptions> _globalOptions;
     private readonly ILogger<SagaTimeoutWorker> _logger;
 
     /// <summary>Initialises a new <see cref="SagaTimeoutWorker"/>.</summary>
@@ -25,11 +27,13 @@ public sealed class SagaTimeoutWorker : BackgroundService
         IServiceProvider serviceProvider,
         TimeProvider timeProvider,
         IOptions<SagaOptions> options,
+        IOptions<OpinionatedEventingOptions> globalOptions,
         ILogger<SagaTimeoutWorker> logger)
     {
         _serviceProvider = serviceProvider;
         _timeProvider = timeProvider;
         _options = options;
+        _globalOptions = globalOptions;
         _logger = logger;
     }
 
@@ -50,7 +54,7 @@ public sealed class SagaTimeoutWorker : BackgroundService
         var store = scope.ServiceProvider.GetRequiredService<ISagaStateStore>();
         var publisher = scope.ServiceProvider.GetRequiredService<IPublisher>();
         var descriptors = _serviceProvider.GetServices<SagaDescriptor>();
-        var serializerOptions = _options.Value.SerializerOptions;
+        var serializerOptions = _options.Value.SerializerOptions ?? _globalOptions.Value.SerializerOptions;
 
         IReadOnlyList<SagaState> expired;
         try

--- a/src/OpinionatedEventing.Testing/InMemoryOutboxStore.cs
+++ b/src/OpinionatedEventing.Testing/InMemoryOutboxStore.cs
@@ -12,6 +12,18 @@ namespace OpinionatedEventing.Testing;
 public sealed class InMemoryOutboxStore : IOutboxStore
 {
     private readonly ConcurrentDictionary<Guid, OutboxMessage> _messages = new();
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initialises a new <see cref="InMemoryOutboxStore"/>.</summary>
+    /// <param name="timeProvider">
+    /// Time source used for <c>ProcessedAt</c>, <c>FailedAt</c>, and pending-message filtering.
+    /// Defaults to <see cref="TimeProvider.System"/> when <see langword="null"/>.
+    /// Pass a <see cref="FakeTimeProvider"/> to control time in tests.
+    /// </param>
+    public InMemoryOutboxStore(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
 
     /// <summary>Gets a snapshot of all messages currently in the store, regardless of status.</summary>
     public IReadOnlyList<OutboxMessage> Messages => _messages.Values.ToList();
@@ -38,7 +50,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore
         int batchSize,
         CancellationToken cancellationToken = default)
     {
-        DateTimeOffset now = DateTimeOffset.UtcNow;
+        DateTimeOffset now = _timeProvider.GetUtcNow();
         var pending = _messages.Values
             .Where(m => m.ProcessedAt is null && m.FailedAt is null &&
                         (m.NextAttemptAt is null || m.NextAttemptAt <= now))
@@ -53,7 +65,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore
     public Task MarkProcessedAsync(Guid id, CancellationToken cancellationToken = default)
     {
         if (_messages.TryGetValue(id, out var message))
-            message.ProcessedAt = DateTimeOffset.UtcNow;
+            message.ProcessedAt = _timeProvider.GetUtcNow();
         return Task.CompletedTask;
     }
 
@@ -62,7 +74,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore
     {
         if (_messages.TryGetValue(id, out var message))
         {
-            message.FailedAt = DateTimeOffset.UtcNow;
+            message.FailedAt = _timeProvider.GetUtcNow();
             message.Error = error;
         }
         return Task.CompletedTask;

--- a/src/OpinionatedEventing/Diagnostics/CoreDiagnostics.cs
+++ b/src/OpinionatedEventing/Diagnostics/CoreDiagnostics.cs
@@ -28,9 +28,9 @@ internal static class CoreDiagnostics
         activity.SetTag("messaging.operation", "receive");
         activity.SetTag("messaging.message.type", messageType);
         activity.SetTag("messaging.message.kind", messageKind);
-        activity.AddBaggage("correlation.id", correlationId.ToString());
+        activity.AddBaggage("messaging.message.correlation_id", correlationId.ToString());
         if (causationId.HasValue)
-            activity.AddBaggage("causation.id", causationId.Value.ToString());
+            activity.AddBaggage("messaging.message.causation_id", causationId.Value.ToString());
 
         return activity;
     }

--- a/src/OpinionatedEventing/Properties/AssemblyInfo.cs
+++ b/src/OpinionatedEventing/Properties/AssemblyInfo.cs
@@ -5,4 +5,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OpinionatedEventing.AzureServiceBus")]
 [assembly: InternalsVisibleTo("OpinionatedEventing.Sagas")]
 [assembly: InternalsVisibleTo("OpinionatedEventing.Tests")]
+[assembly: InternalsVisibleTo("OpinionatedEventing.AzureServiceBus.Tests")]
+[assembly: InternalsVisibleTo("OpinionatedEventing.RabbitMQ.Tests")]
 [assembly: InternalsVisibleTo("OpinionatedEventing.Benchmarks")]

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusConsumerWorkerTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/AzureServiceBusConsumerWorkerTests.cs
@@ -34,6 +34,35 @@ public sealed class AzureServiceBusConsumerWorkerTests
     }
 
     [Fact]
+    public async Task StartAsync_throws_when_ServiceName_is_empty_and_events_are_registered()
+    {
+        var registry = new MessageHandlerRegistry();
+        registry.RegisterEventType(typeof(TestEvent));
+
+        var options = MSOptions.Create(new AzureServiceBusOptions
+        {
+            ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;" +
+                               "SharedAccessKeyName=RootManageSharedAccessKey;" +
+                               "SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            ServiceName = string.Empty,
+        });
+
+        var worker = new AzureServiceBusConsumerWorker(
+            client: new NoOpServiceBusClient(),
+            handlerRunner: new RecordingHandlerRunner(),
+            scopeFactory: new NeverCalledScopeFactory(),
+            registry: registry,
+            options: options,
+            pauseController: new FakeConsumerPauseController(startPaused: false),
+            timeProvider: TimeProvider.System,
+            logger: NullLogger<AzureServiceBusConsumerWorker>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => worker.StartAsync(cts.Token));
+    }
+
+    [Fact]
     public async Task ProcessReceivedMessageAsync_passes_inbound_MessageId_as_causationId()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -116,6 +145,8 @@ public sealed class AzureServiceBusConsumerWorkerTests
     }
 
     // ─── Fakes ────────────────────────────────────────────────────────────────────
+
+    private sealed record TestEvent : IEvent;
 
     private sealed class NoOpServiceBusClient : ServiceBusClient { }
 

--- a/tests/OpinionatedEventing.AzureServiceBus.Tests/MessageNamingConventionTests.cs
+++ b/tests/OpinionatedEventing.AzureServiceBus.Tests/MessageNamingConventionTests.cs
@@ -12,7 +12,8 @@ public sealed class MessageNamingConventionTests
     [InlineData(typeof(OrderPlaced), "order-placed")]
     [InlineData(typeof(PaymentReceived), "payment-received")]
     [InlineData(typeof(SimpleEvent), "simple-event")]
-    [InlineData(typeof(ABCEvent), "a-b-c-event")]
+    [InlineData(typeof(ABCEvent), "abc-event")]
+    [InlineData(typeof(HTTPRequestEvent), "http-request-event")]
     public void GetTopicName_derives_kebab_case_from_type_name(Type type, string expected)
     {
         Assert.Equal(expected, MessageNamingConvention.GetTopicName(type));
@@ -44,6 +45,7 @@ public sealed class MessageNamingConventionTests
     private sealed record PaymentReceived : IEvent;
     private sealed record SimpleEvent : IEvent;
     private sealed record ABCEvent : IEvent;
+    private sealed record HTTPRequestEvent : IEvent;
 
     [MessageTopic("my-custom-topic")]
     private sealed record CustomTopicEvent : IEvent;

--- a/tests/OpinionatedEventing.EntityFramework.Specs/StepDefinitions/EntityFrameworkSteps.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Specs/StepDefinitions/EntityFrameworkSteps.cs
@@ -101,10 +101,12 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
     public async Task WhenSaveChangesWithInterceptorActive()
     {
         var corrId = _correlationId == Guid.Empty ? Guid.NewGuid() : _correlationId;
-        var messagingContext = new FakeMessagingContext(corrId);
+        var services = new ServiceCollection();
+        services.AddSingleton<IMessagingContext>(new FakeMessagingContext(corrId));
+        var sp = services.BuildServiceProvider();
         var opts = Microsoft.Extensions.Options.Options.Create(new OpinionatedEventingOptions());
         var registry = new MessageTypeRegistry();
-        var interceptor = new DomainEventInterceptor(messagingContext, registry, opts, TimeProvider.System);
+        var interceptor = new DomainEventInterceptor(sp, registry, opts, TimeProvider.System);
 
         var options = new DbContextOptionsBuilder<SpecsDbContext>()
             .UseInMemoryDatabase(_databaseName)
@@ -120,10 +122,12 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
     [When("SaveChanges is called synchronously with the DomainEventInterceptor active")]
     public void WhenSaveChangesSyncWithInterceptorActive()
     {
-        var messagingContext = new FakeMessagingContext(Guid.NewGuid());
+        var services = new ServiceCollection();
+        services.AddSingleton<IMessagingContext>(new FakeMessagingContext(Guid.NewGuid()));
+        var sp = services.BuildServiceProvider();
         var opts = Microsoft.Extensions.Options.Options.Create(new OpinionatedEventingOptions());
         var registry = new MessageTypeRegistry();
-        var interceptor = new DomainEventInterceptor(messagingContext, registry, opts, TimeProvider.System);
+        var interceptor = new DomainEventInterceptor(sp, registry, opts, TimeProvider.System);
 
         var options = new DbContextOptionsBuilder<SpecsDbContext>()
             .UseInMemoryDatabase(_databaseName + "-sync")
@@ -244,7 +248,11 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
     [Then("the message attempt count is {int} and error is {string}")]
     public async Task ThenMessageAttemptCountIsWithError(int expectedCount, string expectedError)
     {
-        var messages = await _store!.GetPendingAsync(10);
+        // Use a fresh context: ExecuteUpdateAsync bypasses the change tracker so the existing
+        // context still holds the pre-update tracked entity.
+        await using var freshContext = CreateFreshContext();
+        var freshStore = new EFCoreOutboxStore<SpecsDbContext>(freshContext, TimeProvider.System);
+        var messages = await freshStore.GetPendingAsync(10);
         var message = Xunit.Assert.Single(messages);
         Xunit.Assert.Equal(expectedCount, message.AttemptCount);
         Xunit.Assert.Equal(expectedError, message.Error);
@@ -318,6 +326,11 @@ public sealed class EntityFrameworkSteps : IAsyncDisposable
         _context.Database.EnsureCreated();
         return _context;
     }
+
+    private SpecsDbContext CreateFreshContext()
+        => new(new DbContextOptionsBuilder<SpecsDbContext>()
+            .UseSqlite(_sqliteConnection)
+            .Options);
 
     private static SqliteConnection OpenSqliteConnection()
     {

--- a/tests/OpinionatedEventing.EntityFramework.Tests/DomainEventInterceptorTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/DomainEventInterceptorTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpinionatedEventing;
 using OpinionatedEventing.EntityFramework.Tests.TestSupport;
@@ -17,10 +18,12 @@ public sealed class DomainEventInterceptorTests : IDisposable
         Guid? correlationId = null,
         Guid? causationId = null)
     {
-        var context = new FakeMessagingContext(correlationId ?? Guid.NewGuid(), causationId);
+        var services = new ServiceCollection();
+        services.AddSingleton<IMessagingContext>(new FakeMessagingContext(correlationId ?? Guid.NewGuid(), causationId));
+        var sp = services.BuildServiceProvider();
         var options = Microsoft.Extensions.Options.Options.Create(new OpinionatedEventingOptions());
         var registry = new MessageTypeRegistry();
-        return new DomainEventInterceptor(context, registry, options, TimeProvider.System);
+        return new DomainEventInterceptor(sp, registry, options, TimeProvider.System);
     }
 
     private TestDbContext CreateContextWithInterceptor(DomainEventInterceptor interceptor)

--- a/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxStoreTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxStoreTests.cs
@@ -185,7 +185,9 @@ public sealed class EFCoreOutboxStoreTests : IDisposable
         await context.SaveChangesAsync(ct);
         await store.MarkProcessedAsync(message.Id, ct);
 
-        OutboxMessage? saved = await context.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        // Use a fresh context: ExecuteUpdateAsync bypasses the change tracker
+        await using SqliteTestDbContext context2 = _factory.CreateContext();
+        OutboxMessage? saved = await context2.Set<OutboxMessage>().FindAsync([message.Id], ct);
         Assert.NotNull(saved!.ProcessedAt);
     }
 
@@ -201,7 +203,9 @@ public sealed class EFCoreOutboxStoreTests : IDisposable
         await context.SaveChangesAsync(ct);
         await store.MarkFailedAsync(message.Id, "broker unavailable", ct);
 
-        OutboxMessage? saved = await context.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        // Use a fresh context: ExecuteUpdateAsync bypasses the change tracker
+        await using SqliteTestDbContext context2 = _factory.CreateContext();
+        OutboxMessage? saved = await context2.Set<OutboxMessage>().FindAsync([message.Id], ct);
         Assert.NotNull(saved!.FailedAt);
         Assert.Equal("broker unavailable", saved.Error);
     }
@@ -218,7 +222,9 @@ public sealed class EFCoreOutboxStoreTests : IDisposable
         await context.SaveChangesAsync(ct);
         await store.IncrementAttemptAsync(message.Id, "transient", null, ct);
 
-        OutboxMessage? saved = await context.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        // Use a fresh context: ExecuteUpdateAsync bypasses the change tracker
+        await using SqliteTestDbContext context2 = _factory.CreateContext();
+        OutboxMessage? saved = await context2.Set<OutboxMessage>().FindAsync([message.Id], ct);
         Assert.Equal(1, saved!.AttemptCount);
         Assert.Equal("transient", saved.Error);
     }
@@ -252,7 +258,9 @@ public sealed class EFCoreOutboxStoreTests : IDisposable
         await context.SaveChangesAsync(ct);
         await store.IncrementAttemptAsync(message.Id, "transient", nextAttempt, ct);
 
-        OutboxMessage? saved = await context.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        // Use a fresh context: ExecuteUpdateAsync bypasses the change tracker
+        await using SqliteTestDbContext context2 = _factory.CreateContext();
+        OutboxMessage? saved = await context2.Set<OutboxMessage>().FindAsync([message.Id], ct);
         Assert.NotNull(saved!.NextAttemptAt);
     }
 

--- a/tests/OpinionatedEventing.EntityFramework.Tests/SqliteIntegrationTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/SqliteIntegrationTests.cs
@@ -106,9 +106,12 @@ public sealed class SqliteIntegrationTests : IDisposable
         await ctx.SaveChangesAsync(ct);
         await store.MarkProcessedAsync(message.Id, ct);
 
-        var saved = await ctx.Set<OutboxMessage>().FindAsync([message.Id], ct);
+        // Use a fresh context: ExecuteUpdateAsync bypasses the change tracker
+        await using var ctx2 = _factory.CreateContext();
+        var saved = await ctx2.Set<OutboxMessage>().FindAsync([message.Id], ct);
         Assert.NotNull(saved!.ProcessedAt);
-        Assert.Empty(await store.GetPendingAsync(10, ct));
+        var store2 = CreateOutboxStore(ctx2);
+        Assert.Empty(await store2.GetPendingAsync(10, ct));
     }
 
     [Fact]

--- a/tests/OpinionatedEventing.Outbox.Tests/OutboxPublisherTests.cs
+++ b/tests/OpinionatedEventing.Outbox.Tests/OutboxPublisherTests.cs
@@ -161,6 +161,33 @@ public sealed class OutboxPublisherTests
         Assert.Equal(1, guard.EnsureTransactionCallCount);
     }
 
+    // ---- Runtime type serialization ----
+
+    [Fact]
+    public async Task PublishEventAsync_UsesRuntimeTypeForSerialization()
+    {
+        var (publisher, store) = BuildPublisher();
+        var id = Guid.NewGuid();
+
+        // Publish through the interface — static type is IEvent, runtime type is ConcreteEvent
+        IEvent concreteEvent = new ConcreteEvent(id, "extra");
+        await publisher.PublishEventAsync(concreteEvent, TestContext.Current.CancellationToken);
+
+        var payload = JsonSerializer.Deserialize<ConcreteEvent>(store.Messages[0].Payload);
+        Assert.Equal("extra", payload!.Extra);
+    }
+
+    [Fact]
+    public async Task PublishEventAsync_UsesRuntimeTypeForMessageType()
+    {
+        var (publisher, store) = BuildPublisher();
+        IEvent concreteEvent = new ConcreteEvent(Guid.NewGuid(), "x");
+
+        await publisher.PublishEventAsync(concreteEvent, TestContext.Current.CancellationToken);
+
+        Assert.Equal(typeof(ConcreteEvent).FullName, store.Messages[0].MessageType);
+    }
+
     // ---- Custom serializer options ----
 
     [Fact]
@@ -178,6 +205,7 @@ public sealed class OutboxPublisherTests
 
     private sealed record TestEvent(Guid Id) : IEvent;
     private sealed record TestCommand(Guid Id) : ICommand;
+    private sealed record ConcreteEvent(Guid Id, string Extra) : IEvent;
 
     private sealed class FakeMessagingContext(Guid correlationId, Guid? causationId) : IMessagingContext
     {

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/MessageNamingConventionTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/MessageNamingConventionTests.cs
@@ -12,7 +12,8 @@ public sealed class MessageNamingConventionTests
     [InlineData(typeof(OrderPlaced), "order-placed")]
     [InlineData(typeof(PaymentReceived), "payment-received")]
     [InlineData(typeof(SimpleEvent), "simple-event")]
-    [InlineData(typeof(ABCEvent), "a-b-c-event")]
+    [InlineData(typeof(ABCEvent), "abc-event")]
+    [InlineData(typeof(HTTPRequestEvent), "http-request-event")]
     public void GetExchangeName_derives_kebab_case_from_type_name(Type type, string expected)
     {
         Assert.Equal(expected, MessageNamingConvention.GetExchangeName(type));
@@ -51,6 +52,7 @@ public sealed class MessageNamingConventionTests
     private sealed record PaymentReceived : IEvent;
     private sealed record SimpleEvent : IEvent;
     private sealed record ABCEvent : IEvent;
+    private sealed record HTTPRequestEvent : IEvent;
 
     [MessageTopic("my-custom-topic")]
     private sealed record CustomTopicEvent : IEvent;

--- a/tests/OpinionatedEventing.Testing.Tests/InMemoryOutboxStoreTests.cs
+++ b/tests/OpinionatedEventing.Testing.Tests/InMemoryOutboxStoreTests.cs
@@ -171,4 +171,40 @@ public sealed class InMemoryOutboxStoreTests
         Assert.Equal(0, deleted);
         Assert.Single(store.Messages);
     }
+
+    [Fact]
+    public async Task GetPendingAsync_UsesTimeProviderToFilterByNextAttemptAt()
+    {
+        var fake = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var store = new InMemoryOutboxStore(fake);
+        var ct = TestContext.Current.CancellationToken;
+        var msg = MakeMessage();
+        msg.NextAttemptAt = fake.GetUtcNow().AddMinutes(5);
+        await store.SaveAsync(msg, ct);
+
+        // Before advancing: message is not due yet
+        var batch = await store.GetPendingAsync(10, ct);
+        Assert.Empty(batch);
+
+        // After advancing past the backoff: message becomes eligible
+        fake.Advance(TimeSpan.FromMinutes(6));
+        batch = await store.GetPendingAsync(10, ct);
+        Assert.Single(batch);
+    }
+
+    [Fact]
+    public async Task MarkProcessedAsync_SetsProcessedAtFromTimeProvider()
+    {
+        var start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var fake = new FakeTimeProvider(start);
+        var store = new InMemoryOutboxStore(fake);
+        var ct = TestContext.Current.CancellationToken;
+        var msg = MakeMessage();
+        await store.SaveAsync(msg, ct);
+
+        fake.Advance(TimeSpan.FromSeconds(30));
+        await store.MarkProcessedAsync(msg.Id, ct);
+
+        Assert.Equal(start.AddSeconds(30), store.Messages[0].ProcessedAt);
+    }
 }


### PR DESCRIPTION
Closes #112

## Summary

- **Kebab-case acronyms**: `HTTPRequest` now maps to `http-request` (not `h-t-t-p-request`); both ASB and RabbitMQ naming conventions updated with identical fix
- **DomainEventInterceptor captive dependency**: `IMessagingContext` is now resolved per `SaveChanges` call via `IServiceProvider` rather than captured at construction, preventing stale correlation IDs when the interceptor is registered as Scoped but the context is cached
- **OutboxPublisher polymorphic publish**: `CreateMessage<T>` now uses `payload.GetType()` (runtime type) instead of `typeof(T)` (static type), so publishing an `IEvent`-typed variable serialises and registers the concrete type correctly
- **InMemoryOutboxStore controllable time**: New optional `TimeProvider` constructor parameter; `GetPendingAsync`, `MarkProcessedAsync`, and `MarkFailedAsync` all use it, enabling `FakeTimeProvider` in tests
- **AzureServiceBusConsumerWorker fail-fast**: Validation of `ServiceName` moved to a `StartAsync` override so the `InvalidOperationException` surfaces synchronously from `IHostedService.StartAsync` instead of being buried in the background task
- **EFCoreOutboxStore atomic mark operations**: `MarkProcessedAsync`, `MarkFailedAsync`, and `IncrementAttemptAsync` now use `ExecuteUpdateAsync` (single UPDATE, no change-tracker involvement) instead of `FindAsync` + set + `SaveChangesAsync`, eliminating stale-entity bugs and accidental context flush side-effects
- **Saga serializer fallback**: `SagaDispatcher` and `SagaTimeoutWorker` now fall back to `OpinionatedEventingOptions.SerializerOptions` when `SagaOptions.SerializerOptions` is null, so a single global options configuration works end-to-end
- **OTel baggage keys**: Renamed `correlation.id` → `messaging.message.correlation_id` and `causation.id` → `messaging.message.causation_id` to match OpenTelemetry semantic conventions — **breaking for consumers already reading these keys from spans**
- **Docs**: Added `record struct` unsupported note to `MessageTopicAttribute` and `MessageQueueAttribute`; expanded `MaxConcurrentCalls` with concurrency trade-off guidance

## Test plan

- [x] All 1167 unit/spec tests pass across net8/net9/net10 (`dotnet test`)
- [x] New tests cover each fix: kebab-case acronyms, runtime-type serialization, `StartAsync` fail-fast, `InMemoryOutboxStore` time control, `EFCoreOutboxStore` mark-method assertions via fresh contexts
- [x] EF Specs (45 scenarios) pass, including `IncrementAttemptAsync` scenario that required fresh-context assertion fix

🤖 Generated with [Claude Code](https://claude.ai/claude-code)