### PR TITLE
fix(samples): add AppHost path to aspire.config.json to skip filesystem scan

### DIFF
--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,5 +1,6 @@
 {
   "appHost": {
-    "language": "csharp"
+    "language": "csharp",
+    "path": "samples/Samples.AppHost/Samples.AppHost.csproj"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `"path": "samples/Samples.AppHost/Samples.AppHost.csproj"` to `aspire.config.json`

## Why

Without a path, `aspire run` scans the entire repository tree for `*.csproj` files, then runs `msbuild -getProperty:IsAspireHost` on each one. The `.claude/worktrees` directory duplicates all project files, pushing the candidate count to ~1500 and causing a multi-minute hang at "Finding apphosts...". With the path set, the CLI goes directly to the right project.

## Test plan

- [ ] `aspire run` from the repo root starts immediately without a long scan delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)