### PR TITLE
Drop .NET 9 support before v1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
     id: dotnet_version
     attributes:
       label: .NET version / target framework
-      placeholder: "e.g. net8.0, net9.0"
+      placeholder: "e.g. net8.0, net10.0"
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
             tfm: "net8.0"
             # Bridge mode (TestingPlatformDotnetTestSupport): MTP args go after --
             mtp_sep: "--"
-          - dotnet: "9.0.x"
-            tfm: "net9.0"
-            mtp_sep: "--"
           - dotnet: "10.0.x"
             tfm: "net10.0"
             # Native mode (global.json test.runner): MTP args go directly after build args

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ tests/
 - `async Task` + `CancellationToken` on every async public method
 - No shared mutable static state — all state must be DI-scoped
 - XML `<summary>` doc comments on all `public` and `protected` members in `src/` projects
-- Target frameworks: `net8.0;net9.0;net10.0` (set in `Directory.Build.props` — do not override per project)
+- Target frameworks: `net8.0;net10.0` (set in `Directory.Build.props` — do not override per project)
 - C# naming and formatting rules are enforced via [`.editorconfig`](.editorconfig): file-scoped namespaces, Allman braces, `_camelCase` private fields, `s_camelCase` private static fields, explicit types preferred over `var`
 - Use `using var` (or `await using var`) for every `IDisposable` / `IAsyncDisposable` — including inside test methods; never call `.Dispose()` manually at end of scope
 - Prefer `.Where(predicate)` over `foreach` + `if (!condition) continue`; prefer `.Select(transform)` over `foreach` + `var x = transform(item)` when the body only uses `x`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OpinionatedEventing.CloudEvents`, `OpinionatedEventing.CloudEvents.AzureServiceBus`, and `OpinionatedEventing.CloudEvents.RabbitMQ` — opt-in CloudEvents 1.0 structured envelope for events, enabled per transport via `UseCloudEventsEnvelope()`. Commands are unaffected; services that don't opt in are unaffected.
 - `IServiceBusMessageEnvelope` / `IRabbitMQMessageEnvelope` injectable envelope abstractions on the Azure Service Bus and RabbitMQ transports, replacing the previously inline message build/parse logic
 
+### Removed
+- .NET 9 support — .NET 9 (STS) reached end of support on 2026-05-12. Target frameworks are now `net8.0` and `net10.0`.
+
 ## [0.9.0] - 2026-05-08
 
 Initial pre-release of the OpinionatedEventing library suite for .NET 8+.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for your interest in contributing. This guide covers everything you ne
 | [Aspire CLI](https://aspire.dev/get-started/prerequisites/) | Latest stable | Required only to run the sample — see installation note below |
 | Git | Any recent version | |
 
-The libraries target `net8.0`, `net9.0`, and `net10.0`. CI builds all three, but for local development the .NET 10 SDK is sufficient — it can build all target frameworks.
+The libraries target `net8.0` and `net10.0`. CI builds both, but for local development the .NET 10 SDK is sufficient — it can build all target frameworks.
 
 ## Clone and build
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/SierraNL/OpinionatedEventing/actions/workflows/ci.yml/badge.svg)](https://github.com/SierraNL/OpinionatedEventing/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/SierraNL/OpinionatedEventing/branch/main/graph/badge.svg)](https://codecov.io/gh/SierraNL/OpinionatedEventing)
 [![License: MIT](https://img.shields.io/github/license/SierraNL/OpinionatedEventing)](LICENSE)
-[![.NET](https://img.shields.io/badge/.NET-8%20%7C%209%20%7C%2010-512BD4)](https://dotnet.microsoft.com)
+[![.NET](https://img.shields.io/badge/.NET-8%20%7C%2010-512BD4)](https://dotnet.microsoft.com)
 
 A suite of opinionated .NET libraries for event-driven and command-driven messaging, targeting Azure Service Bus and RabbitMQ. Designed for developers who want correctness and safe defaults over maximum flexibility.
 
@@ -103,7 +103,7 @@ The port is shown in the dashboard under the `order-service` endpoint. See [samp
 
 ## Requirements
 
-.NET 8, 9, or 10. See [REQUIREMENTS.md](REQUIREMENTS.md) for the full specification.
+.NET 8 or 10. See [REQUIREMENTS.md](REQUIREMENTS.md) for the full specification.
 
 ## Why I built it
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -820,7 +820,7 @@ dotnet run
 
 | Requirement | Specification |
 |---|---|
-| Target framework | .NET 8 (minimum); .NET 9 and .NET 10 also targeted |
+| Target framework | .NET 8 (minimum); .NET 10 also targeted |
 | Async | All public APIs are `async Task`; `CancellationToken` on every async method |
 | Thread safety | No shared mutable static state; all state is DI-scoped |
 | Nullable | `#nullable enable` in all projects; no `null!` suppressions without comment |

