### PR TITLE
Add delivery-count-based retry before dead-lettering RabbitMQ messages

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -641,7 +641,7 @@ services.AddRabbitMqTransport(options =>
 
 - **Auto-declare**: exchanges, queues, and bindings are declared at startup when `AutoDeclareTopology = true`. Safe to run repeatedly (idempotent declarations).
 - **Aspire service discovery**: when running under Aspire, the connection string is resolved from `IConfiguration["ConnectionStrings:rabbitmq"]` automatically.
-- **Consumer acknowledgement**: messages are ack'd only after the handler completes successfully; nack'd (with requeue=false) on unhandled exception — relies on broker dead-lettering.
+- **Consumer acknowledgement**: messages are ack'd only after the handler completes successfully. On handler failure, the message is retried up to `MaxDeliveryCount` attempts (tracked via an `x-retry-count` header, default: 5) by republishing it directly back onto the same queue; once exhausted it is published to the queue's dead-letter exchange (`{queue}.dlx` → `{queue}.dlq`) instead. Malformed messages (missing/invalid required headers) are nacked without requeue immediately — no retry, relying on the queue's built-in dead-lettering. This mirrors the Azure Service Bus transport's delivery-count-based retry-before-dead-letter behavior.
 - **Graceful shutdown**: consumer channels are closed cleanly on host stop.
 - **Prefetch**: configurable prefetch count per consumer (default: 10).
 

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
@@ -16,10 +16,16 @@ namespace OpinionatedEventing.RabbitMQ;
 /// <summary>
 /// Background service that consumes messages from RabbitMQ fanout exchanges (events) and direct
 /// queues (commands), then dispatches them to registered handlers via
-/// <see cref="IMessageHandlerRunner"/>.
+/// <see cref="IMessageHandlerRunner"/>. On handler failure, messages are retried up to
+/// <see cref="RabbitMQOptions.MaxDeliveryCount"/> times (tracked via a delivery-count header) before
+/// being routed to the queue's dead-letter exchange.
 /// </summary>
 internal sealed class RabbitMQConsumerWorker : BackgroundService
 {
+    private const string RetryCountHeader = "x-retry-count";
+    private const string DeadLetterReasonHeader = "x-dead-letter-reason";
+    private const string DeadLetterDescriptionHeader = "x-dead-letter-description";
+
     private readonly RabbitMqConnectionHolder _connectionHolder;
     private readonly IMessageHandlerRunner _handlerRunner;
     private readonly IServiceScopeFactory _scopeFactory;
@@ -163,7 +169,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
             try
             {
                 var consumer = new AsyncEventingBasicConsumer(entry.Channel);
-                consumer.ReceivedAsync += (_, ea) => ProcessDeliveryAsync(entry.Channel, ea, ct);
+                consumer.ReceivedAsync += (_, ea) => ProcessDeliveryAsync(entry.Channel, entry.QueueName, ea, ct);
                 var tag = await entry.Channel.BasicConsumeAsync(
                     queue: entry.QueueName,
                     autoAck: false,
@@ -196,7 +202,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
         var entry = new ConsumerEntry { Channel = channel, QueueName = queueName };
         _consumers.Add(entry);
 
-        consumer.ReceivedAsync += (_, ea) => ProcessDeliveryAsync(channel, ea, ct);
+        consumer.ReceivedAsync += (_, ea) => ProcessDeliveryAsync(channel, queueName, ea, ct);
 
         var tag = await channel.BasicConsumeAsync(
             queue: queueName,
@@ -209,6 +215,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
 
     internal async Task ProcessDeliveryAsync(
         IChannel channel,
+        string queueName,
         BasicDeliverEventArgs ea,
         CancellationToken ct)
     {
@@ -253,21 +260,95 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to handle message with delivery tag {DeliveryTag}.", ea.DeliveryTag);
+            var deliveryCount = GetDeliveryCount(ea.BasicProperties) + 1;
+            var maxDeliveryCount = _options.Value.MaxDeliveryCount;
+
+            _logger.LogError(ex,
+                "Failed to handle message with delivery tag {DeliveryTag} (delivery {DeliveryCount}/{MaxDeliveryCount}).",
+                ea.DeliveryTag, deliveryCount, maxDeliveryCount);
 
             // CancellationToken.None: host shutdown must not leave the message unacknowledged.
             try
             {
-                await channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, CancellationToken.None)
+                if (deliveryCount >= maxDeliveryCount)
+                {
+                    var deadLetterProperties = BuildRetryProperties(
+                        ea.BasicProperties, deliveryCount, "HandlerException", ex.Message);
+                    await channel.BasicPublishAsync(
+                        exchange: $"{queueName}.dlx",
+                        routingKey: queueName,
+                        mandatory: false,
+                        basicProperties: deadLetterProperties,
+                        body: ea.Body,
+                        cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                }
+                else
+                {
+                    var retryProperties = BuildRetryProperties(ea.BasicProperties, deliveryCount);
+                    await channel.BasicPublishAsync(
+                        exchange: string.Empty,
+                        routingKey: queueName,
+                        mandatory: false,
+                        basicProperties: retryProperties,
+                        body: ea.Body,
+                        cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                }
+
+                await channel.BasicAckAsync(ea.DeliveryTag, multiple: false, CancellationToken.None)
                     .ConfigureAwait(false);
             }
-            catch (Exception nackEx)
+            catch (Exception publishEx)
             {
-                _logger.LogWarning(nackEx,
-                    "Failed to nack message with delivery tag {DeliveryTag}; message may be redelivered.",
+                _logger.LogWarning(publishEx,
+                    "Failed to requeue/dead-letter message with delivery tag {DeliveryTag}; nacking without requeue.",
                     ea.DeliveryTag);
+
+                try
+                {
+                    await channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception nackEx)
+                {
+                    _logger.LogWarning(nackEx,
+                        "Failed to nack message with delivery tag {DeliveryTag}; message may be redelivered.",
+                        ea.DeliveryTag);
+                }
             }
         }
+    }
+
+    private static BasicProperties BuildRetryProperties(
+        IReadOnlyBasicProperties source,
+        int deliveryCount,
+        string? deadLetterReason = null,
+        string? deadLetterDescription = null)
+    {
+        var headers = source.Headers is not null
+            ? new Dictionary<string, object?>(source.Headers)
+            : new Dictionary<string, object?>();
+        headers[RetryCountHeader] = deliveryCount;
+
+        if (deadLetterReason is not null)
+            headers[DeadLetterReasonHeader] = deadLetterReason;
+        if (deadLetterDescription is not null)
+            headers[DeadLetterDescriptionHeader] = deadLetterDescription;
+
+        return new BasicProperties(source) { Headers = headers };
+    }
+
+    private static int GetDeliveryCount(IReadOnlyBasicProperties properties)
+    {
+        if (properties.Headers is null || !properties.Headers.TryGetValue(RetryCountHeader, out var value))
+            return 0;
+
+        return value switch
+        {
+            int i => i,
+            long l => (int)l,
+            byte[] bytes when int.TryParse(Encoding.UTF8.GetString(bytes), out var parsed) => parsed,
+            _ => 0,
+        };
     }
 
     private async Task CloseConsumerChannelsAsync()

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQConsumerWorker.cs
@@ -318,16 +318,17 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
         }
     }
 
+    // Headers is guaranteed non-null in both helpers below: they are only called from the
+    // handler-failure catch block, reached only after the required-headers check above (which
+    // returns early whenever Headers is null) has already succeeded.
+
     private static BasicProperties BuildRetryProperties(
         IReadOnlyBasicProperties source,
         int deliveryCount,
         string? deadLetterReason = null,
         string? deadLetterDescription = null)
     {
-        var headers = source.Headers is not null
-            ? new Dictionary<string, object?>(source.Headers)
-            : new Dictionary<string, object?>();
-        headers[RetryCountHeader] = deliveryCount;
+        var headers = new Dictionary<string, object?>(source.Headers!) { [RetryCountHeader] = deliveryCount };
 
         if (deadLetterReason is not null)
             headers[DeadLetterReasonHeader] = deadLetterReason;
@@ -338,18 +339,7 @@ internal sealed class RabbitMQConsumerWorker : BackgroundService
     }
 
     private static int GetDeliveryCount(IReadOnlyBasicProperties properties)
-    {
-        if (properties.Headers is null || !properties.Headers.TryGetValue(RetryCountHeader, out var value))
-            return 0;
-
-        return value switch
-        {
-            int i => i,
-            long l => (int)l,
-            byte[] bytes when int.TryParse(Encoding.UTF8.GetString(bytes), out var parsed) => parsed,
-            _ => 0,
-        };
-    }
+        => properties.Headers!.TryGetValue(RetryCountHeader, out var value) && value is int count ? count : 0;
 
     private async Task CloseConsumerChannelsAsync()
     {

--- a/src/OpinionatedEventing.RabbitMQ/RabbitMQOptions.cs
+++ b/src/OpinionatedEventing.RabbitMQ/RabbitMQOptions.cs
@@ -32,6 +32,13 @@ public sealed class RabbitMQOptions
     public ushort PrefetchCount { get; set; } = 10;
 
     /// <summary>
+    /// Gets or sets the maximum number of delivery attempts before a message is dead-lettered.
+    /// Failed messages are retried (redelivered) up to this many times before being routed to the
+    /// queue's dead-letter exchange. Defaults to <c>5</c>.
+    /// </summary>
+    public int MaxDeliveryCount { get; set; } = 5;
+
+    /// <summary>
     /// Gets or sets the <c>ConnectionStrings</c> key used for Aspire service-discovery
     /// (e.g. the resource name passed to <c>AddRabbitMqMessaging(name)</c>).
     /// Defaults to <c>"rabbitmq"</c>. Only consulted when <see cref="ConnectionString"/> is not set.

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQConsumerWorkerTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQConsumerWorkerTests.cs
@@ -15,12 +15,16 @@ namespace OpinionatedEventing.RabbitMQ.Tests;
 
 public sealed class RabbitMQConsumerWorkerTests
 {
-    private static RabbitMQConsumerWorker CreateWorker(IMessageHandlerRunner runner)
+    private static RabbitMQConsumerWorker CreateWorker(IMessageHandlerRunner runner, int maxDeliveryCount = 5)
     {
         var holder = new RabbitMqConnectionHolder();
         holder.SetConnection(new NeverCalledConnection());
 
-        var options = MSOptions.Create(new RabbitMQOptions { ConnectionString = "amqp://localhost" });
+        var options = MSOptions.Create(new RabbitMQOptions
+        {
+            ConnectionString = "amqp://localhost",
+            MaxDeliveryCount = maxDeliveryCount,
+        });
 
         return new RabbitMQConsumerWorker(
             connectionHolder: holder,
@@ -62,7 +66,7 @@ public sealed class RabbitMQConsumerWorkerTests
             properties: props,
             body: Encoding.UTF8.GetBytes("{}"));
 
-        await worker.ProcessDeliveryAsync(channel, ea, ct);
+        await worker.ProcessDeliveryAsync(channel, "queue", ea, ct);
 
         var call = Assert.Single(runner.Calls);
         Assert.Equal(messageId, call.CausationId);
@@ -98,7 +102,7 @@ public sealed class RabbitMQConsumerWorkerTests
             properties: props,
             body: Encoding.UTF8.GetBytes("{}"));
 
-        await worker.ProcessDeliveryAsync(channel, ea, ct);
+        await worker.ProcessDeliveryAsync(channel, "queue", ea, ct);
 
         var call = Assert.Single(runner.Calls);
         Assert.Null(call.CausationId);
@@ -121,10 +125,88 @@ public sealed class RabbitMQConsumerWorkerTests
             properties: new BasicProperties(),
             body: Encoding.UTF8.GetBytes("{}"));
 
-        await worker.ProcessDeliveryAsync(channel, ea, ct);
+        await worker.ProcessDeliveryAsync(channel, "queue", ea, ct);
 
         Assert.True(channel.Nacked);
         Assert.Empty(runner.Calls);
+    }
+
+    [Fact]
+    public async Task ProcessDeliveryAsync_republishes_to_same_queue_with_incremented_retry_count_on_handler_failure()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var correlationId = Guid.NewGuid();
+        var runner = new ThrowingHandlerRunner();
+        var worker = CreateWorker(runner, maxDeliveryCount: 5);
+        var channel = new AckRecordingChannel();
+
+        var props = new BasicProperties
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            Headers = new Dictionary<string, object?>
+            {
+                ["MessageType"] = typeof(object).AssemblyQualifiedName,
+                ["MessageKind"] = "Event",
+                ["CorrelationId"] = correlationId.ToString(),
+            }
+        };
+        var ea = new BasicDeliverEventArgs(
+            consumerTag: "",
+            deliveryTag: 1,
+            redelivered: false,
+            exchange: "",
+            routingKey: "",
+            properties: props,
+            body: Encoding.UTF8.GetBytes("{}"));
+
+        await worker.ProcessDeliveryAsync(channel, "orders.queue", ea, ct);
+
+        Assert.True(channel.Acked);
+        Assert.False(channel.Nacked);
+        var publish = Assert.Single(channel.Publishes);
+        Assert.Equal(string.Empty, publish.Exchange);
+        Assert.Equal("orders.queue", publish.RoutingKey);
+        Assert.Equal(1, publish.Properties.Headers?["x-retry-count"]);
+    }
+
+    [Fact]
+    public async Task ProcessDeliveryAsync_dead_letters_once_max_delivery_count_is_reached()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var correlationId = Guid.NewGuid();
+        var runner = new ThrowingHandlerRunner();
+        var worker = CreateWorker(runner, maxDeliveryCount: 3);
+        var channel = new AckRecordingChannel();
+
+        var props = new BasicProperties
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            Headers = new Dictionary<string, object?>
+            {
+                ["MessageType"] = typeof(object).AssemblyQualifiedName,
+                ["MessageKind"] = "Event",
+                ["CorrelationId"] = correlationId.ToString(),
+                ["x-retry-count"] = 2,
+            }
+        };
+        var ea = new BasicDeliverEventArgs(
+            consumerTag: "",
+            deliveryTag: 1,
+            redelivered: true,
+            exchange: "",
+            routingKey: "",
+            properties: props,
+            body: Encoding.UTF8.GetBytes("{}"));
+
+        await worker.ProcessDeliveryAsync(channel, "orders.queue", ea, ct);
+
+        Assert.True(channel.Acked);
+        Assert.False(channel.Nacked);
+        var publish = Assert.Single(channel.Publishes);
+        Assert.Equal("orders.queue.dlx", publish.Exchange);
+        Assert.Equal("orders.queue", publish.RoutingKey);
+        Assert.Equal(3, publish.Properties.Headers?["x-retry-count"]);
+        Assert.Equal("HandlerException", publish.Properties.Headers?["x-dead-letter-reason"]);
     }
 
     // ─── Fakes ────────────────────────────────────────────────────────────────────
