### PR TITLE
fix: wire CodeQL config-file into workflow and fix follow-on missed-where

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           languages: csharp
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Build
         run: dotnet build LibrariesOnly.slnf --configuration Release --framework net10.0

--- a/src/OpinionatedEventing/MessageTypeRegistry.cs
+++ b/src/OpinionatedEventing/MessageTypeRegistry.cs
@@ -52,11 +52,11 @@ public sealed class MessageTypeRegistry : IMessageTypeRegistry
             return type;
 
         // 2. Scan loaded assemblies by FullName (catches types not yet in the registry).
-        foreach (var found in AppDomain.CurrentDomain.GetAssemblies().Select(a => a.GetType(identifier)))
-        {
-            if (found is not null)
-                return found;
-        }
+        var found = AppDomain.CurrentDomain.GetAssemblies()
+            .Select(a => a.GetType(identifier))
+            .FirstOrDefault(t => t is not null);
+        if (found is not null)
+            return found;
 
         // 3. Type.GetType — backwards-compat for old AssemblyQualifiedName rows.
         Type? legacy = Type.GetType(identifier);


### PR DESCRIPTION
## Summary

- **Root cause of the suppressions not working:** `.github/codeql/codeql-config.yml` (added in #168) was never passed to the `github/codeql-action/init` step — the workflow had no `config-file` parameter, so the exclusions were silently ignored every scan.
- **Fix:** add `config-file: ./.github/codeql/codeql-config.yml` to the init step.
- **Follow-on:** the `Select`+`foreach` refactor in `MessageTypeRegistry.cs` from #168 introduced a new `cs/linq/missed-where` alert (#591). Collapsed to `Select(...).FirstOrDefault(t => t is not null)` which is semantically identical and eliminates the finding.

After this PR the next CodeQL scan should drop from ~574 alerts to ~20–35 (only the intentional `catch (Exception)` blocks in background workers and health checks remain — those should be dismissed on GitHub).

## Test plan

- [x] `dotnet build LibrariesOnly.slnf --configuration Release --framework net10.0 -warnaserror` — 0 warnings, 0 errors
- [x] 393 unit tests pass (net10.0)
- [x] All new `src/` lines covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)