--- a/benchmarks/OpinionatedEventing.Benchmarks/OpinionatedEventing.Benchmarks.csproj
+++ b/benchmarks/OpinionatedEventing.Benchmarks/OpinionatedEventing.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- Benchmarks target a single TFM — BenchmarkDotNet does not support multi-targeting. -->
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <!-- IsSampleProject suppresses the GitVersion + NuGet metadata items in Directory.Build.props. -->
     <IsSampleProject>true</IsSampleProject>
     <IsPackable>false</IsPackable>

--- a/src/OpinionatedEventing.EntityFramework/OpinionatedEventing.EntityFramework.csproj
+++ b/src/OpinionatedEventing.EntityFramework/OpinionatedEventing.EntityFramework.csproj
@@ -9,10 +9,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" VersionOverride="8.0.25" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" VersionOverride="9.0.14" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
   </ItemGroup>

--- a/tests/OpinionatedEventing.EntityFramework.Specs/OpinionatedEventing.EntityFramework.Specs.csproj
+++ b/tests/OpinionatedEventing.EntityFramework.Specs/OpinionatedEventing.EntityFramework.Specs.csproj
@@ -22,11 +22,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="8.0.25" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="9.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="9.0.14" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />

--- a/tests/OpinionatedEventing.EntityFramework.Tests/OpinionatedEventing.EntityFramework.Tests.csproj
+++ b/tests/OpinionatedEventing.EntityFramework.Tests/OpinionatedEventing.EntityFramework.Tests.csproj
@@ -22,12 +22,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="8.0.25" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="9.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" VersionOverride="9.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="9.0.14" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />

--- a/tests/OpinionatedEventing.Sagas.Specs/OpinionatedEventing.Sagas.Specs.csproj
+++ b/tests/OpinionatedEventing.Sagas.Specs/OpinionatedEventing.Sagas.Specs.csproj
@@ -20,10 +20,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="8.0.25" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="9.0.14" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- .NET 9 (STS) reached end of support on 2026-05-12; the project is pre-1.0 (`v0.9.0`), so drop it now rather than ship `v1.0.0` targeting an EOL framework.
- `TargetFrameworks` in `Directory.Build.props` is now `net8.0;net10.0`; removed the `net9.0` conditional `ItemGroup`s from the EF Core/Sagas test and spec projects, and the `9.0.x` matrix entry from CI.
- Updated docs (`AGENTS.md`, `README.md`, `REQUIREMENTS.md`, `CONTRIBUTING.md`, `CHANGELOG.md`) and the bug report issue template.
- Also retargeted `benchmarks/OpinionatedEventing.Benchmarks.csproj` from `net9.0` to `net10.0` — it was the only project hard-targeting `net9.0` as a single TFM (BenchmarkDotNet doesn't support multi-targeting), found while auditing for remaining `net9.0` references.

Closes #240

## Test plan
- [x] `dotnet build -f net10.0` succeeds
- [x] `dotnet test --framework net10.0 --filter-not-trait "Category=Integration"` — 453 passed, 0 failed
- [x] Verified no remaining `net9.0`/`9.0.x` references in the repo (outside the CHANGELOG entry documenting the removal)
- [ ] CI matrix build (net8.0/net10.0) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)