### PR TITLE
fix: correct Aspire package names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ A suite of opinionated .NET libraries for event-driven and command-driven messag
 | `OpinionatedEventing.AzureServiceBus` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.AzureServiceBus.svg)](https://www.nuget.org/packages/OpinionatedEventing.AzureServiceBus) | Azure Service Bus transport |
 | `OpinionatedEventing.RabbitMQ` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.RabbitMQ.svg)](https://www.nuget.org/packages/OpinionatedEventing.RabbitMQ) | RabbitMQ transport |
 | `OpinionatedEventing.OpenTelemetry` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.OpenTelemetry.svg)](https://www.nuget.org/packages/OpinionatedEventing.OpenTelemetry) | OpenTelemetry tracing and metrics integration |
-| `OpinionatedEventing.Aspire` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Aspire.svg)](https://www.nuget.org/packages/OpinionatedEventing.Aspire) | Aspire AppHost extensions and health checks |
+| `OpinionatedEventing.Aspire.AzureServiceBus` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Aspire.AzureServiceBus.svg)](https://www.nuget.org/packages/OpinionatedEventing.Aspire.AzureServiceBus) | Aspire AppHost extension — adds an Azure Service Bus emulator resource |
+| `OpinionatedEventing.Aspire.RabbitMQ` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Aspire.RabbitMQ.svg)](https://www.nuget.org/packages/OpinionatedEventing.Aspire.RabbitMQ) | Aspire AppHost extension — adds a RabbitMQ container resource |
 | `OpinionatedEventing.Testing` | [![NuGet](https://img.shields.io/nuget/v/OpinionatedEventing.Testing.svg)](https://www.nuget.org/packages/OpinionatedEventing.Testing) | In-memory stores and fakes for tests |
 
 ## Quick start


### PR DESCRIPTION
## Summary

- Replaces the non-existent `OpinionatedEventing.Aspire` package row with the two actual packages that exist in `src/`:
  - `OpinionatedEventing.Aspire.AzureServiceBus` — Aspire AppHost extension for the Azure Service Bus emulator
  - `OpinionatedEventing.Aspire.RabbitMQ` — Aspire AppHost extension for the RabbitMQ container

## Test plan

- [ ] Verify the NuGet badge URLs point to the correct package names
- [ ] Confirm both rows render correctly in the README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)