### PR TITLE
fix: publish to NuGet only on version tags, not every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ "main" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:
@@ -126,12 +127,12 @@ jobs:
           path: ./artifacts/nuget/*.nupkg
 
       - name: NuGet trusted publish login
-        if: success() && matrix.tfm == 'net10.0' && github.event_name == 'push'
+        if: success() && matrix.tfm == 'net10.0' && startsWith(github.ref, 'refs/tags/v')
         uses: NuGet/login@v1
         id: nuget-login
         with:
           user: SierraNL
 
       - name: Publish to NuGet.org
-        if: success() && matrix.tfm == 'net10.0' && github.event_name == 'push'
+        if: success() && matrix.tfm == 'net10.0' && startsWith(github.ref, 'refs/tags/v')
         run: dotnet nuget push ./artifacts/nuget/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Problem

Publishing on every push to `main` produced pre-release versions like `1.0.0-217` because GitVersion only emits a stable SemVer when building from a tagged commit.

## Fix

- Add `tags: [ "v*" ]` to the `on.push` trigger so CI runs when a GitHub Release (or manual tag) is created
- Change the NuGet login and push conditions from `github.event_name == 'push'` to `startsWith(github.ref, 'refs/tags/v')`

After merging: create a `v1.0.0` GitHub Release → CI triggers → GitVersion sees the tag → packages are packed as `1.0.0` → pushed to nuget.org.

## Test plan

- [ ] Verify CI passes on this PR (no publish, it's a branch push)
- [ ] After merge, create the `v1.0.0` GitHub Release and confirm the publish step runs and produces `1.0.0` packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)