### PR TITLE
Make the no-inbox-store decision explicit for v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ await publisher.PublishEventAsync(new OrderPlaced(id, total), ct);
 await db.SaveChangesAsync(ct);
 ```
 
+> At-least-once delivery means handlers can see the same message twice — see [Idempotency](docs/idempotency.md) for how to handle duplicates.
+
 ## Try the sample
 
 A runnable end-to-end demo is included — four services (Order, Payment, Fulfillment, Notification) wired together over RabbitMQ with PostgreSQL. Requires [.NET 10 SDK](https://dotnet.microsoft.com/download) and a container runtime (Docker Desktop, Podman, or Rancher Desktop).

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -47,6 +47,7 @@
 - No support for request/reply (RPC) patterns — commands are fire-and-forget to a single handler.
 - No dynamic message routing — topics/queues are determined by message type at registration time.
 - No support for .NET versions below 8.
+- **No inbox / deduplication store.** At-least-once delivery means consumers may see duplicate messages; making handlers idempotent (or deduplicating against their own store) is the consumer's responsibility. This is a deliberate v1.0 decision, not an oversight — see [docs/idempotency.md](docs/idempotency.md).
 
 ---
 

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -2,7 +2,14 @@
 
 The outbox pattern guarantees **at-least-once delivery**: every message written to the outbox will eventually reach the broker, but under certain failure conditions (process crash between dispatch and acknowledgement) a message may be delivered more than once. Consumers must therefore be prepared to receive duplicates.
 
-OpinionatedEventing does **not** provide an inbox pattern implementation for V1.0. This is an explicit design decision: adding a shared inbox store would introduce a mandatory persistence dependency into every consuming service, even when the handler is naturally idempotent or the business risk of a duplicate is low. The decision is re-evaluated after gathering real-world usage data.
+## Decision: no built-in inbox store
+
+OpinionatedEventing does **not** provide an `IInboxStore` abstraction (see [REQUIREMENTS.md § Non-Goals](../REQUIREMENTS.md#1-goals--non-goals)). This is a stated v1.0 scope decision, not a gap:
+
+- **A shared inbox store would introduce a mandatory persistence dependency** into every consuming service, even when the handler is naturally idempotent or the business risk of a duplicate is low.
+- **Deduplication only works if it commits in the same transaction as the handler's business logic** — otherwise there's a window where the "already processed" check and the side effect can disagree. `IOutboxStore` can own its own transaction because it's the only writer at that point; a dedup check has to share the *consumer's own* `DbContext` / unit-of-work, which makes a generic, reusable `IInboxStore` a materially harder abstraction to get right than the outbox was. Handing consumers the primitive (`IMessagingContext.MessageId`, below) and letting them dedupe inside their own transaction sidesteps that problem entirely.
+
+The patterns below — including using `IMessagingContext.MessageId` as a dedup key — cover the same ground an inbox store would. The decision is re-evaluated after gathering real-world usage data — see [Future versions](#future-versions).
 
 ## Why duplicates happen
 


### PR DESCRIPTION
## Summary
- Records "no built-in inbox/dedup store" as a stated Non-Goal in REQUIREMENTS.md instead of leaving it implicit in the idempotency guide.
- Adds the rationale to `docs/idempotency.md`: dedup checks must commit in the same transaction as the handler's business logic, which is why a generic `IInboxStore` (sharing the consumer's own `DbContext`) is a materially harder abstraction than `IOutboxStore` (which owns its own transaction).
- Adds a pointer to the guide from the README quick start, right after the first handler example, so new readers see it before writing their own handler.

Docs-only change — no `src/` changes, no test coverage impact.

Closes #234

## Test plan
- [x] N/A — documentation only, no code changes
- [ ] Markdown links/anchors render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)