### PR TITLE
ci: publish NuGet packages to nuget.org via trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     name: Build & Test (.NET ${{ matrix.dotnet }})
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     strategy:
       matrix:
         include:
@@ -120,3 +124,14 @@ jobs:
         with:
           name: nuget-packages
           path: ./artifacts/nuget/*.nupkg
+
+      - name: NuGet trusted publish login
+        if: success() && matrix.tfm == 'net10.0' && github.event_name == 'push'
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: SierraNL
+
+      - name: Publish to NuGet.org
+        if: success() && matrix.tfm == 'net10.0' && github.event_name == 'push'
+        run: dotnet nuget push ./artifacts/nuget/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary

- Adds `id-token: write` permission to the CI job (required for OIDC)
- Adds `NuGet/login@v1` step to exchange a GitHub OIDC token for a short-lived NuGet API key — no stored secrets needed
- Adds `dotnet nuget push` step using that key, gated to pushes on `main` only (not PRs), `net10.0` leg only
- `--skip-duplicate` prevents failures on re-runs

Once merged, the next push to `main` will produce and publish `1.0.0` packages (GitVersion is already configured with `next-version: 1.0.0`).

## Test plan

- [ ] Verify CI checks pass on this PR (build/test only — no publish on PRs)
- [ ] After merge, confirm the `Publish to NuGet.org` step runs and packages appear on nuget.org

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)