@@ -151,10 +233,20 @@ public sealed class RabbitMQConsumerWorkerTests
         }
     }
 
+    private sealed record RecordedPublish(string Exchange, string RoutingKey, IReadOnlyBasicProperties Properties);
+
+    private sealed class ThrowingHandlerRunner : IMessageHandlerRunner
+    {
+        public Task RunAsync(string messageType, string messageKind, string payload,
+            Guid? messageId, Guid correlationId, Guid? causationId, CancellationToken ct)
+            => throw new InvalidOperationException("Simulated handler failure.");
+    }
+
     private sealed class AckRecordingChannel : IChannel
     {
         public bool Acked { get; private set; }
         public bool Nacked { get; private set; }
+        public List<RecordedPublish> Publishes { get; } = [];
 
         public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple,
             CancellationToken cancellationToken = default)
@@ -167,6 +259,15 @@ public sealed class RabbitMQConsumerWorkerTests
             CancellationToken cancellationToken = default)
         {
             Nacked = true;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey,
+            bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body,
+            CancellationToken cancellationToken = default)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
+        {
+            Publishes.Add(new RecordedPublish(exchange, routingKey, basicProperties));
             return ValueTask.CompletedTask;
         }
 
@@ -207,11 +308,6 @@ public sealed class RabbitMQConsumerWorkerTests
             CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<BasicGetResult?> BasicGetAsync(string queue, bool autoAck,
             CancellationToken cancellationToken = default) => throw new NotImplementedException();
