### PR TITLE
fix: resolve CodeQL findings and exclude generated files from scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "CodeQL config"
+
+paths-ignore:
+  # SpecFlow/Reqnroll-generated files — not real C# source
+  - "tests/**/*.feature"
+  - "tests/**/*.feature.cs"
+  # MSBuild / xUnit auto-generated build artifacts
+  - "**/obj/**"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ tests/
 - XML `<summary>` doc comments on all `public` and `protected` members in `src/` projects
 - Target frameworks: `net8.0;net9.0;net10.0` (set in `Directory.Build.props` — do not override per project)
 - C# naming and formatting rules are enforced via [`.editorconfig`](.editorconfig): file-scoped namespaces, Allman braces, `_camelCase` private fields, `s_camelCase` private static fields, explicit types preferred over `var`
+- Use `using var` (or `await using var`) for every `IDisposable` / `IAsyncDisposable` — including inside test methods; never call `.Dispose()` manually at end of scope
+- Prefer `.Where(predicate)` over `foreach` + `if (!condition) continue`; prefer `.Select(transform)` over `foreach` + `var x = transform(item)` when the body only uses `x`
+- Use `dict.TryGetValue(key, out var v)` instead of `dict.ContainsKey(key)` followed by `dict[key]`
+- `catch (Exception)` is acceptable **only** in: top-level background-service loops (to prevent host crash), best-effort cleanup calls (stop/pause/resume with `LogWarning`), health checks (must not throw), and reflection-based discovery with a "skip silently" comment. Everywhere else, catch a specific exception type.
 
 ## Running locally
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ See [AGENTS.md](AGENTS.md) for the full project context, design rules, conventio
 
 - **Before committing:** always run `/review` on staged changes and address any findings.
 - **GitHub interactions:** use the `gh` CLI for all GitHub operations (issues, PRs, comments, etc.). The repository is `SierraNL/OpinionatedEventing` (case-sensitive — the `O` and `E` are uppercase).
+- **CodeQL:** generated files (SpecFlow `.feature`/`.feature.cs`, `obj/` build artifacts) are excluded via `.github/codeql/codeql-config.yml` — do not add those paths to the CodeQL config without good reason. When a CodeQL finding appears in a background-service worker or health check, verify it is intentional before suppressing.
 
 ## Implementing an issue (mandatory steps — do not skip)
 

--- a/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/AzureServiceBusTransport.cs
@@ -78,10 +78,7 @@ internal sealed class AzureServiceBusTransport : ITransport, IAsyncDisposable
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        foreach (var lazy in _senders.Values)
-        {
-            if (lazy.IsValueCreated)
-                await lazy.Value.DisposeAsync().ConfigureAwait(false);
-        }
+        foreach (var lazy in _senders.Values.Where(l => l.IsValueCreated))
+            await lazy.Value.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/OpinionatedEventing.AzureServiceBus/TopologyInitializer.cs
+++ b/src/OpinionatedEventing.AzureServiceBus/TopologyInitializer.cs
@@ -52,9 +52,8 @@ internal sealed class TopologyInitializer : IHostedService
         var eventTypes = _registry.EventTypes;
         var commandTypes = _registry.CommandTypes;
 
