### PR TITLE
feat: add PackageTags to all NuGet packages for better discoverability

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>logo-128.png</PackageIcon>
+    <PackageTags>messaging eventing dotnet dotnet-library</PackageTags>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(IsSampleProject)' != 'true'">

--- a/src/OpinionatedEventing.Abstractions/OpinionatedEventing.Abstractions.csproj
+++ b/src/OpinionatedEventing.Abstractions/OpinionatedEventing.Abstractions.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Pure contracts for OpinionatedEventing — IEvent, ICommand, IPublisher, IOutboxStore, AggregateRoot, and handler interfaces. No infrastructure dependencies. Reference this package from domain and application assemblies.</Description>
+    <PackageTags>$(PackageTags) contracts abstractions domain-driven-design ddd</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/OpinionatedEventing.Aspire.AzureServiceBus/OpinionatedEventing.Aspire.AzureServiceBus.csproj
+++ b/src/OpinionatedEventing.Aspire.AzureServiceBus/OpinionatedEventing.Aspire.AzureServiceBus.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Aspire AppHost extension for OpinionatedEventing — adds an Azure Service Bus emulator resource. Reference this package from your AppHost project only.</Description>
+    <PackageTags>$(PackageTags) aspire azure azure-service-bus local-dev</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpinionatedEventing.Aspire.RabbitMQ/OpinionatedEventing.Aspire.RabbitMQ.csproj
+++ b/src/OpinionatedEventing.Aspire.RabbitMQ/OpinionatedEventing.Aspire.RabbitMQ.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Aspire AppHost extension for OpinionatedEventing — adds a RabbitMQ container resource with the management plugin enabled. Reference this package from your AppHost project only.</Description>
+    <PackageTags>$(PackageTags) aspire rabbitmq local-dev</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpinionatedEventing.AzureServiceBus/OpinionatedEventing.AzureServiceBus.csproj
+++ b/src/OpinionatedEventing.AzureServiceBus/OpinionatedEventing.AzureServiceBus.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Azure Service Bus transport for OpinionatedEventing. Events map to topics, commands map to queues. Supports DefaultAzureCredential and auto-resource creation.</Description>
+    <PackageTags>$(PackageTags) azure azure-service-bus transport cloud</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpinionatedEventing.EntityFramework/OpinionatedEventing.EntityFramework.csproj
+++ b/src/OpinionatedEventing.EntityFramework/OpinionatedEventing.EntityFramework.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>EF Core integration for OpinionatedEventing — IOutboxStore implementation, domain event interceptor, and saga state persistence.</Description>
+    <PackageTags>$(PackageTags) entity-framework ef-core persistence outbox sagas</PackageTags>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/OpinionatedEventing.OpenTelemetry/OpinionatedEventing.OpenTelemetry.csproj
+++ b/src/OpinionatedEventing.OpenTelemetry/OpinionatedEventing.OpenTelemetry.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>OpenTelemetry SDK integration for OpinionatedEventing. Provides TracerProviderBuilder and MeterProviderBuilder extension methods to opt in to distributed tracing and metrics.</Description>
+    <PackageTags>$(PackageTags) opentelemetry observability tracing metrics</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpinionatedEventing.Outbox/OpinionatedEventing.Outbox.csproj
+++ b/src/OpinionatedEventing.Outbox/OpinionatedEventing.Outbox.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Outbox dispatcher background service for OpinionatedEventing. Polls the outbox store and forwards messages to the configured transport.</Description>
+    <PackageTags>$(PackageTags) outbox transactional-outbox reliability</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpinionatedEventing.RabbitMQ/OpinionatedEventing.RabbitMQ.csproj
+++ b/src/OpinionatedEventing.RabbitMQ/OpinionatedEventing.RabbitMQ.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>RabbitMQ transport for OpinionatedEventing. Events map to topic exchanges, commands map to direct queues. Supports Aspire service discovery and auto-declare topology.</Description>
+    <PackageTags>$(PackageTags) rabbitmq transport amqp</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpinionatedEventing.Sagas/OpinionatedEventing.Sagas.csproj
+++ b/src/OpinionatedEventing.Sagas/OpinionatedEventing.Sagas.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Saga orchestration and choreography engine for OpinionatedEventing. Supports orchestrated sagas with state, timeouts, and compensation, plus lightweight choreography participants.</Description>
+    <PackageTags>$(PackageTags) saga orchestration choreography workflow</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpinionatedEventing.Testing/OpinionatedEventing.Testing.csproj
+++ b/src/OpinionatedEventing.Testing/OpinionatedEventing.Testing.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Test helpers for OpinionatedEventing — InMemoryOutboxStore, FakePublisher, FakeMessagingContext, and TestMessagingBuilder for unit testing without infrastructure.</Description>
+    <PackageTags>$(PackageTags) testing unit-testing test-helpers fakes</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 

--- a/src/OpinionatedEventing/OpinionatedEventing.csproj
+++ b/src/OpinionatedEventing/OpinionatedEventing.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Description>Runtime hosting package for OpinionatedEventing — MessageHandlerRunner, MessagingContext, DI extensions, diagnostics, and options. Reference this package from composition-root/infrastructure assemblies.</Description>
+    <PackageTags>$(PackageTags) hosting dependency-injection</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Adds shared base tags `messaging eventing dotnet dotnet-library` in `Directory.Build.props` (scoped to the existing NuGet property group so test/sample projects are unaffected)
- Adds package-specific tags to all 11 `src/` packages via `$(PackageTags)` composition

| Package | Tags added |
|---------|-----------|
| `Abstractions` | `contracts abstractions domain-driven-design ddd` |
| `OpinionatedEventing` | `hosting dependency-injection` |
| `Outbox` | `outbox transactional-outbox reliability` |
| `EntityFramework` | `entity-framework ef-core persistence outbox sagas` |
| `AzureServiceBus` | `azure azure-service-bus transport cloud` |
| `RabbitMQ` | `rabbitmq transport amqp` |
| `Sagas` | `saga orchestration choreography workflow` |
| `OpenTelemetry` | `opentelemetry observability tracing metrics` |
| `Testing` | `testing unit-testing test-helpers fakes` |
| `Aspire.AzureServiceBus` | `aspire azure azure-service-bus local-dev` |
| `Aspire.RabbitMQ` | `aspire rabbitmq local-dev` |

## Test plan

- [x] Pure metadata change — no C# source modified
- [x] 393 unit tests pass (`dotnet test --framework net10.0 --filter-not-trait "Category=Integration"`)
- [x] Tags will be visible on nuget.org after the next version tag publish

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)