### PR TITLE
fix: guard Directory.Build.targets GetDirectories against empty path (MSB4184)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,8 +11,14 @@
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <_Net9AppHostPackDir>$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::Combine('$(NetCoreTargetingPackRoot)', 'Microsoft.NETCore.App.Host.$(NETCoreSdkRuntimeIdentifier)'))))</_Net9AppHostPackDir>
   </PropertyGroup>
-  <ItemGroup Condition="'$(IsTestProject)' == 'true' and Exists('$(_Net9AppHostPackDir)')">
-    <_InstalledNet9AppHostPackDirs Include="$([System.IO.Directory]::GetDirectories('$(_Net9AppHostPackDir)', '9.0.*'))" />
+  <!-- GetDirectories is moved to a PropertyGroup so the condition reliably prevents
+       evaluation when the path is empty (ItemGroup conditions don't guard static
+       function calls in Include on all MSBuild hosts, e.g. msbuild -getProperty). -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' and '$(_Net9AppHostPackDir)' != '' and Exists('$(_Net9AppHostPackDir)')">
+    <_Net9InstalledDirsList>$([System.IO.Directory]::GetDirectories('$(_Net9AppHostPackDir)', '9.0.*'))</_Net9InstalledDirsList>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(_Net9InstalledDirsList)' != ''">
+    <_InstalledNet9AppHostPackDirs Include="$(_Net9InstalledDirsList)" />
   </ItemGroup>
   <ItemGroup Condition="'@(_InstalledNet9AppHostPackDirs->Count())' == '1'">
     <KnownAppHostPack Update="@(KnownAppHostPack)">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,10 +44,10 @@
 
   <!-- Aspire -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.2" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.4" />
   </ItemGroup>
 
   <!-- Samples (net10.0 only) -->

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ await publisher.PublishEventAsync(new OrderPlaced(id, total), ct);
 await db.SaveChangesAsync(ct);
 ```
 
+## Try the sample
+
+A runnable end-to-end demo is included — four services (Order, Payment, Fulfillment, Notification) wired together over RabbitMQ with PostgreSQL. Requires [.NET 10 SDK](https://dotnet.microsoft.com/download) and a container runtime (Docker Desktop, Podman, or Rancher Desktop).
+
+```bash
+git clone https://github.com/SierraNL/OpinionatedEventing
+cd OpinionatedEventing
+aspire run
+```
+
+> **No `aspire` CLI?** Use `dotnet run --project samples/Samples.AppHost` instead, or install via `winget install Microsoft.Aspire`.
+
+The Aspire dashboard URL is printed to the console at startup. Once all services show healthy, place an order:
+
+```bash
+curl -X POST http://localhost:<order-service-port>/orders \
+  -H "Content-Type: application/json" \
+  -d '{"customerName": "Alice", "total": 99.99}'
+```
+
+The port is shown in the dashboard under the `order-service` endpoint. See [samples/README.md](samples/README.md) for the full walkthrough.
+
 ## Documentation
 
 | Guide | Description |

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,6 @@
+{
+  "appHost": {
+    "language": "csharp",
+    "path": "samples/Samples.AppHost/Samples.AppHost.csproj"
+  }
+}

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -123,6 +123,20 @@ In `appsettings.Development.json`:
 
 ## Running locally
 
+To try the included sample (four services, RabbitMQ, PostgreSQL — zero config):
+
+```bash
+# From the repository root
+aspire run
+
+# Or without the Aspire CLI
+dotnet run --project samples/Samples.AppHost
+```
+
+See [samples/README.md](../samples/README.md) for the full walkthrough and how to place a test order.
+
+For your own solution:
+
 ```bash
 cd src/YourSolution.AppHost
 dotnet run

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,72 @@
+# OpinionatedEventing — Sample
+
+A runnable end-to-end demo of the library: four .NET services communicating over RabbitMQ, with PostgreSQL for persistence and saga state, all orchestrated by .NET Aspire.
+
+## Architecture
+
+```
+POST /orders
+     │
+     ▼
+OrderService ──── ProcessPayment (cmd) ───► PaymentService
+(orchestrator) ◄── PaymentReceived (event) ──┤
+     │                                        │ PaymentReceived (fan-out)
+     │ observes                               ▼
+     │ StockReserved            FulfillmentService (saga participant)
+     │◄── StockReserved (event) ─────────────┘
+     │
+     │                    NotificationService subscribes to:
+     └──────────────────► OrderPlaced · PaymentReceived · StockReserved
+```
+
+| Service | Role | Persistence |
+|---|---|---|
+| `order-service` | Saga orchestrator — drives the order workflow | PostgreSQL (`orderdb`) |
+| `payment-service` | Handles `ProcessPayment` commands, publishes `PaymentReceived`/`PaymentFailed` | PostgreSQL (`paymentdb`) |
+| `fulfillment-service` | Saga participant — reserves stock, publishes `StockReserved` | PostgreSQL (`fulfillmentdb`) |
+| `notification-service` | Subscribes to all outcome events, logs notifications | none |
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- A container runtime: Docker Desktop, Podman, or Rancher Desktop
+
+## Running
+
+From the repository root:
+
+```bash
+# With the Aspire CLI (winget install Microsoft.Aspire)
+aspire run
+
+# Or with dotnet directly
+dotnet run --project samples/Samples.AppHost
+```
+
+The Aspire dashboard URL is printed to the console at startup. It shows all services, logs, and distributed traces.
+
+## Placing an order
+
+Once all four services show **Running** and healthy in the dashboard, find the `order-service` endpoint URL (shown under its resource in the dashboard) and POST an order:
+
+```bash
+curl -X POST http://localhost:<order-service-port>/orders \
+  -H "Content-Type: application/json" \
+  -d '{"customerName": "Alice", "total": 99.99}'
+```
+
+```json
+{ "orderId": "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+```
+
+Watch the dashboard logs to see the saga progress:
+
+1. `order-service` publishes `OrderPlaced` → `OrderSaga` starts, sends `ProcessPayment` command to payment-service
+2. `payment-service` handles `ProcessPayment` → publishes `PaymentReceived`
+3. `fulfillment-service` reacts to `PaymentReceived` (saga participant) → publishes `StockReserved`
+4. `OrderSaga` observes `StockReserved` → order complete
+5. `notification-service` logs a notification for `OrderPlaced`, `PaymentReceived`, and `StockReserved`
+
+## RabbitMQ management UI
+
+The RabbitMQ management plugin is enabled. Open [http://localhost:15672](http://localhost:15672) (credentials: `guest` / `guest`) to inspect exchanges, queues, bindings, and message rates live.

--- a/samples/Samples.AppHost/Properties/launchSettings.json
+++ b/samples/Samples.AppHost/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17100;http://localhost:15100",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21100",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23100",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22100"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15100",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19100",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18100",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20100"
+      }
+    }
+  }
+}