-        public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey,
-            bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body,
-            CancellationToken cancellationToken = default)
-            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
-            => throw new NotImplementedException();
         public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey,
             bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body,
             CancellationToken cancellationToken = default)

--- a/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQConsumerWorkerTests.cs
+++ b/tests/OpinionatedEventing.RabbitMQ.Tests/RabbitMQConsumerWorkerTests.cs
@@ -209,6 +209,79 @@ public sealed class RabbitMQConsumerWorkerTests
         Assert.Equal("HandlerException", publish.Properties.Headers?["x-dead-letter-reason"]);
     }
 
+    [Fact]
+    public async Task ProcessDeliveryAsync_nacks_without_requeue_when_republish_throws()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var correlationId = Guid.NewGuid();
+        var runner = new ThrowingHandlerRunner();
+        var worker = CreateWorker(runner, maxDeliveryCount: 5);
+        var channel = new AckRecordingChannel { PublishException = new InvalidOperationException("channel closed") };
+
+        var props = new BasicProperties
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            Headers = new Dictionary<string, object?>
+            {
+                ["MessageType"] = typeof(object).AssemblyQualifiedName,
+                ["MessageKind"] = "Event",
+                ["CorrelationId"] = correlationId.ToString(),
+            }
+        };
+        var ea = new BasicDeliverEventArgs(
+            consumerTag: "",
+            deliveryTag: 1,
+            redelivered: false,
+            exchange: "",
+            routingKey: "",
+            properties: props,
+            body: Encoding.UTF8.GetBytes("{}"));
+
+        await worker.ProcessDeliveryAsync(channel, "orders.queue", ea, ct);
+
+        Assert.True(channel.Nacked);
+        Assert.False(channel.Acked);
+        Assert.Empty(channel.Publishes);
+    }
+
+    [Fact]
+    public async Task ProcessDeliveryAsync_swallows_exception_when_both_republish_and_nack_fail()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var correlationId = Guid.NewGuid();
+        var runner = new ThrowingHandlerRunner();
+        var worker = CreateWorker(runner, maxDeliveryCount: 5);
+        var channel = new AckRecordingChannel
+        {
+            PublishException = new InvalidOperationException("channel closed"),
+            NackException = new InvalidOperationException("channel also closed"),
+        };
+
+        var props = new BasicProperties
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            Headers = new Dictionary<string, object?>
+            {
+                ["MessageType"] = typeof(object).AssemblyQualifiedName,
+                ["MessageKind"] = "Event",
+                ["CorrelationId"] = correlationId.ToString(),
+            }
+        };
+        var ea = new BasicDeliverEventArgs(
+            consumerTag: "",
+            deliveryTag: 1,
+            redelivered: false,
+            exchange: "",
+            routingKey: "",
+            properties: props,
+            body: Encoding.UTF8.GetBytes("{}"));
+
+        await worker.ProcessDeliveryAsync(channel, "orders.queue", ea, ct);
+
+        Assert.False(channel.Acked);
+        Assert.Empty(channel.Publishes);
+    }
+
     // ─── Fakes ────────────────────────────────────────────────────────────────────
 
     private sealed class NeverCalledScopeFactory : IServiceScopeFactory
