### PR TITLE
fix: use a target to remove .feature.cs from Compile after Reqnroll adds them

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -32,9 +32,18 @@
        These files produce ~550 false-positive alerts (useless-upcast,
        missed-readonly-modifier, etc.) and contain no handwritten logic.
        Pass -p:CodeQLBuild=true to the build command to activate this exclusion.
-       Regular step-definition .cs files are unaffected and remain analysed. -->
-  <ItemGroup Condition="'$(CodeQLBuild)' == 'true'">
-    <Compile Remove="**/*.feature.cs" />
-  </ItemGroup>
+       Regular step-definition .cs files are unaffected and remain analysed.
+
+       Must be a Target (not a static ItemGroup) because Reqnroll adds the generated
+       files to Compile inside the IncludeProcessedReqnrollItemsToBuildInputs target
+       at execution time. A static Compile Remove evaluated at project-load time fires
+       before that target runs and is therefore a no-op. -->
+  <Target Name="ExcludeGeneratedFeatureFilesFromCodeQL"
+          AfterTargets="IncludeProcessedReqnrollItemsToBuildInputs"
+          Condition="'$(CodeQLBuild)' == 'true'">
+    <ItemGroup>
+      <Compile Remove="**/*.feature.cs" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
## Problem

The static `ItemGroup` fix merged in #170 is a no-op at runtime.

Reqnroll adds `.feature.cs` files to the `Compile` item group **inside the `IncludeProcessedReqnrollItemsToBuildInputs` target** at build execution time. A static `<Compile Remove>` in a plain `ItemGroup` fires at **project-evaluation time** — before any targets run — so it never sees those items and removes nothing.

## Fix

Replace the static `ItemGroup` with a `Target` that runs `AfterTargets="IncludeProcessedReqnrollItemsToBuildInputs"`. An `ItemGroup` inside a `Target` body is evaluated at execution time and sees the items Reqnroll just added.

```xml
<Target Name="ExcludeGeneratedFeatureFilesFromCodeQL"
        AfterTargets="IncludeProcessedReqnrollItemsToBuildInputs"
        Condition="'$(CodeQLBuild)' == 'true'">
  <ItemGroup>
    <Compile Remove="**/*.feature.cs" />
  </ItemGroup>
</Target>
```

Step definitions, hooks, and helpers in `*.Specs` projects are unaffected — only the generated runner files are removed. Normal `dotnet build`/`dotnet test` runs (no `CodeQLBuild` property) are completely unchanged.

## Verification

```
dotnet build LibrariesOnly.slnf --configuration Release --framework net10.0 -p:CodeQLBuild=true -v:diag
```
→ Build succeeded, 0 Warning(s), 0 Error(s). No `.feature.cs` files passed to `Csc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)