### PR TITLE
ci: add CODEOWNERS and pull request template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SierraNL

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Description
+
+<!-- What does this PR do and why? -->
+
+## Related issue
+
+Closes #
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] Documentation updated (if applicable)
+- [ ] CHANGELOG entry added


### PR DESCRIPTION
## Description

Adds `.github/CODEOWNERS` and `.github/pull_request_template.md` so that PR review requests are automatically routed to `@SierraNL` and contributors are prompted for the right context.

## Related issue

Closes #146

## Checklist

- [x] Tests added or updated — N/A (no source code changes)
- [x] Documentation updated — N/A
- [x] CHANGELOG entry added — N/A (CI-only change)