### PR TITLE
Group test package dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       efcore:
         patterns:
           - "Microsoft.EntityFrameworkCore*"
+      test-packages:
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "Microsoft.Testing.Extensions.*"
+          - "Testcontainers*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Adds a `test-packages` group to `.github/dependabot.yml`, matching the existing `microsoft-extensions`/`efcore` groups
- Covers `xunit*`, `Microsoft.NET.Test.Sdk`, `Microsoft.Testing.Extensions.*`, and `Testcontainers*` so future updates to these packages open one combined PR instead of one per package
- Closes #258 and #254, which will be recreated as a single grouped PR on dependabot's next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)