### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Use one of the following channels:
 - **GitHub private security advisory (preferred):**
   [Report a vulnerability](https://github.com/SierraNL/OpinionatedEventing/security/advisories/new)
 
-- **Email:** `<CONTACT_EMAIL>`
+- **Email:** `security@opinionated-eventing.com`
 
 Include as much detail as possible: affected package(s), version(s), reproduction steps, and potential impact. You can expect an initial response within **5 business days**.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported versions
+
+The project is currently in pre-release. Security fixes are applied to the **latest published version** only.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.9.x   | Yes       |
+| < 0.9   | No        |
+
+Once 1.0.0 is released this table will be updated to reflect the supported version range.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Use one of the following channels:
+
+- **GitHub private security advisory (preferred):**
+  [Report a vulnerability](https://github.com/SierraNL/OpinionatedEventing/security/advisories/new)
+
+- **Email:** `<CONTACT_EMAIL>`
+
+Include as much detail as possible: affected package(s), version(s), reproduction steps, and potential impact. You can expect an initial response within **5 business days**.
+
+We follow [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure): once a fix is ready and released we will publicly credit the reporter (unless you prefer to remain anonymous).


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` at the repo root, satisfying GitHub's security policy detection
- Lists the supported version matrix (0.9.x = current pre-release)
- Provides a GitHub private security advisory link as the primary reporting channel, with an email placeholder to be filled before merge

Closes #142

## Test plan

- [ ] Verify the Security tab on the repo shows the new policy
- [ ] Fill in `<CONTACT_EMAIL>` placeholder before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)