### PR TITLE
ci: add CodeQL security scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "0 2 * * 0"
+
+jobs:
+  analyze:
+    name: Analyze (csharp)
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          queries: security-and-quality
+
+      - name: Build
+        run: dotnet build LibrariesOnly.slnf --configuration Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
           queries: security-and-quality
 
       - name: Build
-        run: dotnet build LibrariesOnly.slnf --configuration Release
+        run: dotnet build LibrariesOnly.slnf --configuration Release --framework net10.0
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

Closes #147.

- Adds `.github/workflows/codeql.yml` with the `github/codeql-action@v3`
- Triggers on push to `main`, pull requests, and a weekly schedule (Sundays 02:00 UTC)
- Language: `csharp`; query suite: `security-and-quality`
- Explicit `dotnet build LibrariesOnly.slnf` step (preferred over `autobuild` for solution-file projects)
- Least-privilege permissions: `security-events: write`, `actions: read`, `contents: read`

## Test plan

- [ ] Verify the CodeQL check appears in the PR checks list and passes
- [ ] Confirm no high/critical findings are reported in the initial baseline
- [ ] Verify the weekly schedule trigger is visible in the Actions tab after merge