### PR TITLE
Bump all Aspire packages to 13.4.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,10 +44,10 @@
 
   <!-- Aspire -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting" Version="13.2.4" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.3.5" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.6" />
   </ItemGroup>
 
   <!-- Samples (net10.0 only) -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,15 +6,15 @@
 
   <!-- Microsoft.Extensions -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
   </ItemGroup>
 
   <!-- Transport brokers -->
@@ -26,15 +26,15 @@
 
   <!-- EF Core -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <!-- SqlServer provider is used for migration integration tests; per-framework VersionOverrides
          are required in each test .csproj to match the EF Core version for that TFM.
          NOTE: Microsoft.EntityFrameworkCore.Sqlite is NOT suitable for migration tests because
          SQLite has no native DateTimeOffset type — columns are stored as TEXT, which means
          CREATE TABLE DDL generated for SQL Server / PostgreSQL would pass silently with
          incorrect semantics. Use SQL Server or PostgreSQL for migration integration tests. -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
   </ItemGroup>
 
   <!-- OpenTelemetry -->
@@ -78,8 +78,10 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <!-- Pin bundle_e_sqlite3 to 3.0.3 — this version replaces the vulnerable SQLitePCLRaw.lib.e_sqlite3 with SourceGear.sqlite3 >= 3.50.4.5 (GHSA-2m69-gcr7-jv3q). -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="Testcontainers" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.RabbitMq" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />

--- a/samples/Samples.AppHost/Samples.AppHost.csproj
+++ b/samples/Samples.AppHost/Samples.AppHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Aspire AppHost SDK wires up project discovery, resource injection, and the dashboard. -->
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.4" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/tests/OpinionatedEventing.EntityFramework.Specs/OpinionatedEventing.EntityFramework.Specs.csproj
+++ b/tests/OpinionatedEventing.EntityFramework.Specs/OpinionatedEventing.EntityFramework.Specs.csproj
@@ -5,7 +5,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!-- Force bundle_e_sqlite3 3.0.3 across all TFMs: replaces the vulnerable SQLitePCLRaw.lib.e_sqlite3 with SourceGear.sqlite3 (GHSA-2m69-gcr7-jv3q). -->
   <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" VersionOverride="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Reqnroll.xUnit.v3" />
     <PackageReference Include="xunit.v3.mtp-v2" />

--- a/tests/OpinionatedEventing.EntityFramework.Tests/OpinionatedEventing.EntityFramework.Tests.csproj
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/OpinionatedEventing.EntityFramework.Tests.csproj
@@ -5,7 +5,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!-- Force bundle_e_sqlite3 3.0.3 across all TFMs: replaces the vulnerable SQLitePCLRaw.lib.e_sqlite3 with SourceGear.sqlite3 (GHSA-2m69-gcr7-jv3q). -->
   <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" VersionOverride="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/OpinionatedEventing.Sagas.Specs/OpinionatedEventing.Sagas.Specs.csproj
+++ b/tests/OpinionatedEventing.Sagas.Specs/OpinionatedEventing.Sagas.Specs.csproj
@@ -5,7 +5,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!-- Force bundle_e_sqlite3 3.0.3 across all TFMs: replaces the vulnerable SQLitePCLRaw.lib.e_sqlite3 with SourceGear.sqlite3 (GHSA-2m69-gcr7-jv3q). -->
   <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" VersionOverride="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Reqnroll.xUnit.v3" />
     <PackageReference Include="xunit.v3.mtp-v2" />


### PR DESCRIPTION
## Summary

- Bumps `Aspire.Hosting`, `Aspire.Hosting.RabbitMQ`, `Aspire.Hosting.PostgreSQL`, and `Aspire.Hosting.Azure.ServiceBus` from mixed versions (13.2.4 / 13.3.5 / 13.4.2) to a uniform **13.4.6** in `Directory.Packages.props`
- Bumps `Aspire.AppHost.Sdk` in `samples/Samples.AppHost/Samples.AppHost.csproj` to **13.4.6**

This resolves the MessagePack dependency vulnerability introduced via the Aspire transitive dependency chain.

## Test plan

- [ ] CI passes (no `src/` logic changed, only package versions)
- [ ] Verify the `Aspire.Hosting.*` 13.4.6 packages resolve cleanly (`dotnet restore`)
- [ ] Confirm the MessagePack vulnerability advisory no longer appears in dependency scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)