@@ -247,6 +320,8 @@ public sealed class RabbitMQConsumerWorkerTests
         public bool Acked { get; private set; }
         public bool Nacked { get; private set; }
         public List<RecordedPublish> Publishes { get; } = [];
+        public Exception? PublishException { get; set; }
+        public Exception? NackException { get; set; }
 
         public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple,
             CancellationToken cancellationToken = default)
@@ -259,6 +334,8 @@ public sealed class RabbitMQConsumerWorkerTests
             CancellationToken cancellationToken = default)
         {
             Nacked = true;
+            if (NackException is not null)
+                throw NackException;
             return ValueTask.CompletedTask;
         }
 
@@ -267,6 +344,8 @@ public sealed class RabbitMQConsumerWorkerTests
             CancellationToken cancellationToken = default)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
         {
+            if (PublishException is not null)
+                throw PublishException;
             Publishes.Add(new RecordedPublish(exchange, routingKey, basicProperties));
             return ValueTask.CompletedTask;
         }


### PR DESCRIPTION
## Summary

Closes #233.

The RabbitMQ consumer previously `BasicNackAsync(requeue: false)`'d a message straight to its DLQ on the *first* handler failure, while the Azure Service Bus consumer abandons and lets the message redeliver up to `MaxDeliveryCount` times before dead-lettering. This was a functional parity gap between the two "equally-supported" transports.

