### PR TITLE
feat(samples): add Aspire CLI support and clone-and-run experience

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,10 +44,10 @@
 
   <!-- Aspire -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.2" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.4" />
   </ItemGroup>
 
   <!-- Samples (net10.0 only) -->

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ await publisher.PublishEventAsync(new OrderPlaced(id, total), ct);
 await db.SaveChangesAsync(ct);
 ```
 
+## Try the sample
+
+A runnable end-to-end demo is included — four services (Order, Payment, Fulfillment, Notification) wired together over RabbitMQ with PostgreSQL. Requires [.NET 10 SDK](https://dotnet.microsoft.com/download) and a container runtime (Docker Desktop, Podman, or Rancher Desktop).
+
+```bash
+git clone https://github.com/SierraNL/OpinionatedEventing
+cd OpinionatedEventing
+aspire run
+```
+
+> **No `aspire` CLI?** Use `dotnet run --project samples/Samples.AppHost` instead, or install via `winget install Microsoft.Aspire`.
+
+The Aspire dashboard URL is printed to the console at startup. Once all services show healthy, place an order:
+
+```bash
+curl -X POST http://localhost:<order-service-port>/orders \
+  -H "Content-Type: application/json" \
+  -d '{"customerName": "Alice", "total": 99.99}'
+```
+
+The port is shown in the dashboard under the `order-service` endpoint. See [samples/README.md](samples/README.md) for the full walkthrough.
+
 ## Documentation
 
 | Guide | Description |

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "language": "csharp"
+  }
+}

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -123,6 +123,20 @@ In `appsettings.Development.json`:
 
 ## Running locally
 
+To try the included sample (four services, RabbitMQ, PostgreSQL — zero config):
+
+```bash
+# From the repository root
+aspire run
+
+# Or without the Aspire CLI
+dotnet run --project samples/Samples.AppHost
+```
+
+See [samples/README.md](../samples/README.md) for the full walkthrough and how to place a test order.
+
+For your own solution:
+
 ```bash
 cd src/YourSolution.AppHost
 dotnet run

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,72 @@
+# OpinionatedEventing — Sample
+
+A runnable end-to-end demo of the library: four .NET services communicating over RabbitMQ, with PostgreSQL for persistence and saga state, all orchestrated by .NET Aspire.
+
+## Architecture
+
+```
+POST /orders
+     │
+     ▼
+OrderService ──── ProcessPayment (cmd) ───► PaymentService
+(orchestrator) ◄── PaymentReceived (event) ──┤
+     │                                        │ PaymentReceived (fan-out)
+     │ observes                               ▼
+     │ StockReserved            FulfillmentService (saga participant)
+     │◄── StockReserved (event) ─────────────┘
+     │
+     │                    NotificationService subscribes to:
+     └──────────────────► OrderPlaced · PaymentReceived · StockReserved
+```
+
+| Service | Role | Persistence |
+|---|---|---|
+| `order-service` | Saga orchestrator — drives the order workflow | PostgreSQL (`orderdb`) |
+| `payment-service` | Handles `ProcessPayment` commands, publishes `PaymentReceived`/`PaymentFailed` | PostgreSQL (`paymentdb`) |
+| `fulfillment-service` | Saga participant — reserves stock, publishes `StockReserved` | PostgreSQL (`fulfillmentdb`) |
+| `notification-service` | Subscribes to all outcome events, logs notifications | none |
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- A container runtime: Docker Desktop, Podman, or Rancher Desktop
+
+## Running
+
+From the repository root:
+
+```bash
+# With the Aspire CLI (winget install Microsoft.Aspire)
+aspire run
+
+# Or with dotnet directly
+dotnet run --project samples/Samples.AppHost
+```
+
+The Aspire dashboard URL is printed to the console at startup. It shows all services, logs, and distributed traces.
+
+## Placing an order
+
+Once all four services show **Running** and healthy in the dashboard, find the `order-service` endpoint URL (shown under its resource in the dashboard) and POST an order:
+
+```bash
+curl -X POST http://localhost:<order-service-port>/orders \
+  -H "Content-Type: application/json" \
+  -d '{"customerName": "Alice", "total": 99.99}'
+```
+
+```json
+{ "orderId": "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+```
+
+Watch the dashboard logs to see the saga progress:
+
+1. `order-service` publishes `OrderPlaced` → `OrderSaga` starts, sends `ProcessPayment` command to payment-service
+2. `payment-service` handles `ProcessPayment` → publishes `PaymentReceived`
+3. `fulfillment-service` reacts to `PaymentReceived` (saga participant) → publishes `StockReserved`
+4. `OrderSaga` observes `StockReserved` → order complete
+5. `notification-service` logs a notification for `OrderPlaced`, `PaymentReceived`, and `StockReserved`
+
+## RabbitMQ management UI
+
+The RabbitMQ management plugin is enabled. Open [http://localhost:15672](http://localhost:15672) (credentials: `guest` / `guest`) to inspect exchanges, queues, bindings, and message rates live.

--- a/samples/Samples.AppHost/Properties/launchSettings.json
+++ b/samples/Samples.AppHost/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17100;http://localhost:15100",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21100",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23100",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22100"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15100",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19100",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18100",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20100"
+      }
+    }
+  }
+}

--- a/samples/Samples.AppHost/Samples.AppHost.csproj
+++ b/samples/Samples.AppHost/Samples.AppHost.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Aspire AppHost SDK wires up project discovery, resource injection, and the dashboard. -->
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.2" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.4" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- Explicit here so IDEs (Rider) pick it up; other sample projects rely on samples/Directory.Build.props. -->
+    <TargetFramework>net10.0</TargetFramework>
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Adds `aspire.config.json` at the repo root so `aspire run` discovers `Samples.AppHost` automatically — no `--project` flag needed
- Adds `Properties/launchSettings.json` to `Samples.AppHost` with the full `ASPIRE_DASHBOARD_*` env vars that Rider's Aspire plugin requires; also adds explicit `<TargetFramework>net10.0</TargetFramework>` so Rider generates a run configuration (it does not always evaluate `Directory.Build.props`)
- Bumps `Aspire.AppHost.Sdk` and all `Aspire.Hosting.*` packages from 13.2.2 → 13.2.4 to match the current CLI version
- Adds `samples/README.md` with an accurate architecture diagram and step-by-step walkthrough of the order saga
- Adds a "Try the sample" section to the root `README.md` with the three-command clone-and-run sequence
- Updates `docs/local-development.md` to surface the sample run commands before the generic "your solution" instructions

## Test plan

- [ ] `dotnet restore SamplesOnly.slnf && dotnet build SamplesOnly.slnf --no-restore` passes with 0 errors
- [ ] `aspire run` from the repo root discovers and starts `Samples.AppHost` without `--project`
- [ ] Rider shows a run configuration for `Samples.AppHost` after opening the solution

🤖 Generated with [Claude Code](https://claude.com/claude-code)