### PR TITLE
fix: exclude generated .feature.cs files from CodeQL via MSBuild

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Build
-        run: dotnet build LibrariesOnly.slnf --configuration Release --framework net10.0
+        run: dotnet build LibrariesOnly.slnf --configuration Release --framework net10.0 -p:CodeQLBuild=true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,4 +27,14 @@
     </KnownAppHostPack>
   </ItemGroup>
 
+
+  <!-- Exclude Reqnroll/SpecFlow auto-generated runner files from the CodeQL build.
+       These files produce ~550 false-positive alerts (useless-upcast,
+       missed-readonly-modifier, etc.) and contain no handwritten logic.
+       Pass -p:CodeQLBuild=true to the build command to activate this exclusion.
+       Regular step-definition .cs files are unaffected and remain analysed. -->
+  <ItemGroup Condition="'$(CodeQLBuild)' == 'true'">
+    <Compile Remove="**/*.feature.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Problem

Reqnroll/SpecFlow auto-generates `*.feature.cs` runner files that were producing ~550 false-positive CodeQL alerts (`useless-upcast`, `missed-readonly-modifier`, `simplifiable-boolean-expression`, etc.). These files contain no hand-written logic — only generated test runner boilerplate with `#line` directives pointing back to `.feature` files.

`paths-ignore` in the CodeQL config cannot filter these out: CodeQL for C# uses a build tracer that captures all compiled files into the analysis database, and path-based exclusions only work for interpreted languages (JS, Python).

## Solution

Prevent the generated files from being compiled when CodeQL runs:

- **`Directory.Build.targets`**: adds `<Compile Remove="**/*.feature.cs" />` gated on a new `CodeQLBuild` MSBuild property. This runs after Reqnroll's `.targets` (which add the generated files to `Compile`), so the `Remove` correctly undoes the addition. All other `*.cs` files in `*.Specs` projects — step definitions, hooks, helpers — continue to compile and be analysed.
- **`.github/workflows/codeql.yml`**: passes `-p:CodeQLBuild=true` to activate the exclusion during the CodeQL build.

Normal `dotnet build` and `dotnet test` runs are completely unaffected (the property is unset by default).

## Test plan

- [x] `dotnet build LibrariesOnly.slnf --configuration Release --framework net10.0 -p:CodeQLBuild=true -warnaserror` → Build succeeded, 0 Warning(s), 0 Error(s)
- [x] All 393 unit tests pass
- [ ] Verify CodeQL scan produces no `.feature.cs` alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)