### PR TITLE
chore(deps): bump Microsoft.Extensions.* to 10.0.10 and actions/checkout to v7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      efcore:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,15 +6,15 @@
 
   <!-- Microsoft.Extensions -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
   </ItemGroup>
 
   <!-- Transport brokers -->


### PR DESCRIPTION
## Summary

Combines six Dependabot PRs into one:

- #226 Microsoft.Extensions.Configuration.Abstractions 10.0.9 → 10.0.10
- #228 Microsoft.Extensions.DependencyInjection.Abstractions 10.0.9 → 10.0.10
- #229 Microsoft.Extensions.Diagnostics.HealthChecks 10.0.9 → 10.0.10
- #230 Microsoft.Extensions.DependencyInjection + Hosting 10.0.9 → 10.0.10
- #231 Microsoft.Extensions.Hosting.Abstractions 10.0.9 → 10.0.10
- #209 actions/checkout 6 → 7

`Microsoft.Extensions.Diagnostics.HealthChecks` 10.0.10 requires `Logging.Abstractions`/`Options` >= 10.0.10, so the full `Microsoft.Extensions.*` family is bumped together here rather than one package at a time — that mismatch is why #229 and #231 already fail CI individually (`NU1605` downgrade errors). No `PackageReference` pins were added to library projects to work around it; bumping the coupled versions together removes the conflict at the source.

`.github/dependabot.yml` now groups `Microsoft.Extensions.*` and `Microsoft.EntityFrameworkCore*` so future coupled bumps land in a single PR instead of Dependabot inserting elevating package references into libraries to patch around a partial bump.

Closes #226, #228, #229, #230, #231, #209.

## Test plan

- [x] `dotnet build OpinionatedEventing.slnx` succeeds
- [x] `dotnet test --framework net10.0 --filter-not-trait "Category=Integration"` — 393 passed, 0 failed
- [ ] CI green on this PR