--- a/samples/Samples.AppHost/Samples.AppHost.csproj
+++ b/samples/Samples.AppHost/Samples.AppHost.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Aspire AppHost SDK wires up project discovery, resource injection, and the dashboard. -->
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.2" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.4" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- Explicit here so IDEs (Rider) pick it up; other sample projects rely on samples/Directory.Build.props. -->
+    <TargetFramework>net10.0</TargetFramework>
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Moves `GetDirectories` call from an `ItemGroup Include` into a `PropertyGroup` so the condition reliably prevents evaluation when `_Net9AppHostPackDir` is empty
- Adds explicit `'$(_Net9AppHostPackDir)' != ''` guard to the condition before calling `Exists` or `GetDirectories`
- Fixes `aspire run` / `msbuild -getProperty` failing with **MSB4184: The path is empty** for non-test projects (including the Samples AppHost)

**Root cause:** `msbuild -getProperty` (used by the Aspire CLI to detect `IsAspireHost`) evaluates static property function calls in `ItemGroup Include` attributes even when the enclosing `ItemGroup` condition is `false`. The `_Net9AppHostPackDir` property is only set for test projects, so for any other project the `GetDirectories('', ...)` call throws.

**Fix:** Move the `GetDirectories` expression to a `PropertyGroup` (where condition guards are reliably enforced), and reference the resulting `_Net9InstalledDirsList` property in the `ItemGroup Include`.

## Test plan

- [x] `msbuild -getProperty:IsAspireHost,AspireHostingSDKVersion samples/Samples.AppHost/Samples.AppHost.csproj` returns `{"IsAspireHost":"true","AspireHostingSDKVersion":"13.2.4"}` without error
- [x] `aspire run` completes "Checking project type" and launches the dashboard
- [x] Unit tests pass (no changes to `src/` — no new coverage needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)