### PR TITLE
ci: add YAML-based GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report a bug in one of the OpinionatedEventing packages
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which NuGet package is affected?
+      options:
+        - OpinionatedEventing.Core
+        - OpinionatedEventing.AzureServiceBus
+        - OpinionatedEventing.RabbitMQ
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: input
+    id: package_version
+    attributes:
+      label: Package version
+      placeholder: "e.g. 1.2.3"
+    validations:
+      required: true
+
+  - type: input
+    id: dotnet_version
+    attributes:
+      label: .NET version / target framework
+      placeholder: "e.g. net8.0, net9.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Configure ...
+        2. Publish message ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: A code snippet or link to a minimal repository that reproduces the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Propose a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: What problem are you trying to solve? What is the current limitation?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or change you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any workarounds or alternative approaches?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Closes #143.

- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` with required fields for package name + version, .NET version/target framework, steps to reproduce, expected vs actual behaviour, and an optional minimal reproduction snippet
- Adds `.github/ISSUE_TEMPLATE/feature_request.yml` with fields for problem description, proposed solution, and alternatives considered
- Both use YAML form syntax (not legacy Markdown) for the structured GitHub UI

## Test plan

- [ ] Open a new issue on GitHub and verify the template picker shows both options
- [ ] Confirm required fields are enforced in the browser form