-        foreach (var eventType in eventTypes)
+        foreach (var topicName in eventTypes.Select(MessageNamingConvention.GetTopicName))
         {
-            var topicName = MessageNamingConvention.GetTopicName(eventType);
             await EnsureTopicExistsAsync(topicName, cancellationToken).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(opts.ServiceName))

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
@@ -142,10 +142,8 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
 
     private async Task PauseAllConsumersAsync()
     {
-        foreach (var entry in _consumers)
+        foreach (var entry in _consumers.Where(e => !string.IsNullOrEmpty(e.ConsumerTag)))
         {
-            if (string.IsNullOrEmpty(entry.ConsumerTag))
-                continue;
             try
             {
                 await entry.Channel.BasicCancelAsync(entry.ConsumerTag).ConfigureAwait(false);

--- a/src/OpinionatedEventing.Sagas/Internals/SagaDescriptor.cs
+++ b/src/OpinionatedEventing.Sagas/Internals/SagaDescriptor.cs
@@ -114,8 +114,6 @@ internal sealed class SagaDescriptor<TOrchestrator, TSagaState> : SagaDescriptor
         var context = new SagaContext(corrGuid, publisher, ct);
 
         using var activity = SagaDiagnostics.StartSagaStepActivity(typeof(TOrchestrator).Name, correlationKey, eventType.FullName ?? eventType.Name);
-        bool countedActive = false;
-
         try
         {
             if (isCompensation && state.Status == SagaStatus.Active)
@@ -141,10 +139,7 @@ internal sealed class SagaDescriptor<TOrchestrator, TSagaState> : SagaDescriptor
                 await store.SaveAsync(state, ct);
                 // Only count as active after the save succeeds; skip if already completed.
                 if (state.Status != SagaStatus.Completed)
-                {
                     SagaDiagnostics.Active.Add(1);
-                    countedActive = true;
-                }
             }
             else
             {
@@ -159,9 +154,7 @@ internal sealed class SagaDescriptor<TOrchestrator, TSagaState> : SagaDescriptor
             if (state.Status == SagaStatus.Compensating)
             {
                 state.Status = SagaStatus.Failed;
-                if (countedActive)
-                    SagaDiagnostics.Active.Add(-1);
-                else if (!isNew)
+                if (!isNew)
                     SagaDiagnostics.Active.Add(-1);
             }
 

--- a/src/OpinionatedEventing.Testing/InMemorySagaStateStore.cs
+++ b/src/OpinionatedEventing.Testing/InMemorySagaStateStore.cs
@@ -59,17 +59,15 @@ public sealed class InMemorySagaStateStore : ISagaStateStore
 
         lock (_claimLock)
         {
-            foreach (var state in _states.Values)
+            foreach (var state in _states.Values.Where(s =>
+                s.Status == SagaStatus.Active
+                && s.ExpiresAt.HasValue
+                && s.ExpiresAt.Value <= now
+                && (s.LockedUntil == null || s.LockedUntil < now)))
             {
-                if (state.Status == SagaStatus.Active
-                    && state.ExpiresAt.HasValue
-                    && state.ExpiresAt.Value <= now
-                    && (state.LockedUntil == null || state.LockedUntil < now))
-                {
-                    state.LockedBy = claimToken;
-                    state.LockedUntil = lockUntil;
-                    claimed.Add(state);
-                }
+                state.LockedBy = claimToken;
+                state.LockedUntil = lockUntil;
+                claimed.Add(state);
             }
         }
 

--- a/src/OpinionatedEventing/DependencyInjection/MessageHandlerRegistry.cs
+++ b/src/OpinionatedEventing/DependencyInjection/MessageHandlerRegistry.cs
@@ -38,12 +38,8 @@ public sealed class MessageHandlerRegistry
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        foreach (var descriptor in services)
+        foreach (var serviceType in services.Select(d => d.ServiceType).Where(t => t.IsGenericType))
         {
-            var serviceType = descriptor.ServiceType;
-            if (!serviceType.IsGenericType)
-                continue;
-
             var definition = serviceType.GetGenericTypeDefinition();
             var typeArg = serviceType.GetGenericArguments()[0];
 

--- a/src/OpinionatedEventing/DependencyInjection/OpinionatedEventingBuilder.cs
+++ b/src/OpinionatedEventing/DependencyInjection/OpinionatedEventingBuilder.cs
@@ -40,16 +40,10 @@ public sealed class OpinionatedEventingBuilder
     {
         foreach (var assembly in assemblies)
         {
-            foreach (var type in assembly.GetTypes())
+            foreach (var type in assembly.GetTypes().Where(t => t.IsClass && !t.IsAbstract))
             {
-                if (!type.IsClass || type.IsAbstract)
-                    continue;
-
-                foreach (var iface in type.GetInterfaces())
+                foreach (var iface in type.GetInterfaces().Where(i => i.IsGenericType))
                 {
-                    if (!iface.IsGenericType)
-                        continue;
-
                     var definition = iface.GetGenericTypeDefinition();
 
                     if (definition == typeof(IEventHandler<>))

--- a/src/OpinionatedEventing/MessageTypeRegistry.cs
+++ b/src/OpinionatedEventing/MessageTypeRegistry.cs
@@ -52,9 +52,8 @@ public sealed class MessageTypeRegistry : IMessageTypeRegistry
             return type;
 
         // 2. Scan loaded assemblies by FullName (catches types not yet in the registry).
-        foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+        foreach (var found in AppDomain.CurrentDomain.GetAssemblies().Select(a => a.GetType(identifier)))
         {
-            Type? found = assembly.GetType(identifier);
             if (found is not null)
                 return found;
         }

--- a/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxStoreTests.cs
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/EFCoreOutboxStoreTests.cs
@@ -268,7 +268,6 @@ public sealed class EFCoreOutboxStoreTests : IDisposable
     public async Task GetPendingAsync_excludes_messages_before_next_attempt_at()
     {
         await using SqliteTestDbContext context = _factory.CreateContext();
-        EFCoreOutboxStore<SqliteTestDbContext> store = CreateStore(context);
         CancellationToken ct = TestContext.Current.CancellationToken;
         OutboxMessage message = MakeMessage();
 

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQTopologyInitializerTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQTopologyInitializerTests.cs
@@ -65,8 +65,8 @@ public sealed class RabbitMQTopologyInitializerTests
 
         await initializer.StartAsync(ct);
 
-        Assert.True(channel.DeclaredExchanges.ContainsKey("topology-test-event"));
-        Assert.Equal(ExchangeType.Fanout, channel.DeclaredExchanges["topology-test-event"]);
+        Assert.True(channel.DeclaredExchanges.TryGetValue("topology-test-event", out var exchangeType));
+        Assert.Equal(ExchangeType.Fanout, exchangeType);
     }
 
     [Fact]
@@ -79,9 +79,8 @@ public sealed class RabbitMQTopologyInitializerTests
         await initializer.StartAsync(ct);
 
         const string queueName = "test-svc.topology-test-event";
-        Assert.True(channel.DeclaredQueues.ContainsKey(queueName));
-        var args = channel.DeclaredQueues[queueName];
-        Assert.Equal($"{queueName}.dlx", args["x-dead-letter-exchange"]);
+        Assert.True(channel.DeclaredQueues.TryGetValue(queueName, out var args));
+        Assert.Equal($"{queueName}.dlx", args!["x-dead-letter-exchange"]); // args is set when TryGetValue returns true
         Assert.Equal(queueName, args["x-dead-letter-routing-key"]);
     }
 
@@ -95,8 +94,8 @@ public sealed class RabbitMQTopologyInitializerTests
         await initializer.StartAsync(ct);
 
         const string queueName = "test-svc.topology-test-event";
-        Assert.True(channel.DeclaredExchanges.ContainsKey($"{queueName}.dlx"));
-        Assert.Equal(ExchangeType.Direct, channel.DeclaredExchanges[$"{queueName}.dlx"]);
+        Assert.True(channel.DeclaredExchanges.TryGetValue($"{queueName}.dlx", out var dlxExchangeType));
+        Assert.Equal(ExchangeType.Direct, dlxExchangeType);
         Assert.True(channel.DeclaredQueues.ContainsKey($"{queueName}.dlq"));
     }
 
@@ -125,8 +124,8 @@ public sealed class RabbitMQTopologyInitializerTests
 
         await initializer.StartAsync(ct);
 
-        Assert.True(channel.DeclaredExchanges.ContainsKey("topology-test-command"));
-        Assert.Equal(ExchangeType.Direct, channel.DeclaredExchanges["topology-test-command"]);
+        Assert.True(channel.DeclaredExchanges.TryGetValue("topology-test-command", out var commandExchangeType));
+        Assert.Equal(ExchangeType.Direct, commandExchangeType);
     }
 
     [Fact]
@@ -139,9 +138,8 @@ public sealed class RabbitMQTopologyInitializerTests
         await initializer.StartAsync(ct);
 
         const string queueName = "topology-test-command";
-        Assert.True(channel.DeclaredQueues.ContainsKey(queueName));
-        var args = channel.DeclaredQueues[queueName];
-        Assert.Equal($"{queueName}.dlx", args["x-dead-letter-exchange"]);
+        Assert.True(channel.DeclaredQueues.TryGetValue(queueName, out var args));
+        Assert.Equal($"{queueName}.dlx", args!["x-dead-letter-exchange"]); // args is set when TryGetValue returns true
         Assert.Equal(queueName, args["x-dead-letter-routing-key"]);
     }
 
@@ -155,8 +153,8 @@ public sealed class RabbitMQTopologyInitializerTests
         await initializer.StartAsync(ct);
 
         const string queueName = "topology-test-command";
-        Assert.True(channel.DeclaredExchanges.ContainsKey($"{queueName}.dlx"));
-        Assert.Equal(ExchangeType.Direct, channel.DeclaredExchanges[$"{queueName}.dlx"]);
+        Assert.True(channel.DeclaredExchanges.TryGetValue($"{queueName}.dlx", out var cmdDlxExchangeType));
+        Assert.Equal(ExchangeType.Direct, cmdDlxExchangeType);
         Assert.True(channel.DeclaredQueues.ContainsKey($"{queueName}.dlq"));
     }
 

--- a/tests/OpinionatedEventing.Testing.Tests/FakeTimeProviderTests.cs
+++ b/tests/OpinionatedEventing.Testing.Tests/FakeTimeProviderTests.cs
@@ -118,14 +118,13 @@ public sealed class FakeTimeProviderTests
         var clock = new FakeTimeProvider();
         int fired = 0;
 
-        var timer = clock.CreateTimer(_ => fired++, null, TimeSpan.FromSeconds(30), Timeout.InfiniteTimeSpan);
+        using var timer = clock.CreateTimer(_ => fired++, null, TimeSpan.FromSeconds(30), Timeout.InfiniteTimeSpan);
 
         // Reschedule to fire in 5 seconds from now.
         timer.Change(TimeSpan.FromSeconds(5), Timeout.InfiniteTimeSpan);
         clock.Advance(TimeSpan.FromSeconds(10));
 
         Assert.Equal(1, fired);
-        timer.Dispose();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **Add `.github/codeql/codeql-config.yml`** — excludes SpecFlow `.feature`/`.feature.cs` files and `obj/` build artifacts from CodeQL scanning. These generated files were responsible for ~551 false-positive alerts (492 `cs/useless-upcast`, 24 `cs/missed-readonly-modifier`, 14 `cs/missed-ternary-operator`, 8 `cs/simplifiable-boolean-expression`).
- **Fix 12 real findings** in production and test code: dead `countedActive` variable in `SagaDescriptor`, `foreach`+`continue` → `.Where()` in 5 files, `foreach`+transform-var → `.Select()` in 2 files, `ContainsKey`+indexer → `TryGetValue` in 6 test assertions, `using var` for a disposable timer, and one unused `store` variable removed.
- **Update `AGENTS.md` and `CLAUDE.md`** with coding guidelines to prevent the same findings from recurring.

After this PR the remaining open alerts will be ~35 intentional `catch (Exception)` blocks in background-service workers and health checks — those should be dismissed on GitHub with a justification comment (not fixed, since they are correct by design).

## Test plan

- [x] `dotnet build --no-incremental -warnaserror` — 0 warnings, 0 errors
- [x] 393 unit tests pass (non-integration, net10.0)
- [x] All new `src/` lines covered (`codecov/patch` check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)