This PR aligns RabbitMQ with ASB's retry-before-DLQ behavior:

- Adds `RabbitMQOptions.MaxDeliveryCount` (default `5`, matching `AzureServiceBusOptions.MaxDeliveryCount`'s default).
- On handler failure, the consumer reads an `x-retry-count` header from the message (defaults to 0), and:
  - If the resulting delivery count is below `MaxDeliveryCount`: acks the original delivery and republishes a copy directly to the same queue with the incremented header (immediate retry, no topology changes needed).
  - Once `MaxDeliveryCount` is reached: publishes the message to the queue's existing `{queue}.dlx` exchange (already declared by `RabbitMQTopologyInitializer` for every queue) with reason/description headers, then acks the original.
- Malformed messages (missing/invalid required headers) keep the previous immediate nack-without-requeue behavior — no retry, matching ASB's immediate dead-letter for invalid messages.
- No changes to `RabbitMQTopologyInitializer` — the existing per-queue DLX/DLQ pair is reused as-is.
- Updated `REQUIREMENTS.md` §10.4 to describe the new behavior.

## Test plan

- [x] `dotnet build` — src and tests projects build cleanly (0 warnings, 0 errors)
- [x] `dotnet test` (net8/9/10, non-Docker) — 64/64 passed; new tests cover retry-republish, dead-letter-on-exhaustion, and existing behavior (missing headers, causationId mapping)
- [x] Patch coverage verified: all new `src/` lines covered by unit tests
- [x] `/review` run on staged changes — one non-blocking Minor finding (narrow duplicate-delivery window on channel failure between publish and ack, inherent to at-least-once delivery, safe-direction failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)